### PR TITLE
[BUGFIX] Fix symlink creation on windows

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -235,8 +235,9 @@ class Testbase
             'typo3_src/typo3' => $instancePath . '/typo3',
             'typo3_src/index.php' => $instancePath . '/index.php',
         ];
+        chdir($instancePath);
         foreach ($linksToSet as $from => $to) {
-            $success = symlink($from, $to);
+            $success = symlink(realpath($from), $to);
             if (!$success) {
                 throw new Exception(
                     'Creating link failed: from ' . $from . ' to: ' . $to,


### PR DESCRIPTION
- To get correct paths change cwd
- Resolve from path to absolute path before creation