### PR TITLE
[TASK] Remove EXT:lang as core extension to load

### DIFF
--- a/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
@@ -216,7 +216,6 @@ class AcceptanceCoreEnvironment extends Extension
             'fluid',
             'filelist',
             'extensionmanager',
-            'lang',
             'setup',
             'rsaauth',
             'saltedpasswords',

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -264,7 +264,6 @@ abstract class FunctionalTestCase extends BaseTestCase
                 'core',
                 'backend',
                 'frontend',
-                'lang',
                 'extbase',
                 'install',
             ];


### PR DESCRIPTION
The patch https://review.typo3.org/c/56017/ is about to remove EXT:lang. This must be reflected in the testing framework.