### PR TITLE
[BUGFIX] Use TYPO3_PATH_ROOT instead of TYPO3_PATH_WEB

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -125,7 +125,7 @@ class Testbase
         }
 
         if (!file_exists(ORIGINAL_ROOT . 'typo3/cli_dispatch.phpsh')) {
-            $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
+            $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
         }
     }
 
@@ -728,7 +728,10 @@ class Testbase
      */
     protected function getWebRoot()
     {
-        if (getenv('TYPO3_PATH_WEB')) {
+        if (getenv('TYPO3_PATH_ROOT')) {
+            $webRoot = getenv('TYPO3_PATH_ROOT');
+        } elseif (getenv('TYPO3_PATH_WEB')) {
+            // @deprecated
             $webRoot = getenv('TYPO3_PATH_WEB');
         } else {
             $webRoot = getcwd();


### PR DESCRIPTION
In extraction of the framework, the changes made to
testbase made here: https://review.typo3.org/#/c/51331/
got lost somehow.

Integrate these changes again.