### PR TITLE
[FEATURE] Add whitelist to enable code coverage

### DIFF
--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -24,4 +24,9 @@
 			<directory>../../../../../../typo3/sysext/core/Tests/Integrity/</directory>
 		</testsuite>
 	</testsuites>
+    <filter>
+        <whitelist>
+            <directory>../../../../../../typo3/sysext/*/Classes/</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Sets sysext/*/Classes/ on the whitelist to be reporteded by code coverage.

This doesn't activate code coverage itself. To execute it use the code coverage
button of PphStorm or one of the --coverage-** commandline options, for
example:

--coverage-html <dir>