### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and acceptance tests within the TYPO3 extension ecosystem.
 This framework works on top of a composer based installation.
 
 ```
-$ composer require typo3/testing-framework
+$ composer require --dev typo3/testing-framework
 ```
 
 ## Documentation


### PR DESCRIPTION
The testing framework should be installed as a dev dependency. It is only needed for testing, but it is not needed in production environments.