### PR TITLE
[TASK] Simplify useExistingSession setup

### DIFF
--- a/Resources/Core/Build/Configuration/Acceptance/Support/AcceptanceTester.php
+++ b/Resources/Core/Build/Configuration/Acceptance/Support/AcceptanceTester.php
@@ -53,5 +53,9 @@ class AcceptanceTester extends \Codeception\Actor
 
         // reload the page to have a logged in backend
         $I->amOnPage('/typo3/index.php');
+        
+        // Ensure main content frame is fully loaded, otherwise there are load-race-conditions
+        $I->switchToIFrame('list_frame');
+        $I->waitForText('Web Content Management System');
     }
 }


### PR DESCRIPTION
Almost all Cests include the fully loaded routine
right after the useExistingSession call. In order
to ease the setup for new Cests, include the routine
into useExistingSession