### PR TITLE
[TASK] Do not synchronize extension configuration templates in Testbase

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Database\Connection;
@@ -578,11 +577,6 @@ class Testbase
             ->setRequestType(TYPO3_REQUESTTYPE_BE | TYPO3_REQUESTTYPE_CLI)
             ->baseSetup()
             ->loadConfigurationAndInitialize(true);
-
-        if (class_exists(ExtensionConfiguration::class)) {
-            $extensionConfigurationService = new ExtensionConfiguration();
-            $extensionConfigurationService->synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions();
-        }
 
         $this->dumpClassLoadingInformation();
         Bootstrap::getInstance()->loadTypo3LoadedExtAndExtLocalconf(true)

--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,15 @@
     "phpunit/phpunit": "^6.2",
     "mikey179/vfsStream": "~1.6.0",
     "typo3fluid/fluid": "^2.2",
-    "typo3/cms-core": "^9",
-    "typo3/cms-backend": "^9",
-    "typo3/cms-frontend": "^9",
-    "typo3/cms-extbase": "^9",
-    "typo3/cms-fluid": "^9"
+    "typo3/cms-core": "^9.1",
+    "typo3/cms-backend": "^9.1",
+    "typo3/cms-frontend": "^9.1",
+    "typo3/cms-extbase": "^9.1",
+    "typo3/cms-fluid": "^9.1"
   },
   "suggest": {
     "codeception/codeception": "^2.2",
-    "typo3/cms-saltedpasswords": "^9",
+    "typo3/cms-saltedpasswords": "^9.1",
     "typo3/cms-styleguide": "~8.0.8"
   },
   "autoload": {


### PR DESCRIPTION
The change introduced in 75593767e3f1127ec9800f0f6dc0d1bd56c6e516
is no longer required as https://review.typo3.org/55434 improved the
extension configuration API in TYPO3 v9.1.
That patch introduced ondemand ext_conf_template.txt parsing to create
an entry in the LocalConfiguration.php EXTENSIONS setting storage
(when not available) during a call to ExtensionConfiguration::get().