### PR TITLE
[TASK] Render error message of failed frontend requests

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -864,6 +864,10 @@ abstract class FunctionalTestCase extends BaseTestCase
      */
     protected function reconstituteFrontendRequestResult(array $result): InternalResponse
     {
+        if (!empty($result['stderr'])) {
+            $this->fail('Frontend Response is erroneous: ' . LF . $result['stderr']);
+        }
+
         $data = json_decode($result['stdout'], true);
 
         if ($data === null) {
@@ -908,6 +912,10 @@ abstract class FunctionalTestCase extends BaseTestCase
             $workspaceId,
             $frontendUserId
         );
+        if (!empty($result['stderr'])) {
+            $this->fail('Frontend Response is erroneous: ' . LF . $result['stderr']);
+        }
+
         $data = json_decode($result['stdout'], true);
 
         if ($data === null) {


### PR DESCRIPTION
If a frontend request fails, the content of stderr is now rendered to
get the reason why a request failed. Previously, in such cases the
tests simply stated that there is no content at all.