### PR TITLE
[TASK] Add new Acceptance Tests folder to splitter script

### DIFF
--- a/Resources/Core/Build/Scripts/splitAcceptanceTests.php
+++ b/Resources/Core/Build/Scripts/splitAcceptanceTests.php
@@ -80,7 +80,7 @@ class SplitAcceptanceTests extends NodeVisitorAbstract
         // Find functional test files
         $testFiles = (new Finder())
             ->files()
-            ->in(__DIR__ . '/../../../../../../../typo3/sysext/core/Tests/Acceptance/Backend')
+            ->in([__DIR__ . '/../../../../../../../typo3/sysext/core/Tests/Acceptance/Backend', __DIR__ . '/../../../../../../../typo3/sysext/core/Tests/Acceptance/InstallTool'])
             ->name('/Cest\.php$/')
         ;
 


### PR DESCRIPTION
To speed up execution of acceptance tests in bamboo, the available
test files are split into work packages. The script only considers
test files located in typo3/sysext/core/Acceptance/Backend.

With the new main folder InstallTool, that contains tests concerning
the stand alone install tool, the script must also consider those
files for work packages.