### PR TITLE
[BUGFIX] Set correct TYPO3 root path in acceptance tests

### DIFF
--- a/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceCoreEnvironment.php
@@ -167,6 +167,7 @@ class AcceptanceCoreEnvironment extends Extension
         $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
+        putenv('TYPO3_PATH_ROOT=' . $instancePath);
 
         $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();

--- a/Classes/Core/Acceptance/AcceptanceInstallMysqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceInstallMysqlCoreEnvironment.php
@@ -51,6 +51,7 @@ class AcceptanceInstallMysqlCoreEnvironment extends Extension
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptanceinstallmysql';
         $testbase->removeOldInstanceIfExists($instancePath);
+        putenv('TYPO3_PATH_ROOT=' . $instancePath);
 
         // Drop db from a previous run if exists
         $connectionParameters = [

--- a/Classes/Core/Acceptance/AcceptanceInstallPgsqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/AcceptanceInstallPgsqlCoreEnvironment.php
@@ -51,6 +51,7 @@ class AcceptanceInstallPgsqlCoreEnvironment extends Extension
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptanceinstallpgsql';
         $testbase->removeOldInstanceIfExists($instancePath);
+        putenv('TYPO3_PATH_ROOT=' . $instancePath);
 
         // Drop db from a previous run if exists
         $connectionParameters = [


### PR DESCRIPTION
The environment variable TYPO3_PATH_ROOT must be set to the
test folder generated by the bootstrap. This is already the
case for functional tests but not for the acceptance tests.

If the environment variable is not set, the configuration files
like PackageStates.php is not loaded from the test folder but
from the root folder.