### PR TITLE
Add failure message when StructureHasRecordConstraint fails

### DIFF
--- a/Classes/Core/Functional/Framework/Constraint/RequestSection/StructureHasRecordConstraint.php
+++ b/Classes/Core/Functional/Framework/Constraint/RequestSection/StructureHasRecordConstraint.php
@@ -30,7 +30,8 @@ class StructureHasRecordConstraint extends AbstractStructureRecordConstraint
         $nonMatchingVariants = [];
         $remainingRecordVariants = [];
 
-        foreach ($responseSection->findStructures($this->recordIdentifier, $this->recordField) as $path => $structure) {
+        $structures = $responseSection->findStructures($this->recordIdentifier, $this->recordField);
+        foreach ($structures as $path => $structure) {
             if (empty($structure) || !is_array($structure)) {
                 $this->sectionFailures[$responseSection->getIdentifier()] = 'No records found in "' . $path . '"';
                 return false;
@@ -56,6 +57,10 @@ class StructureHasRecordConstraint extends AbstractStructureRecordConstraint
         }
 
         $failureMessage = '';
+
+        if (empty($structures)) {
+            $failureMessage .= 'Could not assert all values for "' . $this->recordIdentifier . '.' . $this->recordField . '.' . $this->table . '.' . $this->field .'"' . LF;
+        }
 
         if (!empty($nonMatchingVariants)) {
             $failureMessage .= 'Could not assert all values for "' . $this->table . '.' . $this->field . '"' . LF;


### PR DESCRIPTION
Now when asserting like:
```
$this->assertThat($responseSections, $this->getRequestSectionStructureHasRecordConstraint()
                    ->setRecordIdentifier(self::TABLE_Content . ':' . $ttContentUid)->setRecordField('image')
                    ->setTable('sys_file_reference')->setField('title')->setValues(...$visibleFileTitles));
``` 
A more verbose error is shown:

```
Failed asserting that structure has record.
* Section "Extbase:list()": Could not assert all values for "tt_content:299.image.sys_file_reference.title"
```
Before it was:
```
Failed asserting that structure has record.
* Section "Extbase:list()": 
```