### PR TITLE
[BUGFIX] Include all tables for data insertion

### DIFF
--- a/Classes/Core/DatabaseConnectionWrapper.php
+++ b/Classes/Core/DatabaseConnectionWrapper.php
@@ -52,7 +52,7 @@ class DatabaseConnectionWrapper extends Connection
      */
     public function insert($tableName, array $data, array $types = []): int
     {
-        $modified = $this->shallModifyIdentityInsert($tableName, $data)
+        $modified = $this->shallModifyIdentityInsert($data)
             && $this->modifyIdentityInsert($tableName, true);
 
         $result = parent::insert($tableName, $data, $types);
@@ -65,16 +65,15 @@ class DatabaseConnectionWrapper extends Connection
     }
 
     /**
-     * @param string $tableName
      * @param array $data
      * @return bool
      */
-    private function shallModifyIdentityInsert(string $tableName, array $data): bool
+    private function shallModifyIdentityInsert(array $data): bool
     {
         if ($this->allowIdentityInsert !== null) {
             return $this->allowIdentityInsert;
         }
-        return !empty($GLOBALS['TCA'][$tableName]) && isset($data['uid']);
+        return isset($data['uid']);
     }
 
     /**


### PR DESCRIPTION
This commit doesn't exclude tables without TCA anymore for data insertion.
This fixes an issue with mssql where inserting values into an identity
column fails due to missing TCA.

Resolves: #127