### PR TITLE
[BUGFIX] Remove possibly undefined constant from test bootstraps

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -773,7 +773,7 @@ class Testbase
      */
     protected function exitWithMessage($message)
     {
-        echo $message . LF;
+        echo $message . chr(10);
         exit(1);
     }
 


### PR DESCRIPTION
The constant LF might not be defined in functional and unit test
bootstrap by the time the script terminates with an error message.

Replacing the usage of this constant with the native value for a
linebreak causes the same result for the error message, but prevents
the additional and confusing messages about the not existing constant.