### PR TITLE
[TASK] putenv TYPO3_PATH_APP in functional and acceptance setup

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendCoreEnvironment.php
@@ -230,6 +230,7 @@ class BackendCoreEnvironment extends Extension
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
+        putenv('TYPO3_PATH_APP=' . $instancePath);
 
         $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();

--- a/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
@@ -93,6 +93,7 @@ class InstallMysqlCoreEnvironment extends Extension
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
+        putenv('TYPO3_PATH_APP=' . $instancePath);
 
         // Drop db from a previous run if exists
         $connectionParameters = [

--- a/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
@@ -99,6 +99,7 @@ class InstallPostgresqlCoreEnvironment extends Extension
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
+        putenv('TYPO3_PATH_APP=' . $instancePath);
 
         // Drop db from a previous run if exists
         $connectionParameters = [

--- a/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
@@ -50,6 +50,7 @@ class InstallSqliteCoreEnvironment extends Extension
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
+        putenv('TYPO3_PATH_APP=' . $instancePath);
 
         $testbase->createDirectory($instancePath);
         $testbase->setUpInstanceCoreLinks($instancePath);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -249,6 +249,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         $this->identifier = self::getInstanceIdentifier();
         $this->instancePath = self::getInstancePath();
         putenv('TYPO3_PATH_ROOT=' . $this->instancePath);
+        putenv('TYPO3_PATH_APP=' . $this->instancePath);
 
         $testbase = new Testbase();
         $testbase->defineTypo3ModeBe();


### PR DESCRIPTION
To simplify functional and acceptance testing within extensions,
the bootstrap now adds environment var TYPO3_PATH_APP to the same
path as TYPO3_PATH_ROOT - both lead to the "instance" path in
typo3temp/var/tests. Core bootstrap will then for pick
"instancePath"/typo3temp/var for caches and other stuff which
may otherwise be located outside of the instance in composer
based installations.