### PR TITLE
[BUGFIX] Prevent notice on empty touch arguments

### DIFF
--- a/Classes/Core/FileStreamWrapper.php
+++ b/Classes/Core/FileStreamWrapper.php
@@ -416,7 +416,11 @@ class FileStreamWrapper
         $path = self::overlayPath($path);
         switch ($options) {
             case STREAM_META_TOUCH:
-                $success = touch($path, $value[0], $value[1]);
+                if (!empty($value)) {
+                    $success = touch($path, $value[0], $value[1]);
+                } else {
+                    $success = touch($path);
+                }
                 break;
             case STREAM_META_OWNER_NAME:
                 // Fall through


### PR DESCRIPTION
Just for reference. Drupal has the same check in their DrupalLocalStreamWrapper (https://api.drupal.org/api/drupal/includes%21stream_wrappers.inc/function/DrupalLocalStreamWrapper%3A%3Astream_metadata/7.x)