### PR TITLE
fix empty condition in DatabaseConnectionWrapper->shallModifyIdentityInsert

### DIFF
--- a/Classes/Core/DatabaseConnectionWrapper.php
+++ b/Classes/Core/DatabaseConnectionWrapper.php
@@ -74,7 +74,7 @@ class DatabaseConnectionWrapper extends Connection
         if ($this->allowIdentityInsert !== null) {
             return $this->allowIdentityInsert;
         }
-        return !empty($GLOBALS['TCA'][$tableName] && isset($data['uid']));
+        return !empty($GLOBALS['TCA'][$tableName]) && isset($data['uid']);
     }
 
     /**


### PR DESCRIPTION
the condition before looks like a typo, and it throws a notice 
PHP Notice: Undefined index: cf_extbase_datamapfactory_datamap in TYPO3/7/vendor/typo3/testing-framework/Classes/Core/DatabaseConnectionWrapper.php on line 77
