### PR TITLE
[!!!][TASK] Remove constants and properly set up environment

### DIFF
--- a/Classes/Core/FileStreamWrapper.php
+++ b/Classes/Core/FileStreamWrapper.php
@@ -38,12 +38,12 @@ namespace TYPO3\TestingFramework\Core;
  * $root->addChild($subfolder);
  * // Load fixture files and folders from disk
  * \org\bovigo\vfs\vfsStream::copyFromFileSystem(__DIR__ . '/Fixture/Files', $subfolder, 1024*1024);
- * FileStreamWrapper::init(PATH_site);
+ * FileStreamWrapper::init(Environment::getPublicPath());
  * FileStreamWrapper::registerOverlayPath('fileadmin', 'vfs://root/fileadmin');
  *
  * // Use file functions as usual
- * mkdir(PATH_site . 'fileadmin/test/');
- * $file = PATH_site . 'fileadmin/test/Foo.bar';
+ * mkdir(Environment::getPublicPath() . '/ileadmin/test/');
+ * $file = Environment::getPublicPath() . '/fileadmin/test/Foo.bar';
  * file_put_contents($file, 'Baz');
  * $content = file_get_contents($file);
  * $this->assertSame('Baz', $content);

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -75,38 +75,22 @@ class Testbase
      */
     public function defineBaseConstants()
     {
-        // A null, a tabulator, a linefeed, a carriage return, a substitution, a CR-LF combination
-        defined('NUL') ?: define('NUL', chr(0));
-        defined('TAB') ?: define('TAB', chr(9));
+        // a linefeed, a carriage return, a CR-LF combination
         defined('LF') ?: define('LF', chr(10));
         defined('CR') ?: define('CR', chr(13));
-        defined('SUB') ?: define('SUB', chr(26));
         defined('CRLF') ?: define('CRLF', CR . LF);
-
-        if (!defined('TYPO3_OS')) {
-            // Operating system identifier
-            // Either "WIN" or empty string
-            $typoOs = '';
-            if (!stristr(PHP_OS, 'darwin') && !stristr(PHP_OS, 'cygwin') && stristr(PHP_OS, 'win')) {
-                $typoOs = 'WIN';
-            }
-            define('TYPO3_OS', $typoOs);
-        }
     }
 
     /**
-     * Defines the PATH_site and PATH_thisScript constant and sets $_SERVER['SCRIPT_NAME'].
+     * Sets $_SERVER['SCRIPT_NAME'].
      * For unit tests only
      *
      * @return void
      */
     public function defineSitePath()
     {
-        define('PATH_site', $this->getWebRoot());
-        define('PATH_thisScript', PATH_site . 'typo3/index.php');
-        $_SERVER['SCRIPT_NAME'] = PATH_thisScript;
-
-        if (!file_exists(PATH_thisScript)) {
+        $_SERVER['SCRIPT_NAME'] = $this->getWebRoot() . 'typo3/index.php';
+        if (!file_exists($_SERVER['SCRIPT_NAME'])) {
             $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
         }
     }

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -32,11 +32,9 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 abstract class UnitTestCase extends BaseTestCase
 {
     /**
-     * @todo make LoadedExtensionsArray serializable instead
-     *
      * @var array
      */
-    protected $backupGlobalsBlacklist = ['TYPO3_LOADED_EXT'];
+    protected $backupGlobalsBlacklist = [];
 
     /**
      * If set to true, setUp() will back up the state of the
@@ -180,7 +178,7 @@ abstract class UnitTestCase extends BaseTestCase
             if (!GeneralUtility::validPathStr($absoluteFileName)) {
                 throw new \RuntimeException('tearDown() cleanup: Filename contains illegal characters', 1410633087);
             }
-            if (strpos($absoluteFileName, PATH_site . 'typo3temp/var/') !== 0) {
+            if (strpos($absoluteFileName, Environment::getPublicPath() . '/typo3temp/var/') !== 0) {
                 throw new \RuntimeException(
                     'tearDown() cleanup:  Files to delete must be within typo3temp/var/',
                     1410633412

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -34,11 +34,17 @@ call_user_func(function () {
     $testbase->defineTypo3ModeBe();
     $testbase->setTypo3TestingContext();
     $testbase->definePackagesPath();
-    $testbase->createDirectory(PATH_site . 'typo3conf/ext');
-    $testbase->createDirectory(PATH_site . 'typo3temp/assets');
-    $testbase->createDirectory(PATH_site . 'typo3temp/var/tests');
-    $testbase->createDirectory(PATH_site . 'typo3temp/var/transient');
-    $testbase->createDirectory(PATH_site . 'uploads');
+
+    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+    \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(3, $requestType);
+
+    // Environment is set up, now create folders for testing
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/uploads');
+
 
     // Retrieve an instance of class loader and inject to core bootstrap
     $classLoaderFilepath = TYPO3_PATH_PACKAGES . 'autoload.php';
@@ -46,15 +52,6 @@ call_user_func(function () {
         die('ClassLoader can\'t be loaded. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
     }
     $classLoader = require $classLoaderFilepath;
-
-    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-    \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(0, $requestType);
-    if (\TYPO3\CMS\Core\Utility\GeneralUtility::getApplicationContext() === null) {
-        // @deprecated can be removed in v5
-        $applicationContext = \TYPO3\CMS\Core\Core\Bootstrap::createApplicationContext();
-        \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::initializeEnvironment($applicationContext);
-        \TYPO3\CMS\Core\Utility\GeneralUtility::presetApplicationContext($applicationContext);
-    }
     \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
     \TYPO3\CMS\Core\Core\Bootstrap::baseSetup();
 


### PR DESCRIPTION
Environment API is now in place in favor of constants
* PATH_site
* PATH_thisScript
* TYPO3_OS

Setting up the constants is now removed, and Environment
initialization for Unit Tests is now working.