### PR TITLE
Bugfix/tests ignore env variables for database

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Configuration\ConfigurationManager;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Tests\Functional\DataHandling\Framework\DataSet;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Configuration\FeatureManager;
 use TYPO3\TestingFramework\Core\BaseTestCase;
@@ -274,6 +275,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             ];
             $testbase->setUpPackageStates($this->instancePath, $defaultCoreExtensionsToLoad, $this->coreExtensionsToLoad, $this->testExtensionsToLoad);
             $testbase->setUpBasicTypo3Bootstrap($this->instancePath);
+            ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TYPO3_CONF_VARS'], $localConfiguration);
             $testbase->setUpTestDatabase($localConfiguration['DB']['Connections']['Default']['dbname'], $originalDatabaseName);
             $testbase->loadExtensionTables();
             $testbase->createDatabaseStructure();

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -98,7 +98,7 @@ class Testbase
     public function defineSitePath()
     {
         define('PATH_site', $this->getWebRoot());
-        define('PATH_thisScript', PATH_site . 'typo3/sysext/core/bin/typo3');
+        define('PATH_thisScript', PATH_site . 'typo3/index.php');
         $_SERVER['SCRIPT_NAME'] = PATH_thisScript;
 
         if (!file_exists(PATH_thisScript)) {

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -125,7 +125,7 @@ class Testbase
         }
 
         if (!file_exists(ORIGINAL_ROOT . 'typo3/cli_dispatch.phpsh')) {
-            $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_WEB\' to your root path.');
+            $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
         }
     }
 
@@ -729,7 +729,10 @@ class Testbase
      */
     protected function getWebRoot()
     {
-        if (getenv('TYPO3_PATH_WEB')) {
+        if (getenv('TYPO3_PATH_ROOT')) {
+            $webRoot = getenv('TYPO3_PATH_ROOT');
+        } elseif (getenv('TYPO3_PATH_WEB')) {
+            // @deprecated
             $webRoot = getenv('TYPO3_PATH_WEB');
         } else {
             $webRoot = getcwd();

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -494,8 +494,6 @@ class Testbase
      */
     public function setUpTestDatabase($databaseName, $originalDatabaseName)
     {
-        Bootstrap::getInstance()->initializeTypo3DbGlobal();
-
         // Drop database if exists. Directly using the Doctrine DriverManager to
         // work around connection caching in ConnectionPool
         $connectionParameters = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
@@ -555,8 +553,6 @@ class Testbase
      */
     public function initializeTestDatabaseAndTruncateTables()
     {
-        Bootstrap::getInstance()->initializeTypo3DbGlobal();
-
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
         $schemaManager = $connection->getSchemaManager();

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -98,7 +98,7 @@ class Testbase
     public function defineSitePath()
     {
         define('PATH_site', $this->getWebRoot());
-        define('PATH_thisScript', PATH_site . 'typo3/cli_dispatch.phpsh');
+        define('PATH_thisScript', PATH_site . 'typo3/sysext/core/bin/typo3');
         $_SERVER['SCRIPT_NAME'] = PATH_thisScript;
 
         if (!file_exists(PATH_thisScript)) {
@@ -124,7 +124,7 @@ class Testbase
             define('ORIGINAL_ROOT', $this->getWebRoot());
         }
 
-        if (!file_exists(ORIGINAL_ROOT . 'typo3/cli_dispatch.phpsh')) {
+        if (!file_exists(ORIGINAL_ROOT . 'typo3/sysext/core/bin/typo3')) {
             $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
         }
     }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -708,17 +708,14 @@ class Testbase
 
     /**
      * Get Path to vendor dir
+     * Since we are installed in vendor dir, we can safely assume the path of the vendor
+     * directory relative to this file
      *
      * @return string
      */
     protected function getPackagesPath(): string
     {
-        if (getenv('TYPO3_PATH_PACKAGES')) {
-            $packagePath = getenv('TYPO3_PATH_PACKAGES');
-        } else {
-            $packagePath = 'vendor/';
-        }
-        return rtrim(strtr($packagePath, '\\', '/'), '/') . '/';
+        return rtrim(strtr(dirname(dirname(dirname(dirname(__DIR__)))), '\\', '/'), '/') . '/';
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Don't use for forking (why ever you would want to do that). Will not be in line with upstream.
+
 # TYPO3 testing framework for core and extensions
 
 A straight and slim set of classes and configuration to test TYPO3 extensions. This framework is

--- a/Resources/Core/Build/AcceptanceTests.yml
+++ b/Resources/Core/Build/AcceptanceTests.yml
@@ -1,8 +1,8 @@
 actor: Tester
 paths:
 # @todo clean up here: https://forge.typo3.org/issues/79097 
-  tests: ../../../../../typo3/sysext/core/Tests
-  log: ../../../../../typo3temp/var/tests/AcceptanceReports
+  tests: ../../../../../../typo3/sysext/core/Tests
+  log: ../../../../../../typo3temp/var/tests/AcceptanceReports
   data: Configuration/Acceptance/Data
   support: Configuration/Acceptance/Support
   envs: Configuration/Acceptance/Envs

--- a/Resources/Core/Build/Configuration/JSUnit/karma.conf.js
+++ b/Resources/Core/Build/Configuration/JSUnit/karma.conf.js
@@ -7,7 +7,7 @@
 module.exports = function(config) {
 	config.set({
 		// base path that will be used to resolve all patterns (eg. files, exclude)
-		basePath: '../../../../../../../',
+		basePath: '../../../../../../../../',
 
 		// frameworks to use
 		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
@@ -18,8 +18,8 @@ module.exports = function(config) {
 			{ pattern: 'typo3/sysext/core/Resources/Public/JavaScript/Contrib/jquery/jquery-3.2.1.js', included: true },
 			{ pattern: 'typo3/sysext/**/Resources/Public/JavaScript/**/*.js', included: false },
 			{ pattern: 'typo3/sysext/**/Tests/JavaScript/**/*.js', included: false },
-			'components/testing_framework/Resources/Core/Build/Configuration/JSUnit/Helper.js',
-			'components/testing_framework/Resources/Core/Build/Configuration/JSUnit/Bootstrap.js'
+			'vendor/typo3/testing-framework/Resources/Core/Build/Configuration/JSUnit/Helper.js',
+			'vendor/typo3/testing-framework/Resources/Core/Build/Configuration/JSUnit/Bootstrap.js'
 		],
 
 		// list of files to exclude

--- a/Resources/Core/Build/Scripts/splitAcceptanceTests.sh
+++ b/Resources/Core/Build/Scripts/splitAcceptanceTests.sh
@@ -7,15 +7,15 @@
 #
 # It expects to be run from the core root.
 #
-# ./components/testing_framework/core/Build/Scripts/splitAcceptanceTests.sh <numberOfConfigs>
+# ./vendor/typo3/testing-framework/core/Build/Scripts/splitAcceptanceTests.sh <numberOfConfigs>
 #
 # The script finds all acceptance tests and creates <numberOfConfigs> number
 # of codeception group files, each containing a sub set of Cest files to execute.
 #
-# components/testing_framework/Resources/Core/Build/Configuration/Acceptance/AcceptanceTests-Job-<counter>
+# vendor/typo3/testing-framework/Resources/Core/Build/Configuration/Acceptance/AcceptanceTests-Job-<counter>
 #
 # Those sub-groups can then be executed with a command like (example for files in group 2 here)
-# ./bin/codecept run Acceptance -d -g AcceptanceTests-Job-2 -c components/testing_framework/Resources/Core/Build/AcceptanceTests.yml
+# ./bin/codecept run Acceptance -d -g AcceptanceTests-Job-2 -c vendor/typo3/testing-framework/Resources/Core/Build/AcceptanceTests.yml
 #
 #########################
 
@@ -47,7 +47,7 @@ done < buildTemp/testFiles.txt
 # Sort list of files numeric
 cat buildTemp/testFilesWithNumberOfTestFiles.txt | sort -n -r > buildTemp/testFilesWeighted.txt
 
-groupFilePath="components/testing_framework/Resources/Core/Build/Configuration/Acceptance"
+groupFilePath="vendor/typo3/testing-framework/Resources/Core/Build/Configuration/Acceptance"
 # Config file boilerplate per job
 for (( i=1; i<=${numberOfAcceptanceTestJobs}; i++)); do
 	if [ -f ${groupFilePath}/AcceptanceTests-Job-${i} ]; then
@@ -84,7 +84,7 @@ while read testFileWeighted; do
 			direction=descending
 		fi
 	fi
-	echo "../../../../../${testFile}" >> ${groupFilePath}/AcceptanceTests-Job-$(( targetJobNumberForFile + 1 ))
+	echo "../../../../../../${testFile}" >> ${groupFilePath}/AcceptanceTests-Job-$(( targetJobNumberForFile + 1 ))
 	(( counter ++ ))
 done < buildTemp/testFilesWeighted.txt
 

--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -24,4 +24,9 @@
 			<directory>../../../../../../typo3/sysext/core/Tests/Integrity/</directory>
 		</testsuite>
 	</testsuites>
+    <filter>
+        <whitelist>
+            <directory>../../../../../../typo3/sysext/*/Classes/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
     "phpunit/phpunit": "^5.6",
     "mikey179/vfsStream": "~1.6.0",
     "typo3fluid/fluid": "^2.2",
-    "typo3/cms-core": "^8.5",
-    "typo3/cms-backend": "^8.5",
-    "typo3/cms-frontend": "^8.5",
-    "typo3/cms-extbase": "^8.5",
-    "typo3/cms-fluid": "^8.5"
+    "typo3/cms-core": "^8.5 || ^9",
+    "typo3/cms-backend": "^8.5 || ^9",
+    "typo3/cms-frontend": "^8.5 || ^9",
+    "typo3/cms-extbase": "^8.5 || ^9",
+    "typo3/cms-fluid": "^8.5 || ^9"
   },
   "suggest": {
     "codeception/codeception": "^2.2",


### PR DESCRIPTION
when using export variables for e.g. database parameters, those are ignored. By overruling the set default values, they take again precedence.