### PR TITLE
[TASK] Stream-Line Path Usages in Testing Framework

### DIFF
--- a/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
@@ -136,7 +136,7 @@ class AcceptanceCoreEnvironment extends Extension
         'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
         'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
         'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
-        'PACKAGE:typo3/testing-frameworkResources/Core/Acceptance/Fixtures/sys_category.xml',
+        'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/sys_category.xml',
         'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml',
         'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_repository.xml',
     ];

--- a/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
@@ -133,12 +133,12 @@ class AcceptanceCoreEnvironment extends Extension
      * @var array
      */
     protected $xmlDatabaseFixtures = [
-        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
-        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
-        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
-        'VENDOR:typo3/testing-frameworkResources/Core/Acceptance/Fixtures/sys_category.xml',
-        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml',
-        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_repository.xml',
+        'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
+        'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
+        'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
+        'PACKAGE:typo3/testing-frameworkResources/Core/Acceptance/Fixtures/sys_category.xml',
+        'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml',
+        'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_repository.xml',
     ];
 
     /**

--- a/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
@@ -133,12 +133,12 @@ class AcceptanceCoreEnvironment extends Extension
      * @var array
      */
     protected $xmlDatabaseFixtures = [
-        'components/testing_framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
-        'components/testing_framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
-        'components/testing_framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
-        'components/testing_framework/Resources/Core/Acceptance/Fixtures/sys_category.xml',
-        'components/testing_framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml',
-        'components/testing_framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_repository.xml',
+        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
+        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_sessions.xml',
+        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
+        'VENDOR:typo3/testing-frameworkResources/Core/Acceptance/Fixtures/sys_category.xml',
+        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml',
+        'VENDOR:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_repository.xml',
     ];
 
     /**
@@ -247,7 +247,7 @@ class AcceptanceCoreEnvironment extends Extension
         $suite->setBackupGlobals(false);
 
         foreach ($this->xmlDatabaseFixtures as $fixture) {
-            $testbase->importXmlDatabaseFixture(ORIGINAL_ROOT . $fixture);
+            $testbase->importXmlDatabaseFixture($fixture);
         }
 
         // styleguide generator uses DataHandler for some parts. DataHandler needs an initialized BE user

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -220,6 +220,7 @@ abstract class FunctionalTestCase extends BaseTestCase
 
         $testbase = new Testbase();
         $testbase->defineTypo3ModeBe();
+        $testbase->defineVendorPath();
         $testbase->setTypo3TestingContext();
         if ($testbase->recentTestInstanceExists($this->instancePath)) {
             // Reusing an existing instance. This typically happens for the second, third, ... test
@@ -684,6 +685,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             [
                 'arguments' => var_export($arguments, true),
                 'originalRoot' => ORIGINAL_ROOT,
+                'vendorPath' => TYPO3_PATH_VENDOR
             ]
         );
 

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -221,7 +221,7 @@ abstract class FunctionalTestCase extends BaseTestCase
 
         $testbase = new Testbase();
         $testbase->defineTypo3ModeBe();
-        $testbase->defineVendorPath();
+        $testbase->definePackagesPath();
         $testbase->setTypo3TestingContext();
         if ($testbase->recentTestInstanceExists($this->instancePath)) {
             // Reusing an existing instance. This typically happens for the second, third, ... test
@@ -686,7 +686,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             [
                 'arguments' => var_export($arguments, true),
                 'originalRoot' => ORIGINAL_ROOT,
-                'vendorPath' => TYPO3_PATH_VENDOR
+                'vendorPath' => TYPO3_PATH_PACKAGES
             ]
         );
 

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -198,7 +198,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      *
      * @var string
      */
-    protected $backendUserFixture = 'components/testing_framework/Resources/Core/Functional/Fixtures/be_users.xml';
+    protected $backendUserFixture = 'VENDOR:typo3/testing-framework/Resources/Core/Functional/Fixtures/be_users.xml';
 
     /**
      * Set up creates a test instance and database.
@@ -317,7 +317,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      */
     protected function setUpBackendUserFromFixture($userUid)
     {
-        $this->importDataSet(ORIGINAL_ROOT . $this->backendUserFixture);
+        $this->importDataSet($this->backendUserFixture);
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('be_users');
         $queryBuilder->getRestrictions()->removeAll();
@@ -340,7 +340,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         $GLOBALS['BE_USER'] = $backendUser;
         $GLOBALS['BE_USER']->start();
         if (!is_array($GLOBALS['BE_USER']->user) || !$GLOBALS['BE_USER']->user['uid']) {
-            throw new Exception(
+            throw new \Exception(
                 'Can not initialize backend user',
                 1377095807
             );

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Tests\Functional\DataHandling\Framework\DataSet;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\BaseTestCase;
+use TYPO3\TestingFramework\Core\Exception;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Response;
 use TYPO3\TestingFramework\Core\Testbase;
 
@@ -198,7 +199,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      *
      * @var string
      */
-    protected $backendUserFixture = 'VENDOR:typo3/testing-framework/Resources/Core/Functional/Fixtures/be_users.xml';
+    protected $backendUserFixture = 'PACKAGE:typo3/testing-framework/Resources/Core/Functional/Fixtures/be_users.xml';
 
     /**
      * Set up creates a test instance and database.
@@ -341,7 +342,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         $GLOBALS['BE_USER'] = $backendUser;
         $GLOBALS['BE_USER']->start();
         if (!is_array($GLOBALS['BE_USER']->user) || !$GLOBALS['BE_USER']->user['uid']) {
-            throw new \Exception(
+            throw new Exception(
                 'Can not initialize backend user',
                 1377095807
             );

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -106,6 +106,11 @@ class Testbase
         }
     }
 
+    public function defineVendorPath()
+    {
+        define('TYPO3_PATH_VENDOR', $this->getVendorPath());
+    }
+
     /**
      * Defines the constant ORIGINAL_ROOT for the path to the original TYPO3 document root.
      * For functional / acceptance tests only

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -751,8 +751,8 @@ class Testbase
     {
         if (strpos($path, 'EXT:') === 0) {
             $path = GeneralUtility::getFileAbsFileName($path);
-        } elseif (strpos($path, 'VENDOR:') === 0) {
-            $path = $this->getVendorPath() . str_replace('VENDOR:', '',$path);
+        } elseif (strpos($path, 'PACKAGE:') === 0) {
+            $path = $this->getVendorPath() . str_replace('PACKAGE:', '',$path);
         }
         return $path;
     }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -713,11 +713,11 @@ class Testbase
     protected function getPackagesPath(): string
     {
         if (getenv('TYPO3_PATH_PACKAGES')) {
-            $vendorPath = getenv('TYPO3_PATH_PACKAGES');
+            $packagePath = getenv('TYPO3_PATH_PACKAGES');
         } else {
-            $vendorPath = 'vendor/';
+            $packagePath = 'vendor/';
         }
-        return rtrim(strtr($vendorPath, '\\', '/'), '/') . '/';
+        return rtrim(strtr($packagePath, '\\', '/'), '/') . '/';
     }
 
     /**

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -106,9 +106,9 @@ class Testbase
         }
     }
 
-    public function defineVendorPath()
+    public function definePackagesPath()
     {
-        define('TYPO3_PATH_VENDOR', $this->getVendorPath());
+        define('TYPO3_PATH_PACKAGES', $this->getPackagesPath());
     }
 
     /**
@@ -710,10 +710,10 @@ class Testbase
      *
      * @return string
      */
-    protected function getVendorPath(): string
+    protected function getPackagesPath(): string
     {
-        if (getenv('TYPO3_PATH_VENDOR')) {
-            $vendorPath = getenv('TYPO3_PATH_VENDOR');
+        if (getenv('TYPO3_PATH_PACKAGES')) {
+            $vendorPath = getenv('TYPO3_PATH_PACKAGES');
         } else {
             $vendorPath = 'vendor/';
         }
@@ -752,7 +752,7 @@ class Testbase
         if (strpos($path, 'EXT:') === 0) {
             $path = GeneralUtility::getFileAbsFileName($path);
         } elseif (strpos($path, 'PACKAGE:') === 0) {
-            $path = $this->getVendorPath() . str_replace('PACKAGE:', '',$path);
+            $path = $this->getPackagesPath() . str_replace('PACKAGE:', '',$path);
         }
         return $path;
     }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -603,6 +603,7 @@ class Testbase
      */
     public function importXmlDatabaseFixture($path)
     {
+        $path = $this->resolvePath($path);
         if (!is_file($path)) {
             throw new \RuntimeException(
                 'Fixture file ' . $path . ' not found',
@@ -700,6 +701,21 @@ class Testbase
     }
 
     /**
+     * Get Path to vendor dir
+     *
+     * @return string
+     */
+    protected function getVendorPath(): string
+    {
+        if (getenv('TYPO3_PATH_VENDOR')) {
+            $vendorPath = getenv('TYPO3_PATH_VENDOR');
+        } else {
+            $vendorPath = 'vendor/';
+        }
+        return rtrim(strtr($vendorPath, '\\', '/'), '/') . '/';
+    }
+
+    /**
      * Returns the absolute path the TYPO3 document root.
      * This is the "original" document root, not the "instance" root for functional / acceptance tests.
      *
@@ -724,6 +740,16 @@ class Testbase
     {
         echo $message . LF;
         exit(1);
+    }
+
+    protected function resolvePath(string $path)
+    {
+        if (strpos($path, 'EXT:') === 0) {
+            $path = GeneralUtility::getFileAbsFileName($path);
+        } elseif (strpos($path, 'VENDOR:') === 0) {
+            $path = $this->getVendorPath() . str_replace('VENDOR:', '',$path);
+        }
+        return $path;
     }
 
     /**

--- a/Resources/Core/Build/FunctionalTests.xml
+++ b/Resources/Core/Build/FunctionalTests.xml
@@ -24,7 +24,7 @@
 >
 	<testsuites>
 		<testsuite name="Core tests">
-			<directory>../../../../../typo3/sysext/*/Tests/Functional/</directory>
+			<directory>../../../../../../typo3/sysext/*/Tests/Functional/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -15,13 +15,13 @@
 >
 	<testsuites>
 		<testsuite name="Core tests">
-			<directory>../../../../../typo3/sysext/*/Tests/Unit/</directory>
+			<directory>../../../../../../typo3/sysext/*/Tests/Unit/</directory>
 		</testsuite>
 		<testsuite name="Core legacy tests">
-			<directory>../../../../../typo3/sysext/core/Tests/Legacy/</directory>
+			<directory>../../../../../../typo3/sysext/core/Tests/Legacy/</directory>
 		</testsuite>
 		<testsuite name="Suite integrity tests">
-			<directory>../../../../../typo3/sysext/core/Tests/Integrity/</directory>
+			<directory>../../../../../../typo3/sysext/core/Tests/Integrity/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -43,9 +43,12 @@ call_user_func(function () {
     define('TYPO3_DLOG', false);
 
     // Retrieve an instance of class loader and inject to core bootstrap
-    $classLoaderFilepath = __DIR__ . '/../../../../../vendor/autoload.php';
+    $classLoaderFilepath = __DIR__ . '/../../../../../../vendor/autoload.php';
     if (!file_exists($classLoaderFilepath)) {
-        die('ClassLoader can\'t be loaded. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
+        $classLoaderFilepath = __DIR__ . '/../../../../../vendor/autoload.php';
+        if (!file_exists($classLoaderFilepath)) {
+            die('ClassLoader can\'t be loaded. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
+        }
     }
     $classLoader = require $classLoaderFilepath;
     \TYPO3\CMS\Core\Core\Bootstrap::getInstance()

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -33,6 +33,7 @@ call_user_func(function () {
     $testbase->defineSitePath();
     $testbase->defineTypo3ModeBe();
     $testbase->setTypo3TestingContext();
+    $testbase->definePackagesPath();
     $testbase->createDirectory(PATH_site . 'typo3conf/ext');
     $testbase->createDirectory(PATH_site . 'typo3temp/assets');
     $testbase->createDirectory(PATH_site . 'typo3temp/var/tests');
@@ -43,12 +44,9 @@ call_user_func(function () {
     define('TYPO3_DLOG', false);
 
     // Retrieve an instance of class loader and inject to core bootstrap
-    $classLoaderFilepath = __DIR__ . '/../../../../../../vendor/autoload.php';
+    $classLoaderFilepath = TYPO3_PATH_PACKAGES . 'autoload.php';
     if (!file_exists($classLoaderFilepath)) {
-        $classLoaderFilepath = __DIR__ . '/../../../../../vendor/autoload.php';
-        if (!file_exists($classLoaderFilepath)) {
-            die('ClassLoader can\'t be loaded. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
-        }
+        die('ClassLoader can\'t be loaded. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
     }
     $classLoader = require $classLoaderFilepath;
     \TYPO3\CMS\Core\Core\Bootstrap::getInstance()

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "autoload": {
     "psr-4": {
-      "TYPO3\\Components\\TestingFramework\\": "Classes/",
+      "TYPO3\\TestingFramework\\": "Classes/",
       "TYPO3\\CMS\\Core\\Tests\\": "compat/core/",
       "TYPO3\\CMS\\Fluid\\Tests\\": "compat/fluid/"
     }


### PR DESCRIPTION
To finally remove the testing framework from the core and make it usable from the outside, the path handling got a slight rework.

By setting the ENV var TYPO3_PATH_PACKAGES you can define, where your vendor/ directory is. Fixtures can be loaded relative to that path, which is available as constant TYPO3_PATH_PACKAGES.