### PR TITLE
[TASK] Disable Caching for testing runs

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -536,7 +536,7 @@ class Testbase
             ->initializeClassLoader($classLoader)
             ->setRequestType(TYPO3_REQUESTTYPE_BE | TYPO3_REQUESTTYPE_CLI)
             ->baseSetup()
-            ->loadConfigurationAndInitialize(true)
+            ->loadConfigurationAndInitialize(false)
             ->loadTypo3LoadedExtAndExtLocalconf(true)
             ->setFinalCachingFrameworkCacheConfiguration()
             ->defineLoggingAndExceptionConstants()


### PR DESCRIPTION
Together with the related core change to the Bootstrap it
is now possible to disable the extbase caches. To profit from this
possibility, we need to set the allowCaching parameter for the
Boostrap to false.

The related core change is https://review.typo3.org/#/c/52695