### PR TITLE
[FEATURE] Backup and Restore Environment Object in Tests

### DIFF
--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -39,6 +39,12 @@ abstract class BaseTestCase extends TestCase
     protected $backupStaticAttributes = false;
 
     /**
+     * restore Environment after each test
+     * @var bool
+     */
+    protected $backupEnvironment = false;
+
+    /**
      * Creates a mock object which allows for calling protected methods and access of protected properties.
      *
      * @param string $originalClassName name of class to create the mock object of, must not be empty

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -61,6 +61,17 @@ abstract class UnitTestCase extends BaseTestCase
     private static $backupErrorReporting;
 
     /**
+     * The Environment object is used in TYPO3 to pass immutable settings
+     * like paths and system info around.
+     * It may be created in tests, but needs to be restored afterwards
+     * The array holds the original data to reset the Environment object
+     * after test run.
+     *
+     * @var array
+     */
+    private $backupedEnvironment = [];
+
+    /**
      * Set error reporting to trigger or suppress E_NOTICE
      */
     public static function setUpBeforeClass()
@@ -152,6 +163,38 @@ abstract class UnitTestCase extends BaseTestCase
             $notCleanInstances,
             'tearDown() integrity check found left over instances in GeneralUtility::makeInstance() instance stack.'
             . ' Always consume instances added via GeneralUtility::addInstance() in your test by the test subject.'
+        );
+    }
+
+    /**
+     * before using Environment::initialize() in tests, backup the current data to be able to restore it afterwards
+     */
+    protected function backupEnvironment() {
+        $this->backupedEnvironment['context'] = TYPO3\CMS\Core\Core\Environment::getContext();
+        $this->backupedEnvironment['isCli'] = TYPO3\CMS\Core\Core\Environment::isCli();
+        $this->backupedEnvironment['composerMode'] = TYPO3\CMS\Core\Core\Environment::isComposerMode();
+        $this->backupedEnvironment['projectPath'] = TYPO3\CMS\Core\Core\Environment::getProjectPath();
+        $this->backupedEnvironment['publicPath'] = TYPO3\CMS\Core\Core\Environment::getPublicPath();
+        $this->backupedEnvironment['varPath'] = TYPO3\CMS\Core\Core\Environment::getVarPath();
+        $this->backupedEnvironment['configPath'] = TYPO3\CMS\Core\Core\Environment::getConfigPath();
+        $this->backupedEnvironment['currentScript'] = TYPO3\CMS\Core\Core\Environment::getCurrentScript();
+        $this->backupedEnvironment['isOsWindows'] = TYPO3\CMS\Core\Core\Environment::isWindows();
+    }
+
+    /**
+     * restore the Environment object after usage
+     */
+    protected function restoreEnvironment() {
+        TYPO3\CMS\Core\Core\Environment::initialize(
+            $this->backupedEnvironment['context'],
+            $this->backupedEnvironment['isCli'],
+            $this->backupedEnvironment['composerMode'],
+            $this->backupedEnvironment['projectPath'],
+            $this->backupedEnvironment['publicPath'],
+            $this->backupedEnvironment['varPath'],
+            $this->backupedEnvironment['configPath'],
+            $this->backupedEnvironment['currentScript'],
+            $this->backupedEnvironment['isOsWindows'] ? 'WINDOWS' : 'UNIX'
         );
     }
 }

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -69,7 +69,7 @@ abstract class UnitTestCase extends BaseTestCase
      *
      * @var array
      */
-    private $backupedEnvironment = [];
+    private $backedUpEnvironment = [];
 
     /**
      * Set error reporting to trigger or suppress E_NOTICE

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -92,6 +92,14 @@ abstract class UnitTestCase extends BaseTestCase
         error_reporting(self::$backupErrorReporting);
     }
 
+    protected function setUp()
+    {
+        if ($this->backupEnvironment === true) {
+            $this->backupEnvironment();
+        }
+        parent::setUp();
+    }
+
     /**
      * Unset all additional properties of test classes to help PHP
      * garbage collection. This reduces memory footprint with lots
@@ -164,6 +172,10 @@ abstract class UnitTestCase extends BaseTestCase
             'tearDown() integrity check found left over instances in GeneralUtility::makeInstance() instance stack.'
             . ' Always consume instances added via GeneralUtility::addInstance() in your test by the test subject.'
         );
+
+        if ($this->backupEnvironment === true) {
+            $this->restoreEnvironment();
+        }
     }
 
     /**

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -182,15 +182,15 @@ abstract class UnitTestCase extends BaseTestCase
      * before using Environment::initialize() in tests, backup the current data to be able to restore it afterwards
      */
     protected function backupEnvironment() {
-        $this->backupedEnvironment['context'] = TYPO3\CMS\Core\Core\Environment::getContext();
-        $this->backupedEnvironment['isCli'] = TYPO3\CMS\Core\Core\Environment::isCli();
-        $this->backupedEnvironment['composerMode'] = TYPO3\CMS\Core\Core\Environment::isComposerMode();
-        $this->backupedEnvironment['projectPath'] = TYPO3\CMS\Core\Core\Environment::getProjectPath();
-        $this->backupedEnvironment['publicPath'] = TYPO3\CMS\Core\Core\Environment::getPublicPath();
-        $this->backupedEnvironment['varPath'] = TYPO3\CMS\Core\Core\Environment::getVarPath();
-        $this->backupedEnvironment['configPath'] = TYPO3\CMS\Core\Core\Environment::getConfigPath();
-        $this->backupedEnvironment['currentScript'] = TYPO3\CMS\Core\Core\Environment::getCurrentScript();
-        $this->backupedEnvironment['isOsWindows'] = TYPO3\CMS\Core\Core\Environment::isWindows();
+        $this->backedUpEnvironment['context'] = TYPO3\CMS\Core\Core\Environment::getContext();
+        $this->backedUpEnvironment['isCli'] = TYPO3\CMS\Core\Core\Environment::isCli();
+        $this->backedUpEnvironment['composerMode'] = TYPO3\CMS\Core\Core\Environment::isComposerMode();
+        $this->backedUpEnvironment['projectPath'] = TYPO3\CMS\Core\Core\Environment::getProjectPath();
+        $this->backedUpEnvironment['publicPath'] = TYPO3\CMS\Core\Core\Environment::getPublicPath();
+        $this->backedUpEnvironment['varPath'] = TYPO3\CMS\Core\Core\Environment::getVarPath();
+        $this->backedUpEnvironment['configPath'] = TYPO3\CMS\Core\Core\Environment::getConfigPath();
+        $this->backedUpEnvironment['currentScript'] = TYPO3\CMS\Core\Core\Environment::getCurrentScript();
+        $this->backedUpEnvironment['isOsWindows'] = TYPO3\CMS\Core\Core\Environment::isWindows();
     }
 
     /**
@@ -198,15 +198,15 @@ abstract class UnitTestCase extends BaseTestCase
      */
     protected function restoreEnvironment() {
         TYPO3\CMS\Core\Core\Environment::initialize(
-            $this->backupedEnvironment['context'],
-            $this->backupedEnvironment['isCli'],
-            $this->backupedEnvironment['composerMode'],
-            $this->backupedEnvironment['projectPath'],
-            $this->backupedEnvironment['publicPath'],
-            $this->backupedEnvironment['varPath'],
-            $this->backupedEnvironment['configPath'],
-            $this->backupedEnvironment['currentScript'],
-            $this->backupedEnvironment['isOsWindows'] ? 'WINDOWS' : 'UNIX'
+            $this->backedUpEnvironment['context'],
+            $this->backedUpEnvironment['isCli'],
+            $this->backedUpEnvironment['composerMode'],
+            $this->backedUpEnvironment['projectPath'],
+            $this->backedUpEnvironment['publicPath'],
+            $this->backedUpEnvironment['varPath'],
+            $this->backedUpEnvironment['configPath'],
+            $this->backedUpEnvironment['currentScript'],
+            $this->backedUpEnvironment['isOsWindows'] ? 'WINDOWS' : 'UNIX'
         );
     }
 }


### PR DESCRIPTION
The Environment object is immutable for any TYPO3 instance, but
tests can initialize their own. In oder to keep tests side
effect free, after each of such tests the original Environment
has to be restored.
New functions to backup and restore this object ready to be used
in Test classes provide an easy solution to that task.