### PR TITLE
[BUGFIX] Core Bootstrap overrides local changes in Test Bootstrap

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Tests\Functional\DataHandling\Framework\DataSet;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 use TYPO3\TestingFramework\Core\Exception;
@@ -271,6 +272,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             ];
             $testbase->setUpPackageStates($this->instancePath, $defaultCoreExtensionsToLoad, $this->coreExtensionsToLoad, $this->testExtensionsToLoad);
             $testbase->setUpBasicTypo3Bootstrap($this->instancePath);
+            ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TYPO3_CONF_VARS'], $localConfiguration);
             $testbase->setUpTestDatabase($localConfiguration['DB']['Connections']['Default']['dbname'], $originalDatabaseName);
             $testbase->loadExtensionTables();
             $testbase->createDatabaseStructure();


### PR DESCRIPTION
By merging the two available arrays, the local changes take
precedence over the default ones. So the manual passage of
e.g. database credentials for functional tests is possible again.