### PR TITLE
[FEATURE] Make testing framework compatible with TYPO3 v9 Core and master

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -873,8 +873,6 @@ class Testbase
      */
     public function getPackagesPath(): string
     {
-        // @hack: remove me
-        return getcwd() . '/vendor';
         return rtrim(strtr(dirname(dirname(dirname(dirname(__DIR__)))), '\\', '/'), '/');
     }
 

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -29,7 +29,6 @@
 call_user_func(function () {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
     $testbase->enableDisplayErrors();
-    $testbase->defineBaseConstants();
 
     // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
     // not create the autoload-include.php file that sets these env vars and sets composer
@@ -57,6 +56,10 @@ call_user_func(function () {
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
 
+    if ($testbase->getCurrentTypo3Version() === 9) {
+        $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/uploads');
+    }
+
     // Retrieve an instance of class loader and inject to core bootstrap
     $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
     \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
@@ -70,7 +73,7 @@ call_user_func(function () {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
 
     $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
-        'core',
+        ($testbase->getCurrentTypo3Version() === 9 ? 'cache_core' : 'core'),
         new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
     );
     // Set all packages to active

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     "phpunit/phpunit": "^7.5.6 || ^8",
     "mikey179/vfsstream": "~1.6.0",
     "typo3fluid/fluid": "^2.5",
-    "typo3/cms-core": "10.*.*@dev",
-    "typo3/cms-backend": "10.*.*@dev",
-    "typo3/cms-frontend": "10.*.*@dev",
-    "typo3/cms-extbase": "10.*.*@dev",
-    "typo3/cms-fluid": "10.*.*@dev",
-    "typo3/cms-recordlist": "10.*.*@dev"
+    "typo3/cms-core": "^9.5 || 10.*.*@dev",
+    "typo3/cms-backend": "^9.5 || 10.*.*@dev",
+    "typo3/cms-frontend": "^9.5 || 10.*.*@dev",
+    "typo3/cms-extbase": "^9.5 || 10.*.*@dev",
+    "typo3/cms-fluid": "^9.5 || 10.*.*@dev",
+    "typo3/cms-recordlist": "^9.5 || 10.*.*@dev"
   },
   "suggest": {
     "codeception/codeception": "^3",
-    "typo3/cms-styleguide": "^9.0"
+    "typo3/cms-styleguide": "^9.0 || 10.*.*@dev"
   },
   "config": {
     "vendor-dir": ".Build/vendor",


### PR DESCRIPTION
In order to run testing-framework v5 (= master) with v9 and master (v10) of TYPO3 Core,
some functionality was re-added.

A main switch within testbase was added to still allow to use PATH_site et al.