### PR TITLE
Revert "Update phpunit to version 8"

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -240,7 +240,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      * @return void
      * @throws \Doctrine\DBAL\DBALException
      */
-    protected function setUp(): void
+    protected function setUp()
     {
         if (!defined('ORIGINAL_ROOT')) {
             $this->markTestSkipped('Functional tests must be called through phpunit on CLI');

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -92,7 +92,7 @@ abstract class UnitTestCase extends BaseTestCase
     /**
      * Set error reporting to always fail on E_NOTICE
      */
-    public static function setUpBeforeClass(): void
+    public static function setUpBeforeClass()
     {
         $errorReporting = self::$backupErrorReporting = error_reporting();
         // Always fail on notice level errors
@@ -102,7 +102,7 @@ abstract class UnitTestCase extends BaseTestCase
     /**
      * Reset error reporting to original state
      */
-    public static function tearDownAfterClass(): void
+    public static function tearDownAfterClass()
     {
         error_reporting(self::$backupErrorReporting);
     }
@@ -110,7 +110,7 @@ abstract class UnitTestCase extends BaseTestCase
     /**
      * Generic setUp()
      */
-    protected function setUp(): void
+    protected function setUp()
     {
         if ($this->backupEnvironment === true) {
             $this->backupEnvironment();
@@ -130,7 +130,7 @@ abstract class UnitTestCase extends BaseTestCase
      * @throws \RuntimeException
      * @return void
      */
-    protected function tearDown(): void
+    protected function tearDown()
     {
         // Restore Environment::class is asked for
         if ($this->backupEnvironment === true) {

--- a/Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -76,9 +76,8 @@ abstract class ViewHelperBaseTestcase extends \TYPO3\TestingFramework\Core\Unit\
     /**
      * @return void
      */
-    protected function setUp(): void
+    protected function setUp()
     {
-        parent::setUp();
         $this->viewHelperVariableContainer = $this->prophesize(ViewHelperVariableContainer::class);
         $this->templateVariableContainer = $this->createMock(StandardVariableProvider::class);
         $this->uriBuilder = $this->createMock(\TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder::class);

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
-    "phpunit/phpunit": "^7.5.6 || ^8",
+    "phpunit/phpunit": "^7.5.6",
     "mikey179/vfsstream": "~1.6.0",
     "typo3fluid/fluid": "^2.5",
     "typo3/cms-core": "^9.3",
@@ -36,7 +36,7 @@
     "typo3/cms-recordlist": "^9.3"
   },
   "suggest": {
-    "codeception/codeception": "^2.5.4 || ^3",
+    "codeception/codeception": "^2.4",
     "typo3/cms-styleguide": "^9.0"
   },
   "config": {


### PR DESCRIPTION
This reverts commits b130f30d57eec75683d90ec43e2e4b54c6c4c98c and
2cc4d197426e80fdde66a579b02ceca3f4fa2b16.

This caused a breaking change for not prepared users.