### PR TITLE
[BUGFIX] Fallback to internal exception in case it cannot be created

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/InternalResponseException.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalResponseException.php
@@ -1,0 +1,41 @@
+<?php
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+class InternalResponseException extends \RuntimeException
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @param string $message
+     * @param int $code
+     * @param string $type
+     */
+    public function __construct(string $message, int $code, string $type) {
+        parent::__construct($message, $code);
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -30,6 +30,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalResponse;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalResponseException;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Response;
 use TYPO3\TestingFramework\Core\Testbase;
 
@@ -772,10 +773,19 @@ abstract class FunctionalTestCase extends BaseTestCase
         }
 
         if ($data['status'] === Response::STATUS_Failure) {
-            throw new $data['exception']['type'](
-                $data['exception']['message'],
-                $data['exception']['code']
-            );
+            try {
+                $exception = new $data['exception']['type'](
+                    $data['exception']['message'],
+                    $data['exception']['code']
+                );
+            } catch (\Throwable $throwable) {
+                $exception = new InternalResponseException(
+                    (string)$data['exception']['message'],
+                    (int)$data['exception']['code'],
+                    (string)$data['exception']['type']
+                );
+            }
+            throw $exception;
         }
 
         return InternalResponse::fromArray($data['content']);


### PR DESCRIPTION
e.g. Doctrine\DBAL\Exception\DriverException cannot be reconstituted
with just message and code, but requires additional context.