### PR TITLE
[BUGFIX] Move middleware logic away from TSFE

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
@@ -44,17 +44,17 @@ class FrontendUserHandler implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $GLOBALS['TSFE']->fe_user->checkPid = 0;
+        $frontendUserAuthentication = $request->getAttribute('frontend.user');
+        $frontendUserAuthentication->checkPid = 0;
 
         $frontendUser = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('fe_users')
             ->select(['*'], 'fe_users', ['uid' => $context->getFrontendUserId()])
             ->fetch();
         if (is_array($frontendUser)) {
-            $GLOBALS['TSFE']->fe_user->createUserSession($frontendUser);
-            $GLOBALS['TSFE']->fe_user->user = $GLOBALS['TSFE']->fe_user->fetchUserSession();
-            $GLOBALS['TSFE']->initUserGroups();
-            $this->setFrontendUserAspect(GeneralUtility::makeInstance(Context::class), $GLOBALS['TSFE']->fe_user);
+            $frontendUserAuthentication->createUserSession($frontendUser);
+            $frontendUserAuthentication->user = $frontendUserAuthentication->fetchUserSession();
+            $this->setFrontendUserAspect(GeneralUtility::makeInstance(Context::class), $frontendUserAuthentication);
         }
 
         return $handler->handle($request);


### PR DESCRIPTION
Frontend User Authenticaiton should be bound
to the PSR-7 request object, not to TSFE,
as this is done at a later stage now.

This has to be merged with 
https://review.typo3.org/c/Packages/TYPO3.CMS/+/61155