### PR TITLE
[TASK] Add basic POST support to executeFrontendRequest.

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/Application.php
+++ b/Classes/Core/Functional/Framework/Frontend/Application.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
+
+/**
+ * Class Application
+ *
+ * Extends the main application because we need our own ServerRequestFactory
+ * to get the body content.
+ *
+ * @package TYPO3\TestingFramework\Core\Functional\Framework\Frontend
+ */
+class Application extends \TYPO3\CMS\Frontend\Http\Application
+{
+    /**
+     * Set up the application and shut it down afterwards
+     *
+     * @param callable $execute
+     */
+    final public function runFromTestingFramework(callable $execute = null)
+    {
+        try {
+            $response = $this->handle(
+                ServerRequestFactory::fromGlobals()
+            );
+            if ($execute !== null) {
+                call_user_func($execute);
+            }
+        } catch (ImmediateResponseException $exception) {
+            $response = $exception->getResponse();
+        }
+
+        $this->sendResponse($response);
+    }
+
+}

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -63,8 +63,9 @@ class InternalRequest extends Request implements \JsonSerializable
      * @param string|null $uri URI for the request, if any.
      * @param string $method method to use, GET is default.
      * @param string|null $content body content to use, if any.
+     * @param array $headers Headers for the message, if any.
      */
-    public function __construct($uri = null, $method = 'GET', string $content = null) {
+    public function __construct($uri = null, $method = 'GET', string $content = null, array $headers = []) {
         if ($uri === null) {
             $uri = 'http://localhost/';
         }
@@ -73,7 +74,7 @@ class InternalRequest extends Request implements \JsonSerializable
             $body->write($content);
             $body->rewind();
         }
-        parent::__construct($uri, $method, $body);
+        parent::__construct($uri, $method, $body, $headers);
     }
 
     /**
@@ -206,5 +207,15 @@ class InternalRequest extends Request implements \JsonSerializable
         $parameters = \GuzzleHttp\Psr7\parse_query($query);
         $parameters[$parameterName] = $value;
         return \GuzzleHttp\Psr7\build_query($parameters);
+    }
+
+    public function withHeaders(array $headers): InternalRequest
+    {
+        $target = clone $this;
+        $target->headers = $headers;
+        if (!isset($target->headers['user-agent'])) {
+            $target->headers['user-agent'] = 'TYPO3 Functional Test Request';
+        }
+        return $target;
     }
 }

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -61,13 +61,19 @@ class InternalRequest extends Request implements \JsonSerializable
 
     /**
      * @param string|null $uri URI for the request, if any.
+     * @param string $method method to use, GET is default.
+     * @param string|null $content body content to use, if any.
      */
-    public function __construct($uri = null) {
+    public function __construct($uri = null, $method = 'GET', string $content = null) {
         if ($uri === null) {
             $uri = 'http://localhost/';
         }
-        $body = new Stream('php://temp', 'rw');
-        parent::__construct($uri, 'GET', $body);
+        $body = new Stream('php://temp', 'wb+');
+        if (null !== $content) {
+            $body->write($content);
+            $body->rewind();
+        }
+        parent::__construct($uri, $method, $body);
     }
 
     /**

--- a/Classes/Core/Functional/Framework/Frontend/ServerRequestFactory.php
+++ b/Classes/Core/Functional/Framework/Frontend/ServerRequestFactory.php
@@ -12,9 +12,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Class ServerRequestFactory
  *
  * Extends the default ServerRequestFactory because we need the body content
- * from the testing framework request which is passed along in the _SERVER
- * variables.
- * 
+ * and the headers from the testing framework request which is passed along
+ * in the _SERVER variables.
+ *
  * @package TYPO3\TestingFramework\Core\Functional\Framework\Frontend
  */
 class ServerRequestFactory extends \TYPO3\CMS\Core\Http\ServerRequestFactory
@@ -38,7 +38,7 @@ class ServerRequestFactory extends \TYPO3\CMS\Core\Http\ServerRequestFactory
             $uri,
             $method,
             $serverParameters['X_TYPO3_TESTING_FRAMEWORK']['request']->getBody(),
-            $headers,
+            $serverParameters['X_TYPO3_TESTING_FRAMEWORK']['request']->getHeaders(),
             $serverParameters,
             static::normalizeUploadedFiles($_FILES)
         );

--- a/Classes/Core/Functional/Framework/Frontend/ServerRequestFactory.php
+++ b/Classes/Core/Functional/Framework/Frontend/ServerRequestFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
+
+
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class ServerRequestFactory
+ *
+ * Extends the default ServerRequestFactory because we need the body content
+ * from the testing framework request which is passed along in the _SERVER
+ * variables.
+ * 
+ * @package TYPO3\TestingFramework\Core\Functional\Framework\Frontend
+ */
+class ServerRequestFactory extends \TYPO3\CMS\Core\Http\ServerRequestFactory
+{
+    /**
+     * Create a request from the original superglobal variables.
+     *
+     * @return ServerRequest
+     * @throws \InvalidArgumentException when invalid file values given
+     * @internal Note that this is not public API yet.
+     */
+    public static function fromGlobals()
+    {
+        $serverParameters = $_SERVER;
+        $headers = static::prepareHeaders($serverParameters);
+
+        $method = $serverParameters['REQUEST_METHOD'] ?? 'GET';
+        $uri = new Uri(GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+
+        $request = new ServerRequest(
+            $uri,
+            $method,
+            $serverParameters['X_TYPO3_TESTING_FRAMEWORK']['request']->getBody(),
+            $headers,
+            $serverParameters,
+            static::normalizeUploadedFiles($_FILES)
+        );
+
+        if (!empty($_COOKIE)) {
+            $request = $request->withCookieParams($_COOKIE);
+        }
+        $queryParameters = GeneralUtility::_GET();
+        if (!empty($queryParameters)) {
+            $request = $request->withQueryParams($queryParameters);
+        }
+        $parsedBody = GeneralUtility::_POST();
+        if (empty($parsedBody) && in_array($method, ['PUT', 'PATCH', 'DELETE'])) {
+            parse_str((string)$_SERVER['X_TYPO3_TESTING_FRAMEWORK']['request']->getBody(), $parsedBody);
+        }
+        if (!empty($parsedBody)) {
+            $request = $request->withParsedBody($parsedBody);
+        }
+        return $request;
+    }
+
+}


### PR DESCRIPTION
* The http method verb is now taken from the request instead of being fixed to GET
* body content is passed along to the request