### PR TITLE
[BUGFIX] Use correct path to autoload.php

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -609,7 +609,7 @@ class Testbase
         GeneralUtility::purgeInstances();
         GeneralUtility::resetApplicationContext();
 
-        $classLoader = require rtrim(realpath($instancePath . '/typo3'), '\\/') . '/../vendor/autoload.php';
+        $classLoader = require __DIR__ . '/../../../../autoload.php';
         SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);
         Bootstrap::init($classLoader);
         // Make sure output is not buffered, so command-line output can take place and


### PR DESCRIPTION
Using the subtree packages of TYPO3, the typo3 folder isn't a symlink
anymore. Thus the realpath cannot be used to resolve the path to
autoload. As the testing framework requires composer mode, the path
can simply be resolved from the current directory.