### PR TITLE
[BUGFIX] Modify SQL Server IDENTITY_INSERT when creating records

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -869,4 +869,26 @@ abstract class FunctionalTestCase extends BaseTestCase
             false
         );
     }
+
+    /**
+     * Whether to allow modification of IDENTITY_INSERT for SQL Server platform.
+     * + null: unspecified, decided later during runtime (based on 'uid' & $TCA)
+     * + true: always allow, e.g. before actually importing data
+     * + false: always deny, e.g. when importing data is finished
+     *
+     * @param bool|null $allowIdentityInsert
+     * @param bool|null $allowIdentityInsert
+     * @throws DBALException
+     */
+    protected function allowIdentityInsert(?bool $allowIdentityInsert)
+    {
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+
+        if (!$connection instanceof DatabaseConnectionWrapper) {
+            return;
+        }
+
+        $connection->allowIdentityInsert($allowIdentityInsert);
+    }
 }


### PR DESCRIPTION
* since PHP namespaces have not been imported properly, the according
  runtime setting was of course not applied correctly
* using the adjustmend without persisting identity columns in the given
  data set failed - currently the autodetections is enabled for all $TCA
  tables and when a 'uid' column is provided