### PR TITLE
[BUGFIX] Test for existing table before deleting from it

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -807,13 +807,17 @@ class Testbase
                 );
             }
         } elseif ($platform instanceof SqlitePlatform) {
-            // Drop eventually existing sqlite sequence for this table
-            $connection->exec(
-                sprintf(
-                    'DELETE FROM sqlite_sequence WHERE name=%s',
-                    $connection->quote($tableName)
-                )
-            );
+
+            $sequenceExists = $connection->select(['name'],'sqlite_master', ['type' => 'table', 'name' =>'sqlite_sequence'])->fetchColumn();
+            if ($sequenceExists !== false) {
+                // Drop eventually existing sqlite sequence for this table
+                $connection->exec(
+                    sprintf(
+                        'DELETE FROM sqlite_sequence WHERE name=%s',
+                        $connection->quote($tableName)
+                    )
+                );
+            }
         }
     }
 


### PR DESCRIPTION
According documentation, sqlite will create table sqlite_sequence
only if a table with AUTOINCREMENT exists in the schema.
This means for the functional tests of TYPO3, that maybe this
table does not exist at all. Trying to reset the sequence
will lead to an error then.
Checking for existence before manipulating prevents the error.