### PR TITLE
[TASK] Remove the need for TYPO3_PATH_PACKAGES env

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -707,17 +707,14 @@ class Testbase
 
     /**
      * Get Path to vendor dir
+     * Since we are installed in vendor dir, we can safely assume the path of the vendor
+     * directory relative to this file
      *
      * @return string
      */
     protected function getPackagesPath(): string
     {
-        if (getenv('TYPO3_PATH_PACKAGES')) {
-            $packagePath = getenv('TYPO3_PATH_PACKAGES');
-        } else {
-            $packagePath = 'vendor/';
-        }
-        return rtrim(strtr($packagePath, '\\', '/'), '/') . '/';
+        return rtrim(strtr(dirname(dirname(dirname(dirname(__DIR__)))), '\\', '/'), '/') . '/';
     }
 
     /**


### PR DESCRIPTION
Since the packae is always installed in the vendor dir,
wen can remove the need to define an env var here
by just using a relative path from the testbase class