### PR TITLE
[FEATURE] Add possibility to duplicate paths instead of creating links

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -149,6 +149,15 @@ abstract class FunctionalTestCase extends BaseTestCase
     protected $pathsToLinkInTestInstance = [];
 
     /**
+     * Similar to $pathsToLinkInTestInstance, with the difference that given
+     * paths are really duplicated and provided in the instance - instead of
+     * using symbolic links.
+     *
+     * @var string[]
+     */
+    protected $pathsToProvideInTestInstance = [];
+
+    /**
      * This configuration array is merged with TYPO3_CONF_VARS
      * that are set in default configuration and factory configuration
      *
@@ -235,6 +244,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             $testbase->setUpInstanceCoreLinks($this->instancePath);
             $testbase->linkTestExtensionsToInstance($this->instancePath, $this->testExtensionsToLoad);
             $testbase->linkPathsInTestInstance($this->instancePath, $this->pathsToLinkInTestInstance);
+            $testbase->providePathsInTestInstance($this->instancePath, $this->pathsToProvideInTestInstance);
             $localConfiguration['DB'] = $testbase->getOriginalDatabaseSettingsFromEnvironmentOrLocalConfiguration();
             $originalDatabaseName = $localConfiguration['DB']['Connections']['Default']['dbname'];
             // Append the unique identifier to the base database name to end up with a single database per test case

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -309,6 +309,39 @@ class Testbase
     }
 
     /**
+     * Copies paths inside the test instance, e.g. from a fixture fileadmin
+     * sub-folder to the test instance fileadmin folder. This method should
+     * be used in case the references paths shall be modified inside the
+     * testing instance which might not be possible with symbolic links.
+     *
+     * For functional and acceptance tests.
+     *
+     * @param string $instancePath
+     * @param array $pathsToProvideInTestInstance
+     * @throws Exception
+     */
+    public function providePathsInTestInstance(string $instancePath, array $pathsToProvideInTestInstance)
+    {
+        foreach ($pathsToProvideInTestInstance as $sourceIdentifier => $designationIdentifier) {
+            $sourcePath = $instancePath . '/' . ltrim($sourceIdentifier, '/');
+            if (!file_exists($sourcePath)) {
+                throw new Exception(
+                    'Path ' . $sourcePath . ' not found',
+                    1511956084
+                );
+            }
+            $destinationPath = $instancePath . '/' . ltrim($designationIdentifier, '/');
+            $success = copy($sourcePath, $destinationPath);
+            if (!$success) {
+                throw new Exception(
+                    'Can not copy the path ' . $sourcePath . ' to ' . $destinationPath,
+                    1511956085
+                );
+            }
+        }
+    }
+
+    /**
      * Database settings for functional and acceptance tests can be either set by
      * environment variables (recommended), or from an existing LocalConfiguration as fallback.
      * The method fetches these.


### PR DESCRIPTION
$pathsToLinkInTestInstance already allows to create symbolic links from
outside into the testing instance. However, in case these resource shall
be modified inside the testing instance, having real stand-alone
resources is better.

$pathsToProvideInTestInstance is introduced which behaves similar to
$pathsToLinkInTestInstance with the important difference that resources
are duplicated now instead of being linked.

Resolves: #42