### PR TITLE
[TASK] Check method_exists before injecting ReflectionService

### DIFF
--- a/Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -115,9 +115,9 @@ abstract class ViewHelperBaseTestcase extends \TYPO3\TestingFramework\Core\Unit\
     {
         $viewHelper->setRenderingContext($this->renderingContext);
         $viewHelper->setArguments($this->arguments);
-        // this condition is needed, because the (Be)/Security\*ViewHelper don't extend the
-        // AbstractViewHelper and contain no method injectReflectionService()
-        if ($viewHelper instanceof AbstractViewHelper) {
+        // this condition is needed for compatibility with both CMS and Fluid base VH class,
+        // as well as support for testing on core source before/after https://review.typo3.org/#/c/52796/
+        if (method_exists($viewHelper, 'injectReflectionService')) {
             $reflectionServiceProphecy = $this->prophesize(ReflectionService::class);
             $viewHelper->injectReflectionService($reflectionServiceProphecy->reveal());
         }


### PR DESCRIPTION
Allows the testing framework to correctly test VH classes which
subclass non-CMS VH classes, and allows testing VH classes
after applying https://review.typo3.org/#/c/52796/.