### PR TITLE
[FEATURE] Enhance functional test frontend and scenario handling

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendCoreEnvironment.php
@@ -256,7 +256,7 @@ class BackendCoreEnvironment extends Extension
         $originalDatabaseName = $localConfiguration['DB']['Connections']['Default']['dbname'];
         // Append the unique identifier to the base database name to end up with a single database per test case
         $localConfiguration['DB']['Connections']['Default']['dbname'] = $originalDatabaseName . '_at';
-        
+
         $this->output->debug('Database Connection: ' . json_encode($localConfiguration['DB']));
         $testbase->testDatabaseNameIsNotTooLong($originalDatabaseName, $localConfiguration);
         // Set some hard coded base settings for the instance. Those could be overruled by
@@ -296,7 +296,8 @@ class BackendCoreEnvironment extends Extension
             'scheduler',
             'tstemplate',
         ];
-        $testbase->setUpPackageStates($instancePath, $defaultCoreExtensionsToLoad, $this->config['coreExtensionsToLoad'], $testExtensionsToLoad);
+        $frameworkExtensionPaths = [];
+        $testbase->setUpPackageStates($instancePath, $defaultCoreExtensionsToLoad, $this->config['coreExtensionsToLoad'], $testExtensionsToLoad, $frameworkExtensionPaths);
         $this->output->debug('Loaded Extensions: ' . json_encode(array_merge($defaultCoreExtensionsToLoad, $this->config['coreExtensionsToLoad'], $testExtensionsToLoad)));
         $testbase->setUpBasicTypo3Bootstrap($instancePath);
         $testbase->setUpTestDatabase($localConfiguration['DB']['Connections']['Default']['dbname'], $originalDatabaseName);

--- a/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
+++ b/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
@@ -1,0 +1,65 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Model of internal frontend request
+ */
+trait AssignablePropertyTrait
+{
+    /**
+     * @param array $data
+     * @return static
+     */
+    private function assign(array $data, callable $cast = null)
+    {
+        if ($cast !== null) {
+            $data = array_map($cast, $data);
+        }
+        $assignables = array_intersect_key(
+            array_filter($data),
+            get_object_vars($this)
+        );
+        if (empty($assignables)) {
+            return $this;
+        }
+        $target = clone $this;
+        foreach ($assignables as $name => $value) {
+            $target->{$name} = $value;
+        }
+        return $target;
+    }
+
+    /**
+     * @param array $data
+     * @return static
+     */
+    private function with(array $data)
+    {
+        $target = $this;
+        $data = array_filter($data);
+        foreach ($data as $name => $value) {
+            $methodName = 'with' . ucfirst($name);
+            if (!method_exists($this, $methodName)) {
+                throw new \RuntimeException(
+                    sprintf('Method "%s" not found', $methodName),
+                    1533632522
+                );
+            }
+            $target = call_user_func([$target, $methodName], $value);
+        }
+        return $target;
+    }
+}

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -426,9 +426,10 @@ class ActionService
      * @param array $dataMap
      * @param array $commandMap
      */
-    public function invoke(array $dataMap, array $commandMap)
+    public function invoke(array $dataMap, array $commandMap, array $suggestedIds = [])
     {
         $this->createDataHandler();
+        $this->dataHandler->suggestedInsertUids = $suggestedIds;
         $this->dataHandler->start($dataMap, $commandMap);
         $this->dataHandler->process_datamap();
         $this->dataHandler->process_cmdmap();

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataMapFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataMapFactory.php
@@ -19,11 +19,12 @@ use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**
- * Data scenario data map factory
+ * Factory for DataHandler data map information parsed from a structured array
+ * (or more specifically a scenario definition written in YAML)
  */
 class DataMapFactory
 {
-    const DYNAMIC_ID = 10000;
+    private const DYNAMIC_ID = 10000;
 
     /**
      * @var array
@@ -89,6 +90,11 @@ class DataMapFactory
         return $this->suggestedIds;
     }
 
+    /**
+     * @param array $settings
+     * @param string|null $nodeId
+     * @param string|null $parentId
+     */
     private function processEntities(
         array $settings,
         string $nodeId = null,
@@ -107,6 +113,12 @@ class DataMapFactory
         }
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @param array $itemSettings
+     * @param string|null $nodeId
+     * @param string|null $parentId
+     */
     private function processEntityItem(
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
@@ -155,6 +167,12 @@ class DataMapFactory
         $this->setInDataMap($tableName, $newId, $values);
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @param array $itemSettings
+     * @param array $ancestorIds
+     * @param string|null $nodeId
+     */
     private function processLanguageVariantItem(
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
@@ -191,6 +209,13 @@ class DataMapFactory
         $this->setInDataMap($tableName, $newId, $values);
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @param array $itemSettings
+     * @param string|null $nodeId
+     * @param string|null $parentId
+     * @return array
+     */
     private function processEntityValues(
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
@@ -238,6 +263,9 @@ class DataMapFactory
         return $values;
     }
 
+    /**
+     * @param array $settings
+     */
     private function buildEntityConfigurations(array $settings): void
     {
         $defaultSettings = $settings['*'] ?? [];
@@ -269,6 +297,10 @@ class DataMapFactory
         return $this->entityConfigurations[$entityName];
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @param int $suggestedId
+     */
     private function addSuggestedId(
         EntityConfiguration $entityConfiguration,
         int $suggestedId
@@ -277,6 +309,11 @@ class DataMapFactory
         $this->suggestedIds[$identifier] = true;
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @param int $id
+     * @return bool
+     */
     private function hasStaticId(
         EntityConfiguration $entityConfiguration,
         int $id
@@ -288,6 +325,10 @@ class DataMapFactory
         );
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @param int $id
+     */
     private function addStaticId(
         EntityConfiguration $entityConfiguration,
         int $id
@@ -298,6 +339,10 @@ class DataMapFactory
         $this->staticIdsPerEntity[$entityConfiguration->getName()][] = $id;
     }
 
+    /**
+     * @param EntityConfiguration $entityConfiguration
+     * @return int
+     */
     private function incrementDynamicId(
         EntityConfiguration $entityConfiguration
     ): int {

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataMapFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataMapFactory.php
@@ -1,0 +1,301 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Scenario;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\Utility\StringUtility;
+
+/**
+ * Data scenario data map factory
+ */
+class DataMapFactory
+{
+    const DYNAMIC_ID = 10000;
+
+    /**
+     * @var array
+     */
+    private $settings;
+
+    /**
+     * @var EntityConfiguration[]
+     */
+    private $entityConfigurations = [];
+
+    /**
+     * @var array
+     */
+    private $dataMap = [];
+
+    /**
+     * @var bool[]
+     */
+    private $suggestedIds = [];
+
+    /**
+     * @var int
+     */
+    private $dynamicIdsPerEntity = [];
+
+    /**
+     * @var int[]
+     */
+    private $staticIdsPerEntity = [];
+
+    /**
+     * @param string $yamlFile
+     * @return DataMapFactory
+     */
+    public static function fromYamlFile(string $yamlFile): DataMapFactory
+    {
+        $yamlContent = file_get_contents($yamlFile);
+        $settings = Yaml::parse($yamlContent);
+        return new static($settings);
+    }
+
+    public function __construct(array $settings)
+    {
+        $this->settings = $settings;
+        $this->buildEntityConfigurations($settings['entitySettings'] ?? []);
+        $this->processEntities($this->settings['entities'] ?? []);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDataMap(): array
+    {
+        return $this->dataMap;
+    }
+
+    /**
+     * @return bool[]
+     */
+    public function getSuggestedIds(): array
+    {
+        return $this->suggestedIds;
+    }
+
+    private function processEntities(
+        array $settings,
+        string $nodeId = null,
+        string $parentId = null
+    ) {
+        foreach ($settings as $entityName => $entitySettings) {
+            $entityConfiguration = $this->provideEntityConfiguration($entityName);
+            foreach ($entitySettings as $itemSettings) {
+                $this->processEntityItem(
+                    $entityConfiguration,
+                    $itemSettings,
+                    $nodeId,
+                    $parentId
+                );
+            }
+        }
+    }
+
+    private function processEntityItem(
+        EntityConfiguration $entityConfiguration,
+        array $itemSettings,
+        string $nodeId = null,
+        string $parentId = null
+    ) {
+        $values = $this->processEntityValues(
+            $entityConfiguration,
+            $itemSettings,
+            $nodeId,
+            $parentId
+        );
+
+        $tableName = $entityConfiguration->getTableName();
+        $newId = StringUtility::getUniqueId('NEW');
+        // Placeholder to preserve creation order
+        $this->dataMap[$tableName][$newId] = [];
+
+        foreach ($itemSettings['languageVariants'] as $variantItemSettings) {
+            $this->processLanguageVariantItem(
+                $entityConfiguration,
+                $variantItemSettings,
+                [$newId],
+                $entityConfiguration->isNode() ? $newId : $nodeId
+            );
+        }
+
+        foreach ($itemSettings['children'] ?? [] as $childItemSettings) {
+            $this->processEntityItem(
+                $entityConfiguration,
+                $childItemSettings,
+                $nodeId,
+                $newId
+            );
+        }
+
+        if (!empty($itemSettings['entities']) && $entityConfiguration->isNode()) {
+            $this->processEntities(
+                $itemSettings['entities'],
+                $newId,
+                $parentId
+            );
+        }
+
+        // Finally assign values
+        $this->dataMap[$tableName][$newId] = $values;
+    }
+
+    private function processLanguageVariantItem(
+        EntityConfiguration $entityConfiguration,
+        array $itemSettings,
+        array $ancestorIds,
+        string $nodeId = null
+    )
+    {
+        $values = $this->processEntityValues(
+            $entityConfiguration,
+            $itemSettings,
+            $nodeId
+        );
+
+        // Language values can be overriden by declared values
+        $values = array_merge(
+            $entityConfiguration->processLanguageValues($ancestorIds),
+            $values
+        );
+
+        $tableName = $entityConfiguration->getTableName();
+        $newId = StringUtility::getUniqueId('NEW');
+        // Placeholder to preserve creation order
+        $this->dataMap[$tableName][$newId] = [];
+
+        foreach ($itemSettings['languageVariants'] as $variantItemSettings) {
+            $this->processLanguageVariantItem(
+                $entityConfiguration,
+                $variantItemSettings,
+                array_merge($ancestorIds, [$newId]),
+                $nodeId
+            );
+        }
+
+        $this->dataMap[$tableName][$newId] = $values;
+    }
+
+    private function processEntityValues(
+        EntityConfiguration $entityConfiguration,
+        array $itemSettings,
+        string $nodeId = null,
+        string $parentId = null
+    ): array {
+        if (empty($itemSettings['self']) || !is_array($itemSettings['self'])) {
+            throw new \LogicException(
+                sprintf(
+                    'Missing "self" declaration for entity "%s"',
+                    $entityConfiguration->getName()
+                ),
+                1533734369
+            );
+        }
+
+        $staticId = (int)($itemSettings['self']['id'] ?? 0);
+        if ($this->hasStaticId($entityConfiguration, $staticId)) {
+            throw new \LogicException(
+                sprintf(
+                    'Cannot assign ID "%s" multiple times',
+                    $staticId
+                ),
+                1533734370
+            );
+        }
+
+        $parentColumnName = $entityConfiguration->getParentColumnName();
+        $nodeColumnName = $entityConfiguration->getNodeColumnName();
+
+        $suggestedId = $staticId > 0 ? $staticId : $this->incrementDynamicId($entityConfiguration);
+        $this->addSuggestedId($entityConfiguration, $suggestedId);
+        $values = $entityConfiguration->processValues($itemSettings['self']);
+        $values['uid'] = $suggestedId;
+
+        // Assign node pointer value
+        if ($nodeId !== null && !empty($nodeColumnName)) {
+            $values[$nodeColumnName] = $nodeId;
+        }
+        // Assign parent pointer value
+        if ($parentId !== null && !empty($parentColumnName)) {
+            $values[$parentColumnName] = $parentId;
+        }
+
+        return $values;
+    }
+
+    private function buildEntityConfigurations(array $settings): void
+    {
+        $defaultSettings = $settings['*'] ?? [];
+        foreach ($settings as $entityName => $entitySettings) {
+            if ($entityName === '*') {
+                continue;
+            }
+            $entityConfiguration = EntityConfiguration::fromArray(
+                $entityName,
+                array_merge_recursive(
+                    $defaultSettings,
+                    $entitySettings
+                )
+            );
+            $this->entityConfigurations[$entityName] = $entityConfiguration;
+        }
+    }
+
+    /**
+     * @param string $entityName
+     * @return EntityConfiguration
+     */
+    private function provideEntityConfiguration(string $entityName): EntityConfiguration
+    {
+        if (empty($this->entityConfigurations[$entityName])) {
+            $this->entityConfigurations[$entityName] = new EntityConfiguration($entityName);
+        }
+        return $this->entityConfigurations[$entityName];
+    }
+
+    private function addSuggestedId(EntityConfiguration $entityConfiguration, int $suggestedId)
+    {
+        $identifier = $entityConfiguration->getTableName() . ':' . $suggestedId;
+        $this->suggestedIds[$identifier] = true;
+    }
+
+    private function hasStaticId(EntityConfiguration $entityConfiguration, int $id): bool
+    {
+        return in_array(
+            $id,
+            $this->staticIdsPerEntity[$entityConfiguration->getName()] ?? [],
+            true
+        );
+    }
+
+    private function addStaticId(EntityConfiguration $entityConfiguration, int $id): void
+    {
+        if (!isset($this->staticIdsPerEntity[$entityConfiguration->getName()])) {
+            $this->staticIdsPerEntity[$entityConfiguration->getName()] = [];
+        }
+        $this->staticIdsPerEntity[$entityConfiguration->getName()][] = $id;
+    }
+
+    private function incrementDynamicId(EntityConfiguration $entityConfiguration): int
+    {
+        if (!isset($this->dynamicIdsPerEntity[$entityConfiguration->getName()])) {
+            $this->dynamicIdsPerEntity[$entityConfiguration->getName()] = static::DYNAMIC_ID;
+        }
+        return ++$this->dynamicIdsPerEntity[$entityConfiguration->getName()];
+    }
+}

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
@@ -1,0 +1,231 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Scenario;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Data scenario import service
+ */
+class EntityConfiguration
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var bool
+     */
+    private $isNode = false;
+
+    /**
+     * @var null|string
+     */
+    private $tableName;
+
+    /**
+     * @var null|string
+     */
+    private $parentColumnName;
+
+    /**
+     * @var null|string
+     */
+    private $nodeColumnName;
+
+    /**
+     * @var array
+     */
+    private $columnNames = [];
+
+    /**
+     * @var array
+     */
+    private $languageColumnNames = [];
+
+    /**
+     * @var array
+     */
+    private $defaultValues = [];
+
+    /**
+     * @var array
+     */
+    private $valueInstructions = [];
+
+    public static function fromArray(string $name, array $settings)
+    {
+        $target = new static($name);
+
+        if (isset($settings['isNode'])) {
+            $target->isNode = (bool)$settings['isNode'];
+        }
+
+        if (!empty($settings['tableName'])) {
+            $target->tableName = $settings['tableName'];
+        }
+
+        if (!empty($settings['parentColumnName'])) {
+            $target->parentColumnName = $settings['parentColumnName'];
+        }
+
+        if (!empty($settings['nodeColumnName'])) {
+            $target->nodeColumnName = $settings['nodeColumnName'];
+        }
+
+        if (!empty($settings['columnNames'])) {
+            $target->columnNames = $settings['columnNames'];
+        }
+
+        if (!empty($settings['languageColumnNames'])) {
+            $target->languageColumnNames = $settings['languageColumnNames'];
+        }
+
+        if (!empty($settings['defaultValues'])) {
+            $target->defaultValues = $settings['defaultValues'];
+        }
+
+        if (!empty($settings['valueInstructions'])) {
+            $target->assertValueInstructions($settings['valueInstructions']);
+            $target->valueInstructions = $settings['valueInstructions'];
+        }
+
+        return $target;
+    }
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNode(): bool
+    {
+        return $this->isNode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTableName(): string
+    {
+        return $this->tableName ?? $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParentColumnName(): ?string
+    {
+        return $this->parentColumnName;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getNodeColumnName(): ?string
+    {
+        return $this->nodeColumnName;
+    }
+
+    /**
+     * @param string $name
+     * @return string
+     */
+    public function resolveColumnName(string $name): string
+    {
+        return $this->columnNames[$name] ?? $name;
+    }
+
+    public function processValues(array $values): array
+    {
+        $processedValues = $this->defaultValues;
+
+        foreach ($values as $name => $value) {
+            $processedValues[$this->resolveColumnName($name)] = $value;
+        }
+        foreach ($values as $name => $value) {
+            $processedValues = $this->assignValueInstructions(
+                $processedValues,
+                $name,
+                $value
+            );
+        }
+        return $processedValues;
+    }
+
+    public function processLanguageValues(array $ancestorIds): array
+    {
+        if (empty($ancestorIds)) {
+            throw new \RuntimeException(
+                'Language ancestor IDs is empty',
+                1533744471
+            );
+        }
+
+        $processedValues = [];
+
+        if (empty($this->languageColumnNames)) {
+            return $processedValues;
+        }
+
+        $lastAncestorIdsIndex = count($ancestorIds) - 1;
+        $lastLanguageColumnNamesIndex = count($this->languageColumnNames) - 1;
+
+        foreach ($this->languageColumnNames as $index => $columnName) {
+            if ($index === $lastLanguageColumnNamesIndex || $index > $lastAncestorIdsIndex) {
+                $ancestorId = $ancestorIds[$lastAncestorIdsIndex];
+            } else {
+                $ancestorId = $ancestorIds[$index];
+            }
+            $processedValues[$columnName] = $ancestorId;
+        }
+
+        return $processedValues;
+    }
+
+    private function assignValueInstructions(array $values, string $name, $value)
+    {
+        if (empty($this->valueInstructions[$name][$value])) {
+            return $values;
+        }
+        return array_merge($values, $this->valueInstructions[$name][$value]);
+    }
+
+    private function assertValueInstructions(array $valueInstruction)
+    {
+        foreach ($valueInstruction as $columnName => $valueInstruction) {
+            if (empty($valueInstruction) || !is_array($valueInstruction)) {
+                throw new \LogicException(
+                    sprintf(
+                        'Value instruction for column "%s" must be array',
+                        $columnName
+                    ),
+                    1533734368
+                );
+            }
+        }
+    }
+}

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
@@ -16,7 +16,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Scenario
  */
 
 /**
- * Data scenario import service
+ * Model describing a entity configuration used in a data scenario
  */
 class EntityConfiguration
 {
@@ -65,6 +65,11 @@ class EntityConfiguration
      */
     private $valueInstructions = [];
 
+    /**
+     * @param string $name
+     * @param array $settings
+     * @return EntityConfiguration
+     */
     public static function fromArray(string $name, array $settings)
     {
         $target = new static($name);
@@ -105,6 +110,9 @@ class EntityConfiguration
         return $target;
     }
 
+    /**
+     * @param string $name
+     */
     public function __construct(string $name)
     {
         $this->name = $name;
@@ -176,6 +184,10 @@ class EntityConfiguration
         return $processedValues;
     }
 
+    /**
+     * @param array $ancestorIds
+     * @return array
+     */
     public function processLanguageValues(array $ancestorIds): array
     {
         if (empty($ancestorIds)) {
@@ -206,6 +218,12 @@ class EntityConfiguration
         return $processedValues;
     }
 
+    /**
+     * @param array $values
+     * @param string $name
+     * @param $value
+     * @return array
+     */
     private function assignValueInstructions(array $values, string $name, $value)
     {
         if (empty($this->valueInstructions[$name][$value])) {
@@ -214,7 +232,10 @@ class EntityConfiguration
         return array_merge($values, $this->valueInstructions[$name][$value]);
     }
 
-    private function assertValueInstructions(array $valueInstruction)
+    /**
+     * @param array $valueInstruction
+     */
+    private function assertValueInstructions(array $valueInstruction): void
     {
         foreach ($valueInstruction as $columnName => $valueInstruction) {
             if (empty($valueInstruction) || !is_array($valueInstruction)) {

--- a/Classes/Core/Functional/Framework/Frontend/Hook/BackendUserHandler.php
+++ b/Classes/Core/Functional/Framework/Frontend/Hook/BackendUserHandler.php
@@ -16,6 +16,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap;
 
 /**
  * Handler for backend user
@@ -28,19 +29,18 @@ class BackendUserHandler implements \TYPO3\CMS\Core\SingletonInterface
      */
     public function initialize(array $parameters, \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $frontendController)
     {
-        $backendUserId = (int)GeneralUtility::_GP('backendUserId');
-        $workspaceId = (int)GeneralUtility::_GP('workspaceId');
-
-        if (empty($backendUserId) || empty($workspaceId)) {
+        $context = RequestBootstrap::getInternalRequestContext();
+        if (empty($context) || empty($context->getBackendUserId()) || empty($context->getWorkspaceId())) {
             return;
         }
 
         $backendUser = $this->createBackendUser();
         $backendUser->user = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('be_users')
-            ->select(['*'], 'be_users', ['uid' => $backendUserId])
+            ->select(['*'], 'be_users', ['uid' => $context->getBackendUserId()])
             ->fetch();
-        $backendUser->setTemporaryWorkspace($workspaceId);
+        $backendUser->setTemporaryWorkspace($context->getWorkspaceId());
+        // @todo Deprecated, switch to aspect
         $frontendController->beUserLogin = true;
 
         $parameters['BE_USER'] = $backendUser;

--- a/Classes/Core/Functional/Framework/Frontend/Hook/FrontendUserHandler.php
+++ b/Classes/Core/Functional/Framework/Frontend/Hook/FrontendUserHandler.php
@@ -16,6 +16,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook;
 
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap;
 
 /**
  * Handler for frontend user
@@ -30,14 +31,19 @@ class FrontendUserHandler implements \TYPO3\CMS\Core\SingletonInterface
      */
     public function initialize(array $parameters, \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $frontendController)
     {
-        $frontendUserId = (int)GeneralUtility::_GP('frontendUserId');
+        $context = RequestBootstrap::getInternalRequestContext();
+        if (empty($context) || empty($context->getFrontendUserId())) {
+            return;
+        }
+
         $frontendController->fe_user->checkPid = 0;
 
         $frontendUser = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('fe_users')
-            ->select(['*'], 'fe_users', ['uid' => $frontendUserId])
+            ->select(['*'], 'fe_users', ['uid' => $context->getFrontendUserId()])
             ->fetch();
         if (is_array($frontendUser)) {
+            // @todo Deprecated, switch to aspect
             $frontendController->loginUser = 1;
             $frontendController->fe_user->createUserSession($frontendUser);
             $frontendController->fe_user->user = $GLOBALS['TSFE']->fe_user->fetchUserSession();

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -37,6 +37,9 @@ class InternalRequest extends Request implements \JsonSerializable
         return $target->with($data);
     }
 
+    /**
+     * @param string|null $uri URI for the request, if any.
+     */
     public function __construct($uri = null) {
         if ($uri === null) {
             $uri = 'http://localhost/';

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -1,0 +1,101 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Http\Request;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
+
+/**
+ * Model of internal frontend request context
+ */
+class InternalRequest extends Request implements \JsonSerializable
+{
+    use AssignablePropertyTrait;
+
+    /**
+     * @param array $data
+     * @return InternalRequest
+     */
+    public static function fromArray(array $data): InternalRequest
+    {
+        $target = (new static($data['uri'] ?? ''));
+        $target->getBody()->write($data['body'] ?? '');
+        unset($data['uri'], $data['body']);
+        return $target->with($data);
+    }
+
+    public function __construct($uri = null) {
+        if ($uri === null) {
+            $uri = 'http://localhost/';
+        }
+        parent::__construct($uri, 'GET');
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'method' => $this->method,
+            'headers' => $this->headers,
+            'uri' => (string)$this->uri,
+            'body' => (string)$this->body
+        ];
+    }
+
+    /**
+     * @param int $pageId
+     * @return InternalRequest
+     */
+    public function withPageId(int $pageId): InternalRequest
+    {
+        return $this->withQueryParameter('id', $pageId);
+    }
+
+    /**
+     * @param int $languageId
+     * @return InternalRequest
+     */
+    public function withLanguageId(int $languageId): InternalRequest
+    {
+        return $this->withQueryParameter('L', $languageId);
+    }
+
+    /**
+     * @param string $parameterName
+     * @param int|float|string $value
+     * @return InternalRequest
+     */
+    public function withQueryParameter(string $parameterName, $value): InternalRequest
+    {
+        if (!is_float($value) && !is_int($value) && !is_string($value) && $value !== null) {
+            throw new \RuntimeException(
+                sprintf('Invalid type "%s"', gettype($value)),
+                1533639711
+            );
+        }
+
+        $parameters = \GuzzleHttp\Psr7\parse_query($this->uri->getQuery());
+        $parameters[$parameterName] = $value;
+
+        $target = clone $this;
+        $target->uri = $target->uri->withQuery(
+            \GuzzleHttp\Psr7\build_query($parameters)
+        );
+        return $target;
+    }
+}

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
@@ -1,0 +1,114 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
+
+/**
+ * Model of internal frontend request context
+ */
+class InternalRequestContext implements \JsonSerializable
+{
+    use AssignablePropertyTrait;
+
+    /**
+     * @var int
+     */
+    private $frontendUserId;
+
+    /**
+     * @var int
+     */
+    private $backendUserId;
+
+    /**
+     * @var int
+     */
+    private $workspaceId;
+
+    /**
+     * @param array $data
+     * @return InternalRequestContext
+     */
+    public static function fromArray(array $data)
+    {
+        return (new static())->with($data);
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+
+    /**
+     * @return int
+     */
+    public function getFrontendUserId(): ?int
+    {
+        return $this->frontendUserId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBackendUserId(): ?int
+    {
+        return $this->backendUserId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWorkspaceId(): ?int
+    {
+        return $this->workspaceId;
+    }
+
+    /**
+     * @param int $workspaceId
+     * @return InternalRequestContext
+     */
+    public function withFrontendUserId(int $frontendUserId): InternalRequestContext
+    {
+        $target = clone $this;
+        $target->frontendUserId = $frontendUserId;
+        return $target;
+    }
+
+    /**
+     * @param int $workspaceId
+     * @return InternalRequestContext
+     */
+    public function withBackendUserId(int $backendUserId): InternalRequestContext
+    {
+        $target = clone $this;
+        $target->backendUserId = $backendUserId;
+        return $target;
+    }
+
+    /**
+     * @param int $workspaceId
+     * @return InternalRequestContext
+     */
+    public function withWorkspaceId(int $workspaceId): InternalRequestContext
+    {
+        $target = clone $this;
+        $target->workspaceId = $workspaceId;
+        return $target;
+    }
+}

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
@@ -14,6 +14,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 
 /**
@@ -39,6 +40,11 @@ class InternalRequestContext implements \JsonSerializable
     private $workspaceId;
 
     /**
+     * @var array
+     */
+    private $globalSettings;
+
+    /**
      * @param array $data
      * @return InternalRequestContext
      */
@@ -56,7 +62,7 @@ class InternalRequestContext implements \JsonSerializable
     }
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getFrontendUserId(): ?int
     {
@@ -64,7 +70,7 @@ class InternalRequestContext implements \JsonSerializable
     }
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getBackendUserId(): ?int
     {
@@ -72,11 +78,19 @@ class InternalRequestContext implements \JsonSerializable
     }
 
     /**
-     * @return int
+     * @return null|int
      */
     public function getWorkspaceId(): ?int
     {
         return $this->workspaceId;
+    }
+
+    /**
+     * @return null|array
+     */
+    public function getGlobalSettings(): ?array
+    {
+        return $this->globalSettings;
     }
 
     /**
@@ -109,6 +123,38 @@ class InternalRequestContext implements \JsonSerializable
     {
         $target = clone $this;
         $target->workspaceId = $workspaceId;
+        return $target;
+    }
+
+    /**
+     * @param array $globalSettings
+     * @return InternalRequestContext
+     */
+    public function withGlobalSettings(array $globalSettings): InternalRequestContext
+    {
+        if (empty($globalSettings)) {
+            return $this;
+        }
+        $target = clone $this;
+        $target->globalSettings = $globalSettings;
+        return $target;
+    }
+
+    /**
+     * @param array $globalSettings
+     * @return InternalRequestContext
+     */
+    public function withMergedGlobalSettings(array $globalSettings): InternalRequestContext
+    {
+        if (empty($globalSettings)) {
+            return $this;
+        }
+        $target = clone $this;
+        $target->globalSettings = $this->globalSettings ?? [];
+        ArrayUtility::mergeRecursiveWithOverrule(
+            $target->globalSettings,
+            $globalSettings
+        );
         return $target;
     }
 }

--- a/Classes/Core/Functional/Framework/Frontend/InternalResponse.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalResponse.php
@@ -1,0 +1,51 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
+
+/**
+ * Model of internal frontend response.
+ */
+class InternalResponse extends \TYPO3\CMS\Core\Http\Response
+{
+    use AssignablePropertyTrait;
+
+    /**
+     * @param array $data
+     * @return InternalResponse
+     */
+    public static function fromArray(array $data): InternalResponse
+    {
+        $target = new static(
+            $data['body'] ?? '',
+            $data['statusCode'] ?? 0,
+            $data['headers'] ?? []
+        );
+        unset($data['body'], $data['statusCode'], $data['headers']);
+        return $target->assign($data);
+    }
+
+    /**
+     * @param string $body
+     * @param int $statusCode
+     * @param array $headers
+     */
+    public function __construct(string $body, int $statusCode = 200, array $headers = []) {
+        parent::__construct('php://temp', $statusCode, $headers);
+        $this->getBody()->write($body);
+    }
+}

--- a/Classes/Core/Functional/Framework/Frontend/Response.php
+++ b/Classes/Core/Functional/Framework/Frontend/Response.php
@@ -80,11 +80,12 @@ class Response
 
     /**
      * @return ResponseContent
+     * @deprecated use ResponseContent::fromString() instead
      */
     public function getResponseContent()
     {
         if (!isset($this->responseContent)) {
-            $this->responseContent = new ResponseContent($this);
+            $this->responseContent = ResponseContent::fromString($this->getContent());
         }
         return $this->responseContent;
     }
@@ -92,18 +93,10 @@ class Response
     /**
      * @param mixed $sectionIdentifiers
      * @return NULL|array|ResponseSection[]
+     * @deprecated use ResponseContent::getSections() instead
      */
     public function getResponseSections(...$sectionIdentifiers)
     {
-        if (empty($sectionIdentifiers)) {
-            $sectionIdentifiers = ['Default'];
-        }
-
-        $sections = [];
-        foreach ($sectionIdentifiers as $sectionIdentifier) {
-            $sections[] = $this->getResponseContent()->getSection($sectionIdentifier);
-        }
-
-        return $sections;
+        return $this->getResponseContent()->getSections(...$sectionIdentifiers);
     }
 }

--- a/Classes/Core/Functional/Framework/Frontend/ResponseSection.php
+++ b/Classes/Core/Functional/Framework/Frontend/ResponseSection.php
@@ -50,6 +50,16 @@ class ResponseSection
      */
     public function __construct($identifier, array $data)
     {
+        if (!isset($data['structure'])
+            && !isset($data['structurePaths'])
+            && !isset($data['records'])
+        ) {
+            throw new \RuntimeException(
+                'Empty structure results',
+                1533666273
+            );
+        }
+
         $this->identifier = (string)$identifier;
         $this->structure = $data['structure'];
         $this->structurePaths = $data['structurePaths'];

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -26,6 +26,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 use TYPO3\TestingFramework\Core\Exception;
 use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalResponse;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Response;
 use TYPO3\TestingFramework\Core\Testbase;
 
@@ -114,9 +117,18 @@ abstract class FunctionalTestCase extends BaseTestCase
      * Extensions in this array are linked to the test instance, loaded
      * and their ext_tables.sql will be applied.
      *
-     * @var array
+     * @var string[]
      */
     protected $testExtensionsToLoad = [];
+
+    /**
+     * Same as $testExtensionsToLoad, but included per default from the testing framework.
+     *
+     * @var string[]
+     */
+    protected $frameworkExtensionsToLoad = [
+        'Resources/Core/Functional/Extensions/json_response',
+    ];
 
     /**
      * Array of test/fixture folder or file paths that should be linked for a test.
@@ -262,6 +274,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             }
             $testbase->setUpInstanceCoreLinks($this->instancePath);
             $testbase->linkTestExtensionsToInstance($this->instancePath, $this->testExtensionsToLoad);
+            $testbase->linkFrameworkExtensionsToInstance($this->instancePath, $this->frameworkExtensionsToLoad);
             $testbase->linkPathsInTestInstance($this->instancePath, $this->pathsToLinkInTestInstance);
             $testbase->providePathsInTestInstance($this->instancePath, $this->pathsToProvideInTestInstance);
             $localConfiguration['DB'] = $testbase->getOriginalDatabaseSettingsFromEnvironmentOrLocalConfiguration();
@@ -298,7 +311,13 @@ abstract class FunctionalTestCase extends BaseTestCase
                 'extbase',
                 'install',
             ];
-            $testbase->setUpPackageStates($this->instancePath, $defaultCoreExtensionsToLoad, $this->coreExtensionsToLoad, $this->testExtensionsToLoad);
+            $testbase->setUpPackageStates(
+                $this->instancePath,
+                $defaultCoreExtensionsToLoad,
+                $this->coreExtensionsToLoad,
+                $this->testExtensionsToLoad,
+                $this->frameworkExtensionsToLoad
+            );
             $testbase->setUpBasicTypo3Bootstrap($this->instancePath);
             if ($dbDriver !== 'pdo_sqlite') {
                 $testbase->setUpTestDatabase($dbName, $originalDatabaseName);
@@ -726,6 +745,62 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
+     * @param InternalRequest $request
+     * @param InternalRequestContext|null $context
+     * @param bool $failOnFailure
+     * @return InternalResponse
+     */
+    protected function executeFrontendRequest(InternalRequest $request, InternalRequestContext $context = null, $failOnFailure = true): InternalResponse
+    {
+        if ($context === null) {
+            $context = new InternalRequestContext();
+        }
+
+        $result = $this->retrieveFrontendRequestResult($request, $context);
+        $data = json_decode($result['stdout'], true);
+
+        if ($data === null) {
+            $this->fail('Frontend Response is empty: ' . LF . $result['stdout']);
+        }
+
+        if ($failOnFailure && $data['status'] === Response::STATUS_Failure) {
+            $this->fail('Frontend Response has failure:' . LF . $data['error']);
+        }
+
+        return InternalResponse::fromArray($data['content']);
+    }
+
+    /**
+     * @param InternalRequest $request
+     * @param InternalRequestContext $context
+     * @param bool $legacyMode
+     * @return array
+     */
+    protected function retrieveFrontendRequestResult(InternalRequest $request, InternalRequestContext $context, bool $withJsonResponse = true): array
+    {
+        $arguments = [
+            'withJsonResponse' => $withJsonResponse,
+            'documentRoot' => $this->instancePath,
+            'request' => json_encode($request),
+            'context' => json_encode($context),
+        ];
+
+        $template = new \Text_Template(TYPO3_PATH_PACKAGES . 'typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
+        $template->setVar(
+            [
+                'arguments' => var_export($arguments, true),
+                'documentRoot' => $this->instancePath,
+                'originalRoot' => ORIGINAL_ROOT,
+                'vendorPath' => TYPO3_PATH_PACKAGES
+            ]
+        );
+
+        $php = AbstractPhpProcess::factory();
+        $result = $php->runJob($template->render());
+        return $result;
+    }
+
+    /**
      * @param int $pageId
      * @param int $languageId
      * @param int $backendUserId
@@ -733,6 +808,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      * @param bool $failOnFailure
      * @param int $frontendUserId
      * @return Response
+     * @deprecated Use retrieveFrontendRequestResult() instead
      */
     protected function getFrontendResponse($pageId, $languageId = 0, $backendUserId = 0, $workspaceId = 0, $failOnFailure = true, $frontendUserId = 0)
     {
@@ -741,7 +817,6 @@ abstract class FunctionalTestCase extends BaseTestCase
             $languageId,
             $backendUserId,
             $workspaceId,
-            $failOnFailure,
             $frontendUserId
         );
         $data = json_decode($result['stdout'], true);
@@ -766,43 +841,21 @@ abstract class FunctionalTestCase extends BaseTestCase
      * @param int $languageId
      * @param int $backendUserId
      * @param int $workspaceId
-     * @param bool $failOnFailure
      * @param int $frontendUserId
      * @return array containing keys 'stdout' and 'stderr'
+     * @deprecated Use retrieveFrontendRequestResult() instead
      */
-    protected function getFrontendResult($pageId, $languageId = 0, $backendUserId = 0, $workspaceId = 0, $failOnFailure = true, $frontendUserId = 0)
+    protected function getFrontendResult($pageId, $languageId = 0, $backendUserId = 0, $workspaceId = 0, $frontendUserId = 0)
     {
-        $pageId = (int)$pageId;
-        $languageId = (int)$languageId;
-
-        $additionalParameter = '';
-
-        if (!empty($frontendUserId)) {
-            $additionalParameter .= '&frontendUserId=' . (int)$frontendUserId;
-        }
-        if (!empty($backendUserId)) {
-            $additionalParameter .= '&backendUserId=' . (int)$backendUserId;
-        }
-        if (!empty($workspaceId)) {
-            $additionalParameter .= '&workspaceId=' . (int)$workspaceId;
-        }
-
-        $arguments = [
-            'documentRoot' => $this->instancePath,
-            'requestUrl' => 'http://localhost/?id=' . $pageId . '&L=' . $languageId . $additionalParameter,
-        ];
-
-        $template = new \Text_Template(TYPO3_PATH_PACKAGES . 'typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
-        $template->setVar(
-            [
-                'arguments' => var_export($arguments, true),
-                'originalRoot' => ORIGINAL_ROOT,
-                'vendorPath' => TYPO3_PATH_PACKAGES
-            ]
+        return $this->retrieveFrontendRequestResult(
+            (new InternalRequest())
+                ->withPageId($pageId)
+                ->withLanguageId($languageId),
+            (new InternalRequestContext())
+                ->withBackendUserId($backendUserId)
+                ->withWorkspaceId($workspaceId)
+                ->withFrontendUserId($frontendUserId),
+            false
         );
-
-        $php = AbstractPhpProcess::factory();
-        $result = $php->runJob($template->render());
-        return $result;
     }
 }

--- a/Resources/Core/Functional/Extensions/json_response/Classes/Encoder.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/Encoder.php
@@ -1,0 +1,39 @@
+<?php
+namespace TYPO3\JsonResponse;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\ImmediateResponseException;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap;
+
+class Encoder implements MiddlewareInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // Fallback for legacy tests that do not expect JSON response
+        if (!RequestBootstrap::shallUseWithJsonResponse()) {
+            return $handler->handle($request);
+        }
+
+        try {
+            $response = $handler->handle($request);
+        } catch (ImmediateResponseException $exception) {
+            $response = $exception->getResponse();
+        }
+
+        return new JsonResponse([
+            'statusCode' => $response->getStatusCode(),
+            'reasonPhrase' => $response->getReasonPhrase(),
+            'headers' => $response->getHeaders(),
+            'body' => $response->getBody()->__toString(),
+        ]);
+    }
+}

--- a/Resources/Core/Functional/Extensions/json_response/Configuration/RequestMiddlewares.php
+++ b/Resources/Core/Functional/Extensions/json_response/Configuration/RequestMiddlewares.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * An array consisting of implementations of middlewares for a middleware stack to be registered
+ *
+ *  'stackname' => [
+ *      'middleware-identifier' => [
+ *         'target' => classname or callable
+ *         'before/after' => array of dependencies
+ *      ]
+ *   ]
+ */
+return [
+    'frontend' => [
+        'typo3/json-response/encoder' => [
+            'target' => \TYPO3\JsonResponse\Encoder::class,
+            'before' => [
+                'typo3/cms-frontend/timetracker'
+            ]
+        ],
+    ]
+];

--- a/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
@@ -1,0 +1,21 @@
+<?php
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'JSON Response',
+    'description' => 'JSON Response',
+    'category' => 'example',
+    'version' => '9.4.0',
+    'state' => 'beta',
+    'uploadfolder' => 0,
+    'createDirs' => '',
+    'clearCacheOnLoad' => 0,
+    'author' => 'Oliver Hader',
+    'author_email' => 'oliver@typo3.org',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '9.4.0'
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Resources/Core/Functional/Fixtures/Frontend/request.tpl
+++ b/Resources/Core/Functional/Fixtures/Frontend/request.tpl
@@ -1,5 +1,5 @@
 <?php
 require '{vendorPath}typo3/testing-framework/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php';
-\TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap::setGlobalVariables({arguments});
-\TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap::executeAndOutput();
+(new \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap('{documentRoot}', {arguments}))
+    ->executeAndOutput();
 ?>


### PR DESCRIPTION
Basically this change introduces the possibility to make use of (pseudo) PRS-7 request/response handling in frontend functional testing as well. Besides that, whole database scenarios can be declared using a new data declaration written in YAML.