### PR TITLE
[BUGFIX] Create extension configuration on boot

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -26,6 +26,7 @@ use TYPO3\CMS\Core\Database\Schema\SchemaMigrator;
 use TYPO3\CMS\Core\Database\Schema\SqlReader;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Service\ExtensionConfigurationService;
 
 /**
  * This is a helper class used by unit, functional and acceptance test
@@ -577,6 +578,13 @@ class Testbase
             ->setRequestType(TYPO3_REQUESTTYPE_BE | TYPO3_REQUESTTYPE_CLI)
             ->baseSetup()
             ->loadConfigurationAndInitialize(true);
+
+        if (class_exists(ExtensionConfigurationService::class)) {
+            $extensionConfigurationService = new ExtensionConfigurationService();
+            $extensionConfigurationService->synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions();
+            Bootstrap::getInstance()->populateLocalConfiguration();
+        }
+
         $this->dumpClassLoadingInformation();
         Bootstrap::getInstance()->loadTypo3LoadedExtAndExtLocalconf(true)
             ->setFinalCachingFrameworkCacheConfiguration()


### PR DESCRIPTION
Since TYPO3 will throw exceptions when extension
configuration is not present and added tests extensions
can bring their own configuration, we need to ensure
that configuration for all active extensions is present
before including their ext_localconf.php files.