### PR TITLE
[TASK] Extract DataHandling Framework from ext:core

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
 
 /*
@@ -14,6 +15,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -34,28 +36,32 @@ class ActionService
     /**
      * @return DataHandler
      */
-    public function getDataHandler()
+    public function getDataHandler(): DataHandler
     {
         return $this->dataHandler;
     }
 
     /**
+     * Creates the new record and returns an array keyed by table, containing the new id
+     *
      * @param string $tableName
      * @param int $pageId
      * @param array $recordData
      * @return array
      */
-    public function createNewRecord($tableName, $pageId, array $recordData)
+    public function createNewRecord(string $tableName, int $pageId, array $recordData): array
     {
         return $this->createNewRecords($pageId, [$tableName => $recordData]);
     }
 
     /**
+     * Creates the records and returns an array keyed by table, containing the new ids
+     *
      * @param int $pageId
      * @param array $tableRecordData
      * @return array
      */
-    public function createNewRecords($pageId, array $tableRecordData)
+    public function createNewRecords(int $pageId, array $tableRecordData): array
     {
         $dataMap = [];
         $newTableIds = [];
@@ -98,9 +104,9 @@ class ActionService
      * @param string $tableName
      * @param int $uid
      * @param array $recordData
-     * @param NULL|array $deleteTableRecordIds
+     * @param array $deleteTableRecordIds
      */
-    public function modifyRecord($tableName, $uid, array $recordData, array $deleteTableRecordIds = null)
+    public function modifyRecord(string $tableName, int $uid, array $recordData, array $deleteTableRecordIds = null)
     {
         $dataMap = [
             $tableName => [
@@ -127,7 +133,7 @@ class ActionService
      * @param int $pageId
      * @param array $tableRecordData
      */
-    public function modifyRecords($pageId, array $tableRecordData)
+    public function modifyRecords(int $pageId, array $tableRecordData)
     {
         $dataMap = [];
         $currentUid = null;
@@ -142,7 +148,7 @@ class ActionService
             if ($recordData['uid'] === '__NEW') {
                 $currentUid = StringUtility::getUniqueId('NEW');
             }
-            if (strpos($currentUid, 'NEW') === 0) {
+            if (strpos((string)$currentUid, 'NEW') === 0) {
                 $recordData['pid'] = $pageId;
             }
             unset($recordData['uid']);
@@ -166,7 +172,7 @@ class ActionService
      * @param int $uid
      * @return array
      */
-    public function deleteRecord($tableName, $uid)
+    public function deleteRecord(string $tableName, int $uid): array
     {
         return $this->deleteRecords(
             [
@@ -179,7 +185,7 @@ class ActionService
      * @param array $tableRecordIds
      * @return array
      */
-    public function deleteRecords(array $tableRecordIds)
+    public function deleteRecords(array $tableRecordIds): array
     {
         $commandMap = [];
         foreach ($tableRecordIds as $tableName => $ids) {
@@ -200,7 +206,7 @@ class ActionService
      * @param string $tableName
      * @param int $uid
      */
-    public function clearWorkspaceRecord($tableName, $uid)
+    public function clearWorkspaceRecord(string $tableName, int $uid)
     {
         $this->clearWorkspaceRecords(
             [
@@ -233,10 +239,10 @@ class ActionService
      * @param string $tableName
      * @param int $uid
      * @param int $pageId
-     * @param NULL|array $recordData
+     * @param array $recordData
      * @return array
      */
-    public function copyRecord($tableName, $uid, $pageId, array $recordData = null)
+    public function copyRecord(string $tableName, int $uid, int $pageId, array $recordData = null): array
     {
         $commandMap = [
             $tableName => [
@@ -262,10 +268,10 @@ class ActionService
      * @param string $tableName
      * @param int $uid
      * @param int $pageId
-     * @param NULL|array $recordData
+     * @param array $recordData
      * @return array
      */
-    public function moveRecord($tableName, $uid, $pageId, array $recordData = null)
+    public function moveRecord(string $tableName, int $uid, int $pageId, array $recordData = null): array
     {
         $commandMap = [
             $tableName => [
@@ -293,7 +299,7 @@ class ActionService
      * @param int $languageId
      * @return array
      */
-    public function localizeRecord($tableName, $uid, $languageId)
+    public function localizeRecord(string $tableName, int $uid, int $languageId): array
     {
         $commandMap = [
             $tableName => [
@@ -314,7 +320,7 @@ class ActionService
      * @param int $languageId
      * @return array
      */
-    public function copyRecordToLanguage($tableName, $uid, $languageId)
+    public function copyRecordToLanguage(string $tableName, int $uid, int $languageId): array
     {
         $commandMap = [
             $tableName => [
@@ -335,7 +341,7 @@ class ActionService
      * @param string $fieldName
      * @param array $referenceIds
      */
-    public function modifyReferences($tableName, $uid, $fieldName, array $referenceIds)
+    public function modifyReferences(string $tableName, int $uid, string $fieldName, array $referenceIds)
     {
         $dataMap = [
             $tableName => [
@@ -354,7 +360,7 @@ class ActionService
      * @param int $liveUid
      * @param bool $throwException
      */
-    public function publishRecord($tableName, $liveUid, $throwException = true)
+    public function publishRecord(string $tableName, $liveUid, bool $throwException = true)
     {
         $this->publishRecords([$tableName => [$liveUid]], $throwException);
     }
@@ -364,7 +370,7 @@ class ActionService
      * @param bool $throwException
      * @throws Exception
      */
-    public function publishRecords(array $tableLiveUids, $throwException = true)
+    public function publishRecords(array $tableLiveUids, bool $throwException = true)
     {
         $commandMap = [];
         foreach ($tableLiveUids as $tableName => $liveUids) {
@@ -395,7 +401,7 @@ class ActionService
     /**
      * @param int $workspaceId
      */
-    public function publishWorkspace($workspaceId)
+    public function publishWorkspace(int $workspaceId)
     {
         $commandMap = $this->getWorkspaceService()->getCmdArrayForPublishWS($workspaceId, false);
         $this->createDataHandler();
@@ -406,7 +412,7 @@ class ActionService
     /**
      * @param int $workspaceId
      */
-    public function swapWorkspace($workspaceId)
+    public function swapWorkspace(int $workspaceId)
     {
         $commandMap = $this->getWorkspaceService()->getCmdArrayForPublishWS($workspaceId, true);
         $this->createDataHandler();
@@ -419,13 +425,13 @@ class ActionService
      * @param NULL|string|int $previousUid
      * @return array
      */
-    protected function resolvePreviousUid(array $recordData, $previousUid)
+    protected function resolvePreviousUid(array $recordData, $previousUid): array
     {
         if ($previousUid === null) {
             return $recordData;
         }
         foreach ($recordData as $fieldName => $fieldValue) {
-            if (strpos($fieldValue, '__previousUid') === false) {
+            if (strpos((string)$fieldValue, '__previousUid') === false) {
                 continue;
             }
             $recordData[$fieldName] = str_replace('__previousUid', $previousUid, $fieldValue);
@@ -438,13 +444,13 @@ class ActionService
      * @param NULL|string|int $nextUid
      * @return array
      */
-    protected function resolveNextUid(array $recordData, $nextUid)
+    protected function resolveNextUid(array $recordData, $nextUid): array
     {
         if ($nextUid === null) {
             return $recordData;
         }
         foreach ($recordData as $fieldName => $fieldValue) {
-            if (strpos($fieldValue, '__nextUid') === false) {
+            if (strpos((string)$fieldValue, '__nextUid') === false) {
                 continue;
             }
             $recordData[$fieldName] = str_replace('__nextUid', $nextUid, $fieldValue);
@@ -454,10 +460,10 @@ class ActionService
 
     /**
      * @param string $tableName
-     * @param int $liveUid
+     * @param int|string $liveUid
      * @return NULL|int
      */
-    protected function getVersionedId($tableName, $liveUid)
+    protected function getVersionedId(string $tableName, $liveUid)
     {
         $versionedId = null;
         $liveUid = (int)$liveUid;
@@ -495,7 +501,7 @@ class ActionService
     /**
      * @return DataHandler
      */
-    protected function createDataHandler()
+    protected function createDataHandler(): DataHandler
     {
         $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $backendUser = $this->getBackendUser();
@@ -508,7 +514,7 @@ class ActionService
     /**
      * @return WorkspaceService
      */
-    protected function getWorkspaceService()
+    protected function getWorkspaceService(): WorkspaceService
     {
         return GeneralUtility::makeInstance(
             WorkspaceService::class
@@ -518,7 +524,7 @@ class ActionService
     /**
      * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
      */
-    protected function getBackendUser()
+    protected function getBackendUser(): BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'];
     }

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -1,0 +1,525 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\StringUtility;
+use TYPO3\CMS\Workspaces\Service\WorkspaceService;
+use TYPO3\TestingFramework\Core\Exception;
+
+/**
+ * DataHandler Actions
+ */
+class ActionService
+{
+    /**
+     * @var DataHandler
+     */
+    protected $dataHandler;
+
+    /**
+     * @return DataHandler
+     */
+    public function getDataHandler()
+    {
+        return $this->dataHandler;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $pageId
+     * @param array $recordData
+     * @return array
+     */
+    public function createNewRecord($tableName, $pageId, array $recordData)
+    {
+        return $this->createNewRecords($pageId, [$tableName => $recordData]);
+    }
+
+    /**
+     * @param int $pageId
+     * @param array $tableRecordData
+     * @return array
+     */
+    public function createNewRecords($pageId, array $tableRecordData)
+    {
+        $dataMap = [];
+        $newTableIds = [];
+        $currentUid = null;
+        $previousTableName = null;
+        $previousUid = null;
+        foreach ($tableRecordData as $tableName => $recordData) {
+            $recordData = $this->resolvePreviousUid($recordData, $currentUid);
+            if (!isset($recordData['pid'])) {
+                $recordData['pid'] = $pageId;
+            }
+            $currentUid = StringUtility::getUniqueId('NEW');
+            $newTableIds[$tableName][] = $currentUid;
+            $dataMap[$tableName][$currentUid] = $recordData;
+            if ($previousTableName !== null && $previousUid !== null) {
+                $dataMap[$previousTableName][$previousUid] = $this->resolveNextUid(
+                    $dataMap[$previousTableName][$previousUid],
+                    $currentUid
+                );
+            }
+            $previousTableName = $tableName;
+            $previousUid = $currentUid;
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start($dataMap, []);
+        $this->dataHandler->process_datamap();
+
+        foreach ($newTableIds as $tableName => &$ids) {
+            foreach ($ids as &$id) {
+                if (!empty($this->dataHandler->substNEWwithIDs[$id])) {
+                    $id = $this->dataHandler->substNEWwithIDs[$id];
+                }
+            }
+        }
+
+        return $newTableIds;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @param array $recordData
+     * @param NULL|array $deleteTableRecordIds
+     */
+    public function modifyRecord($tableName, $uid, array $recordData, array $deleteTableRecordIds = null)
+    {
+        $dataMap = [
+            $tableName => [
+                $uid => $recordData,
+            ],
+        ];
+        $commandMap = [];
+        if (!empty($deleteTableRecordIds)) {
+            foreach ($deleteTableRecordIds as $tableName => $recordIds) {
+                foreach ($recordIds as $recordId) {
+                    $commandMap[$tableName][$recordId]['delete'] = true;
+                }
+            }
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start($dataMap, $commandMap);
+        $this->dataHandler->process_datamap();
+        if (!empty($commandMap)) {
+            $this->dataHandler->process_cmdmap();
+        }
+    }
+
+    /**
+     * @param int $pageId
+     * @param array $tableRecordData
+     */
+    public function modifyRecords($pageId, array $tableRecordData)
+    {
+        $dataMap = [];
+        $currentUid = null;
+        $previousTableName = null;
+        $previousUid = null;
+        foreach ($tableRecordData as $tableName => $recordData) {
+            if (empty($recordData['uid'])) {
+                continue;
+            }
+            $recordData = $this->resolvePreviousUid($recordData, $currentUid);
+            $currentUid = $recordData['uid'];
+            if ($recordData['uid'] === '__NEW') {
+                $currentUid = StringUtility::getUniqueId('NEW');
+            }
+            if (strpos($currentUid, 'NEW') === 0) {
+                $recordData['pid'] = $pageId;
+            }
+            unset($recordData['uid']);
+            $dataMap[$tableName][$currentUid] = $recordData;
+            if ($previousTableName !== null && $previousUid !== null) {
+                $dataMap[$previousTableName][$previousUid] = $this->resolveNextUid(
+                    $dataMap[$previousTableName][$previousUid],
+                    $currentUid
+                );
+            }
+            $previousTableName = $tableName;
+            $previousUid = $currentUid;
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start($dataMap, []);
+        $this->dataHandler->process_datamap();
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @return array
+     */
+    public function deleteRecord($tableName, $uid)
+    {
+        return $this->deleteRecords(
+            [
+                $tableName => [$uid],
+            ]
+        );
+    }
+
+    /**
+     * @param array $tableRecordIds
+     * @return array
+     */
+    public function deleteRecords(array $tableRecordIds)
+    {
+        $commandMap = [];
+        foreach ($tableRecordIds as $tableName => $ids) {
+            foreach ($ids as $uid) {
+                $commandMap[$tableName][$uid] = [
+                    'delete' => true,
+                ];
+            }
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+        // Deleting workspace records is actually a copy(!)
+        return $this->dataHandler->copyMappingArray;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     */
+    public function clearWorkspaceRecord($tableName, $uid)
+    {
+        $this->clearWorkspaceRecords(
+            [
+                $tableName => [$uid],
+            ]
+        );
+    }
+
+    /**
+     * @param array $tableRecordIds
+     */
+    public function clearWorkspaceRecords(array $tableRecordIds)
+    {
+        $commandMap = [];
+        foreach ($tableRecordIds as $tableName => $ids) {
+            foreach ($ids as $uid) {
+                $commandMap[$tableName][$uid] = [
+                    'version' => [
+                        'action' => 'clearWSID',
+                    ]
+                ];
+            }
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @param int $pageId
+     * @param NULL|array $recordData
+     * @return array
+     */
+    public function copyRecord($tableName, $uid, $pageId, array $recordData = null)
+    {
+        $commandMap = [
+            $tableName => [
+                $uid => [
+                    'copy' => $pageId,
+                ],
+            ],
+        ];
+        if ($recordData !== null) {
+            $commandMap[$tableName][$uid]['copy'] = [
+                'action' => 'paste',
+                'target' => $pageId,
+                'update' => $recordData,
+            ];
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+        return $this->dataHandler->copyMappingArray;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @param int $pageId
+     * @param NULL|array $recordData
+     * @return array
+     */
+    public function moveRecord($tableName, $uid, $pageId, array $recordData = null)
+    {
+        $commandMap = [
+            $tableName => [
+                $uid => [
+                    'move' => $pageId,
+                ],
+            ],
+        ];
+        if ($recordData !== null) {
+            $commandMap[$tableName][$uid]['move'] = [
+                'action' => 'paste',
+                'target' => $pageId,
+                'update' => $recordData,
+            ];
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+        return $this->dataHandler->copyMappingArray;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @param int $languageId
+     * @return array
+     */
+    public function localizeRecord($tableName, $uid, $languageId)
+    {
+        $commandMap = [
+            $tableName => [
+                $uid => [
+                    'localize' => $languageId,
+                ],
+            ],
+        ];
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+        return $this->dataHandler->copyMappingArray;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @param int $languageId
+     * @return array
+     */
+    public function copyRecordToLanguage($tableName, $uid, $languageId)
+    {
+        $commandMap = [
+            $tableName => [
+                $uid => [
+                    'copyToLanguage' => $languageId,
+                ],
+            ],
+        ];
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+        return $this->dataHandler->copyMappingArray;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $uid
+     * @param string $fieldName
+     * @param array $referenceIds
+     */
+    public function modifyReferences($tableName, $uid, $fieldName, array $referenceIds)
+    {
+        $dataMap = [
+            $tableName => [
+                $uid => [
+                    $fieldName => implode(',', $referenceIds),
+                ],
+            ]
+        ];
+        $this->createDataHandler();
+        $this->dataHandler->start($dataMap, []);
+        $this->dataHandler->process_datamap();
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $liveUid
+     * @param bool $throwException
+     */
+    public function publishRecord($tableName, $liveUid, $throwException = true)
+    {
+        $this->publishRecords([$tableName => [$liveUid]], $throwException);
+    }
+
+    /**
+     * @param array $tableLiveUids
+     * @param bool $throwException
+     * @throws Exception
+     */
+    public function publishRecords(array $tableLiveUids, $throwException = true)
+    {
+        $commandMap = [];
+        foreach ($tableLiveUids as $tableName => $liveUids) {
+            foreach ($liveUids as $liveUid) {
+                $versionedUid = $this->getVersionedId($tableName, $liveUid);
+                if (empty($versionedUid)) {
+                    if ($throwException) {
+                        throw new Exception('Versioned UID could not be determined', 1476049592);
+                    } else {
+                        continue;
+                    }
+                }
+
+                $commandMap[$tableName][$liveUid] = [
+                    'version' => [
+                        'action' => 'swap',
+                        'swapWith' => $versionedUid,
+                        'notificationAlternativeRecipients' => [],
+                    ],
+                ];
+            }
+        }
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+    }
+
+    /**
+     * @param int $workspaceId
+     */
+    public function publishWorkspace($workspaceId)
+    {
+        $commandMap = $this->getWorkspaceService()->getCmdArrayForPublishWS($workspaceId, false);
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+    }
+
+    /**
+     * @param int $workspaceId
+     */
+    public function swapWorkspace($workspaceId)
+    {
+        $commandMap = $this->getWorkspaceService()->getCmdArrayForPublishWS($workspaceId, true);
+        $this->createDataHandler();
+        $this->dataHandler->start([], $commandMap);
+        $this->dataHandler->process_cmdmap();
+    }
+
+    /**
+     * @param array $recordData
+     * @param NULL|string|int $previousUid
+     * @return array
+     */
+    protected function resolvePreviousUid(array $recordData, $previousUid)
+    {
+        if ($previousUid === null) {
+            return $recordData;
+        }
+        foreach ($recordData as $fieldName => $fieldValue) {
+            if (strpos($fieldValue, '__previousUid') === false) {
+                continue;
+            }
+            $recordData[$fieldName] = str_replace('__previousUid', $previousUid, $fieldValue);
+        }
+        return $recordData;
+    }
+
+    /**
+     * @param array $recordData
+     * @param NULL|string|int $nextUid
+     * @return array
+     */
+    protected function resolveNextUid(array $recordData, $nextUid)
+    {
+        if ($nextUid === null) {
+            return $recordData;
+        }
+        foreach ($recordData as $fieldName => $fieldValue) {
+            if (strpos($fieldValue, '__nextUid') === false) {
+                continue;
+            }
+            $recordData[$fieldName] = str_replace('__nextUid', $nextUid, $fieldValue);
+        }
+        return $recordData;
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $liveUid
+     * @return NULL|int
+     */
+    protected function getVersionedId($tableName, $liveUid)
+    {
+        $versionedId = null;
+        $liveUid = (int)$liveUid;
+        $workspaceId = (int)$this->getBackendUser()->workspace;
+
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable($tableName);
+        $queryBuilder->getRestrictions()->removeAll();
+        $statement = $queryBuilder
+            ->select('uid')
+            ->from($tableName)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'pid',
+                    $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    't3ver_oid',
+                    $queryBuilder->createNamedParameter($liveUid, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    't3ver_wsid',
+                    $queryBuilder->createNamedParameter($workspaceId, \PDO::PARAM_INT)
+                )
+            )
+            ->execute();
+
+        $row = $statement->fetch();
+        if (!empty($row['uid'])) {
+            $versionedId = (int)$row['uid'];
+        }
+        return $versionedId;
+    }
+
+    /**
+     * @return DataHandler
+     */
+    protected function createDataHandler()
+    {
+        $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $backendUser = $this->getBackendUser();
+        if (isset($backendUser->uc['copyLevels'])) {
+            $this->dataHandler->copyTree = $backendUser->uc['copyLevels'];
+        }
+        return $this->dataHandler;
+    }
+
+    /**
+     * @return WorkspaceService
+     */
+    protected function getWorkspaceService()
+    {
+        return GeneralUtility::makeInstance(
+            WorkspaceService::class
+        );
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUser()
+    {
+        return $GLOBALS['BE_USER'];
+    }
+}

--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
 
 /*
@@ -31,7 +33,7 @@ class DataSet
      * @param bool $applyDefaultValues
      * @return DataSet
      */
-    public static function read($fileName, $applyDefaultValues = false)
+    public static function read(string $fileName, bool $applyDefaultValues = false): DataSet
     {
         $data = self::parseData(self::readData($fileName));
 
@@ -50,7 +52,7 @@ class DataSet
      * @return array
      * @throws \RuntimeException
      */
-    protected static function readData($fileName)
+    protected static function readData(string $fileName): array
     {
         if (!file_exists($fileName)) {
             throw new \RuntimeException('File "' . $fileName . '" does not exist', 1476049619);
@@ -75,7 +77,7 @@ class DataSet
      * @param array $rawData
      * @return array
      */
-    protected static function parseData(array $rawData)
+    protected static function parseData(array $rawData): array
     {
         $data = [];
         $tableName = null;
@@ -142,7 +144,7 @@ class DataSet
      * @param array $data
      * @return array
      */
-    protected static function applyDefaultValues(array $data)
+    protected static function applyDefaultValues(array $data): array
     {
         foreach ($data as $tableName => $sections) {
             if (empty($GLOBALS['TCA'][$tableName]['columns'])) {
@@ -185,7 +187,7 @@ class DataSet
     /**
      * @return array
      */
-    public function getTableNames()
+    public function getTableNames(): array
     {
         return array_keys($this->data);
     }
@@ -194,7 +196,7 @@ class DataSet
      * @param string $tableName
      * @return NULL|array
      */
-    public function getFields($tableName)
+    public function getFields(string $tableName)
     {
         $fields = null;
         if (isset($this->data[$tableName]['fields'])) {
@@ -207,7 +209,7 @@ class DataSet
      * @param string $tableName
      * @return NULL|int
      */
-    public function getIdIndex($tableName)
+    public function getIdIndex(string $tableName)
     {
         $idIndex = null;
         if (isset($this->data[$tableName]['idIndex'])) {
@@ -220,7 +222,7 @@ class DataSet
      * @param string $tableName
      * @return NULL|array
      */
-    public function getElements($tableName)
+    public function getElements(string $tableName)
     {
         $elements = null;
         if (isset($this->data[$tableName]['elements'])) {
@@ -232,7 +234,7 @@ class DataSet
     /**
      * @param string $fileName
      */
-    public function persist($fileName)
+    public function persist(string $fileName)
     {
         $fileHandle = fopen($fileName, 'w');
 

--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -1,0 +1,258 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * DataHandler DataSet
+ */
+class DataSet
+{
+    /**
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * @param string $fileName
+     * @param bool $applyDefaultValues
+     * @return DataSet
+     */
+    public static function read($fileName, $applyDefaultValues = false)
+    {
+        $data = self::parseData(self::readData($fileName));
+
+        if ($applyDefaultValues) {
+            $data = self::applyDefaultValues($data);
+        }
+
+        return GeneralUtility::makeInstance(
+            DataSet::class,
+            $data
+        );
+    }
+
+    /**
+     * @param string $fileName
+     * @return array
+     * @throws \RuntimeException
+     */
+    protected static function readData($fileName)
+    {
+        if (!file_exists($fileName)) {
+            throw new \RuntimeException('File "' . $fileName . '" does not exist', 1476049619);
+        }
+
+        $rawData = [];
+        $fileHandle = fopen($fileName, 'r');
+        while (($values = fgetcsv($fileHandle, 0)) !== false) {
+            $rawData[] = $values;
+        }
+        fclose($fileHandle);
+        return $rawData;
+    }
+
+    /**
+     * Parses CSV data.
+     *
+     * Special values are:
+     * + "\NULL" to treat as NULL value
+     * + "\*" to ignore value during comparison
+     *
+     * @param array $rawData
+     * @return array
+     */
+    protected static function parseData(array $rawData)
+    {
+        $data = [];
+        $tableName = null;
+        $fieldCount = null;
+        $idIndex = null;
+        foreach ($rawData as $values) {
+            if (!empty($values[0])) {
+                // Skip comment lines, starting with "#"
+                if ($values[0]{0} === '#') {
+                    continue;
+                }
+                $tableName = $values[0];
+                $fieldCount = null;
+                $idIndex = null;
+                if (!isset($data[$tableName])) {
+                    $data[$tableName] = [];
+                }
+            } elseif (implode('', $values) === '') {
+                $tableName = null;
+                $fieldCount = null;
+                $idIndex = null;
+            } elseif ($tableName !== null && !empty($values[1])) {
+                array_shift($values);
+                if (!isset($data[$tableName]['fields'])) {
+                    $data[$tableName]['fields'] = [];
+                    foreach ($values as $value) {
+                        if (empty($value)) {
+                            continue;
+                        }
+                        $data[$tableName]['fields'][] = $value;
+                        $fieldCount = count($data[$tableName]['fields']);
+                    }
+                    if (in_array('uid', $values)) {
+                        $idIndex = array_search('uid', $values);
+                        $data[$tableName]['idIndex'] = $idIndex;
+                    }
+                } else {
+                    if (!isset($data[$tableName]['elements'])) {
+                        $data[$tableName]['elements'] = [];
+                    }
+                    $values = array_slice($values, 0, $fieldCount);
+                    foreach ($values as &$value) {
+                        if ($value === '\\NULL') {
+                            $value = null;
+                        }
+                    }
+                    unset($value);
+                    $element = array_combine($data[$tableName]['fields'], $values);
+                    if ($idIndex !== null) {
+                        $data[$tableName]['elements'][$values[$idIndex]] = $element;
+                    } else {
+                        $data[$tableName]['elements'][] = $element;
+                    }
+                }
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * Applies TCA default values to missing fields on the imported scenario data-set.
+     * This is basically required for running the functional tests in a SQL strict mode environment.
+     *
+     * @param array $data
+     * @return array
+     */
+    protected static function applyDefaultValues(array $data)
+    {
+        foreach ($data as $tableName => $sections) {
+            if (empty($GLOBALS['TCA'][$tableName]['columns'])) {
+                continue;
+            }
+
+            $fields = $sections['fields'];
+
+            foreach ($GLOBALS['TCA'][$tableName]['columns'] as $tcaFieldName => $tcaFieldConfiguration) {
+                // Skip if field was already imported
+                if (in_array($tcaFieldName, $fields)) {
+                    continue;
+                }
+                // Skip if field is an enable-column (it's expected that those fields have proper DBMS defaults)
+                if (!empty($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']) && in_array($tcaFieldName, $GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns'])) {
+                    continue;
+                }
+                // Skip if no default value is defined in the accordant TCA definition (NULL values might occur as well)
+                if (empty($tcaFieldConfiguration['config']) || !array_key_exists('default', $tcaFieldConfiguration['config'])) {
+                    continue;
+                }
+
+                $data[$tableName]['fields'][] = $tcaFieldName;
+                foreach ($data[$tableName]['elements'] as &$element) {
+                    $element[$tcaFieldName] = $tcaFieldConfiguration['config']['default'];
+                }
+            }
+        }
+        return $data;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTableNames()
+    {
+        return array_keys($this->data);
+    }
+
+    /**
+     * @param string $tableName
+     * @return NULL|array
+     */
+    public function getFields($tableName)
+    {
+        $fields = null;
+        if (isset($this->data[$tableName]['fields'])) {
+            $fields = $this->data[$tableName]['fields'];
+        }
+        return $fields;
+    }
+
+    /**
+     * @param string $tableName
+     * @return NULL|int
+     */
+    public function getIdIndex($tableName)
+    {
+        $idIndex = null;
+        if (isset($this->data[$tableName]['idIndex'])) {
+            $idIndex = $this->data[$tableName]['idIndex'];
+        }
+        return $idIndex;
+    }
+
+    /**
+     * @param string $tableName
+     * @return NULL|array
+     */
+    public function getElements($tableName)
+    {
+        $elements = null;
+        if (isset($this->data[$tableName]['elements'])) {
+            $elements = $this->data[$tableName]['elements'];
+        }
+        return $elements;
+    }
+
+    /**
+     * @param string $fileName
+     */
+    public function persist($fileName)
+    {
+        $fileHandle = fopen($fileName, 'w');
+
+        foreach ($this->data as $tableName => $tableData) {
+            if (empty($tableData['fields']) || empty($tableData['elements'])) {
+                continue;
+            }
+
+            $fields = $tableData['fields'];
+            array_unshift($fields, '');
+
+            fputcsv($fileHandle, [$tableName]);
+            fputcsv($fileHandle, $fields);
+
+            foreach ($tableData['elements'] as $element) {
+                array_unshift($element, '');
+                fputcsv($fileHandle, $element);
+            }
+        }
+
+        fclose($fileHandle);
+    }
+}

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -20,10 +20,10 @@ use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Tests\Functional\DataHandling\Framework\DataSet;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 use TYPO3\TestingFramework\Core\Exception;
+use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Response;
 use TYPO3\TestingFramework\Core\Testbase;
 

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -19,6 +19,8 @@ return [
     '\\TYPO3\\Components\\TestingFramework\\Core\\Functional\\Framework\Frontend\\RequestBootstrap' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap::class,
     '\\TYPO3\\Components\\TestingFramework\\Core\\Functional\\Framework\Frontend\\ResponseContent' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\ResponseContent::class,
     '\\TYPO3\\Components\\TestingFramework\\Core\\Functional\\Framework\Frontend\\ResponseSection' => \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\ResponseSection::class,
+    '\\TYPO3\\CMS\\Core\\Tests\\Functional\\DataHandling\\Framework\\ActionService' => \TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\ActionService::class,
+    '\\TYPO3\\CMS\\Core\\Tests\\Functional\\DataHandling\\Framework\\DataSet' => \TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet::class,
 
     // Unit
     '\\TYPO3\\Components\\TestingFramework\\Core\\Unit\\UnitTestCase' => \TYPO3\TestingFramework\Core\Unit\UnitTestCase::class,


### PR DESCRIPTION
The classes in ext:core/Test/Functional/DataHandling/Framework
are pretty useful for DataHandler tests. So it comes in handy
to have them available in testing-framework instead as part of
sysext:core.