### PR TITLE
[BUGFIX] Never snapshot cf_* or cache_* tables

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -44,7 +44,7 @@ class DatabaseAccessor
         $export = [];
         foreach ($schemaManager->listTables() as $table) {
             $tableName = $table->getName();
-            if (stripos($tableName, 'cf_') === 0) {
+            if (stripos($tableName, 'cf_') === 0 || stripos($tableName, 'cache_') === 0) {
                 continue;
             }
 


### PR DESCRIPTION
due to the core change, tables now start with `cache_*` for the database.