### PR TITLE
Preparing v3.0.0

### DIFF
--- a/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
@@ -201,8 +201,6 @@ class AcceptanceCoreEnvironment extends Extension
         $localConfiguration['BE']['lockHashKeyWords'] = '';
         $localConfiguration['BE']['installToolPassword'] = $this->getInstallToolPassword();
         $localConfiguration['BE']['loginSecurityLevel'] = 'rsa';
-        $localConfiguration['SYS']['isInitialInstallationInProgress'] = false;
-        $localConfiguration['SYS']['isInitialDatabaseImportDone'] = true;
         $localConfiguration['SYS']['displayErrors'] = false;
         $localConfiguration['SYS']['debugExceptionHandler'] = '';
         $localConfiguration['SYS']['trustedHostsPattern'] = 'localhost:8000';

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -252,8 +252,6 @@ abstract class FunctionalTestCase extends BaseTestCase
             $testbase->testDatabaseNameIsNotTooLong($originalDatabaseName, $localConfiguration);
             // Set some hard coded base settings for the instance. Those could be overruled by
             // $this->configurationToUseInTestInstance if needed again.
-            $localConfiguration['SYS']['isInitialInstallationInProgress'] = false;
-            $localConfiguration['SYS']['isInitialDatabaseImportDone'] = true;
             $localConfiguration['SYS']['displayErrors'] = '1';
             $localConfiguration['SYS']['debugExceptionHandler'] = '';
             $localConfiguration['SYS']['trustedHostsPattern'] = '.*';

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -46,6 +46,42 @@ abstract class UnitTestCase extends BaseTestCase
     protected $testFilesToDelete = [];
 
     /**
+     * This variable can be set to true if unit tests execute
+     * code that is not E_NOTICE free to not let the test fail.
+     *
+     * @deprecated This setting will be removed if TYPO3 core does not need it any longer.
+     *
+     * @var bool
+     */
+    protected static $suppressNotices = false;
+
+    /**
+     * @var int Backup variable of current error reporting
+     */
+    private static $backupErrorReporting;
+
+    /**
+     * Set error reporting to trigger or suppress E_NOTICE
+     */
+    public static function setUpBeforeClass()
+    {
+        $errorReporting = self::$backupErrorReporting = error_reporting();
+        if (static::$suppressNotices === false) {
+            error_reporting($errorReporting | E_NOTICE);
+        } else {
+            error_reporting($errorReporting & ~E_NOTICE);
+        }
+    }
+
+    /**
+     * Reset error reporting to original state
+     */
+    public static function tearDownAfterClass()
+    {
+        error_reporting(self::$backupErrorReporting);
+    }
+
+    /**
      * Unset all additional properties of test classes to help PHP
      * garbage collection. This reduces memory footprint with lots
      * of tests.

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -40,9 +40,6 @@ call_user_func(function () {
     $testbase->createDirectory(PATH_site . 'typo3temp/var/transient');
     $testbase->createDirectory(PATH_site . 'uploads');
 
-    // disable TYPO3_DLOG
-    define('TYPO3_DLOG', false);
-
     // Retrieve an instance of class loader and inject to core bootstrap
     $classLoaderFilepath = TYPO3_PATH_PACKAGES . 'autoload.php';
     if (!file_exists($classLoaderFilepath)) {

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,15 @@
     "phpunit/phpunit": "^6.2",
     "mikey179/vfsStream": "~1.6.0",
     "typo3fluid/fluid": "^2.2",
-    "typo3/cms-core": "^8.5 || ^9",
-    "typo3/cms-backend": "^8.5 || ^9",
-    "typo3/cms-frontend": "^8.5 || ^9",
-    "typo3/cms-extbase": "^8.5 || ^9",
-    "typo3/cms-fluid": "^8.5 || ^9"
+    "typo3/cms-core": "^9",
+    "typo3/cms-backend": "^9",
+    "typo3/cms-frontend": "^9",
+    "typo3/cms-extbase": "^9",
+    "typo3/cms-fluid": "^9"
   },
   "suggest": {
     "codeception/codeception": "^2.2",
-    "typo3/cms-saltedpasswords": "^8.5",
+    "typo3/cms-saltedpasswords": "^9",
     "typo3/cms-styleguide": "~8.0.8"
   },
   "autoload": {


### PR DESCRIPTION
Major version raise bringing core v9-only compatibility
and a UnitTestCase base class that no longer supresses
E_NOTICE PHP level errors by default.