### PR TITLE
[TASK] Clean up code base

### DIFF
--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -14,6 +14,7 @@ namespace TYPO3\TestingFramework\Core;
  * The TYPO3 project - inspiring people to share!
  */
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -42,7 +43,7 @@ abstract class BaseTestCase extends TestCase
      * @param bool $callOriginalClone whether to call the __clone method
      * @param bool $callAutoload whether to call any autoload function
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject|\TYPO3\TestingFramework\Core\AccessibleObjectInterface
+     * @return MockObject|AccessibleObjectInterface
      *         a mock of $originalClassName with access methods added
      *
      * @throws \InvalidArgumentException
@@ -87,10 +88,9 @@ abstract class BaseTestCase extends TestCase
      * @param bool $callOriginalClone
      * @param bool $callAutoload
      * @param array $mockedMethods
+     * @return MockObject|AccessibleObjectInterface
      *
      * @throws \InvalidArgumentException
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject|\TYPO3\TestingFramework\Core\AccessibleObjectInterface
      *
      */
     protected function getAccessibleMockForAbstractClass(
@@ -127,7 +127,7 @@ abstract class BaseTestCase extends TestCase
 
         eval(
             $abstractModifier . 'class ' . $accessibleClassName .
-                ' extends ' . $className . ' implements ' . \TYPO3\TestingFramework\Core\AccessibleObjectInterface::class . ' {' .
+                ' extends ' . $className . ' implements ' . AccessibleObjectInterface::class . ' {' .
                     'public function _call($methodName) {' .
                         'if ($methodName === \'\') {' .
                             'throw new \InvalidArgumentException(\'$methodName must not be empty.\', 1334663993);' .

--- a/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
+++ b/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
@@ -21,6 +21,7 @@ trait AssignablePropertyTrait
 {
     /**
      * @param array $data
+     * @param callable|null $cast
      * @return static
      */
     private function assign(array $data, callable $cast = null)

--- a/Classes/Core/Functional/Framework/Constraint/RequestSection/AbstractRecordConstraint.php
+++ b/Classes/Core/Functional/Framework/Constraint/RequestSection/AbstractRecordConstraint.php
@@ -14,12 +14,13 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Constraint\RequestSec
  * The TYPO3 project - inspiring people to share!
  */
 
+use PHPUnit\Framework\Constraint\Constraint;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\ResponseSection;
 
 /**
  * Model of frontend response
  */
-abstract class AbstractRecordConstraint extends \PHPUnit\Framework\Constraint\Constraint
+abstract class AbstractRecordConstraint extends Constraint
 {
     /**
      * @var array

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -535,7 +535,7 @@ class ActionService
     }
 
     /**
-     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     * @return BackendUserAuthentication
      */
     protected function getBackendUser(): BackendUserAuthentication
     {

--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -16,8 +16,6 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-
 /**
  * DataHandler DataSet
  */
@@ -41,10 +39,7 @@ class DataSet
             $data = self::applyDefaultValues($data);
         }
 
-        return GeneralUtility::makeInstance(
-            DataSet::class,
-            $data
-        );
+        return new DataSet($data);
     }
 
     /**

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
@@ -415,7 +415,7 @@ class DataHandlerFactory
             $this->dynamicIdsPerEntity[$entityConfiguration->getName()] = static::DYNAMIC_ID;
         }
         $result = $this->dynamicIdsPerEntity[$entityConfiguration->getName()];
-        // increment for next(!) assingment, since current process might create version or language variants
+        // increment for next(!) assignment, since current process might create version or language variants
         $this->dynamicIdsPerEntity[$entityConfiguration->getName()] += $incrementValue;
         return $result;
     }

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
@@ -233,11 +233,11 @@ class EntityConfiguration
     }
 
     /**
-     * @param array $valueInstruction
+     * @param array $valueInstructions
      */
-    private function assertValueInstructions(array $valueInstruction): void
+    private function assertValueInstructions(array $valueInstructions): void
     {
-        foreach ($valueInstruction as $columnName => $valueInstruction) {
+        foreach ($valueInstructions as $columnName => $valueInstruction) {
             if (empty($valueInstruction) || !is_array($valueInstruction)) {
                 throw new \LogicException(
                     sprintf(

--- a/Classes/Core/Functional/Framework/Frontend/Collector.php
+++ b/Classes/Core/Functional/Framework/Frontend/Collector.php
@@ -14,6 +14,11 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
 /**
  * Model of frontend response
  */
@@ -67,9 +72,9 @@ class Collector implements \TYPO3\CMS\Core\SingletonInterface
     {
         $currentFile = $this->cObj->getCurrentFile();
 
-        if ($currentFile instanceof \TYPO3\CMS\Core\Resource\File) {
+        if ($currentFile instanceof File) {
             $tableName = 'sys_file';
-        } elseif ($currentFile instanceof \TYPO3\CMS\Core\Resource\FileReference) {
+        } elseif ($currentFile instanceof FileReference) {
             $tableName = 'sys_file_reference';
         } else {
             return;
@@ -149,7 +154,7 @@ class Collector implements \TYPO3\CMS\Core\SingletonInterface
         if (!isset($this->tableFields) && !empty($this->getFrontendController()->tmpl->setup['config.']['watcher.']['tableFields.'])) {
             $this->tableFields = $this->getFrontendController()->tmpl->setup['config.']['watcher.']['tableFields.'];
             foreach ($this->tableFields as &$fieldList) {
-                $fieldList = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', $fieldList, true);
+                $fieldList = GeneralUtility::trimExplode(',', $fieldList, true);
             }
             unset($fieldList);
         }
@@ -174,13 +179,13 @@ class Collector implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected function getRenderer()
     {
-        return \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-            \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Renderer::class
+        return GeneralUtility::makeInstance(
+            Renderer::class
         );
     }
 
     /**
-     * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
+     * @return TypoScriptFrontendController
      */
     protected function getFrontendController()
     {

--- a/Classes/Core/Functional/Framework/Frontend/Hook/TypoScriptInstructionModifier.php
+++ b/Classes/Core/Functional/Framework/Frontend/Hook/TypoScriptInstructionModifier.php
@@ -14,6 +14,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Hook;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\TypoScriptInstruction;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap;
@@ -21,7 +22,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap;
 /**
  * Modifier for global TypoScript dynamically provided by test-case.
  */
-class TypoScriptInstructionModifier implements \TYPO3\CMS\Core\SingletonInterface
+class TypoScriptInstructionModifier implements SingletonInterface
 {
     /**
      * @param array $parameters
@@ -82,14 +83,14 @@ class TypoScriptInstructionModifier implements \TYPO3\CMS\Core\SingletonInterfac
      */
     private function compileAssignments(array $nestedArray): string
     {
-        $assingments = $this->flatten($nestedArray);
+        $assignments = $this->flatten($nestedArray);
         array_walk(
-            $assingments,
+            $assignments,
             function (&$value, $key) {
                 $value = sprintf('%s = %s', $key, $value);
             }
         );
-        return implode("\n", $assingments);
+        return implode("\n", $assignments);
     }
 
     /**

--- a/Classes/Core/Functional/Framework/Frontend/Internal/ArrayValueInstruction.php
+++ b/Classes/Core/Functional/Framework/Frontend/Internal/ArrayValueInstruction.php
@@ -27,7 +27,7 @@ class ArrayValueInstruction extends AbstractInstruction
     protected $array = [];
 
     /**
-     * @param array $typoScript
+     * @param array $array
      * @return static
      */
     public function withArray(array $array): self

--- a/Classes/Core/Functional/Framework/Frontend/Internal/TypoScriptInstruction.php
+++ b/Classes/Core/Functional/Framework/Frontend/Internal/TypoScriptInstruction.php
@@ -32,7 +32,7 @@ class TypoScriptInstruction extends AbstractInstruction
     protected $typoScript;
 
     /**
-     * @param array $typoScript
+     * @param array $constants
      * @return static
      */
     public function withConstants(array $constants): self

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -16,7 +16,6 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
 
 use TYPO3\CMS\Core\Http\Request;
 use TYPO3\CMS\Core\Http\Stream;
-use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\AbstractInstruction;
 

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
@@ -14,7 +14,6 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 
 /**
@@ -94,7 +93,7 @@ class InternalRequestContext implements \JsonSerializable
     }
 
     /**
-     * @param int $workspaceId
+     * @param int $frontendUserId
      * @return InternalRequestContext
      */
     public function withFrontendUserId(int $frontendUserId): InternalRequestContext
@@ -105,7 +104,7 @@ class InternalRequestContext implements \JsonSerializable
     }
 
     /**
-     * @param int $workspaceId
+     * @param int $backendUserId
      * @return InternalRequestContext
      */
     public function withBackendUserId(int $backendUserId): InternalRequestContext
@@ -137,24 +136,6 @@ class InternalRequestContext implements \JsonSerializable
         }
         $target = clone $this;
         $target->globalSettings = $globalSettings;
-        return $target;
-    }
-
-    /**
-     * @param array $globalSettings
-     * @return InternalRequestContext
-     */
-    public function withMergedGlobalSettings(array $globalSettings): InternalRequestContext
-    {
-        if (empty($globalSettings)) {
-            return $this;
-        }
-        $target = clone $this;
-        $target->globalSettings = $this->globalSettings ?? [];
-        ArrayUtility::mergeRecursiveWithOverrule(
-            $target->globalSettings,
-            $globalSettings
-        );
         return $target;
     }
 }

--- a/Classes/Core/Functional/Framework/Frontend/InternalResponse.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalResponse.php
@@ -20,7 +20,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 /**
  * Model of internal frontend response.
  */
-class InternalResponse extends \TYPO3\CMS\Core\Http\Response
+class InternalResponse extends Response
 {
     use AssignablePropertyTrait;
 

--- a/Classes/Core/Functional/Framework/Frontend/Parser.php
+++ b/Classes/Core/Functional/Framework/Frontend/Parser.php
@@ -14,10 +14,12 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\SingletonInterface;
+
 /**
  * Model of frontend response
  */
-class Parser implements \TYPO3\CMS\Core\SingletonInterface
+class Parser implements SingletonInterface
 {
     /**
      * @var array

--- a/Classes/Core/Functional/Framework/Frontend/Renderer.php
+++ b/Classes/Core/Functional/Framework/Frontend/Renderer.php
@@ -14,10 +14,14 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
 /**
  * Section renderer for frontend responses.
  */
-class Renderer implements \TYPO3\CMS\Core\SingletonInterface
+class Renderer implements SingletonInterface
 {
     /**
      * @var array
@@ -25,7 +29,7 @@ class Renderer implements \TYPO3\CMS\Core\SingletonInterface
     protected $sections = [];
 
     /**
-     * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
+     * @var ContentObjectRenderer
      */
     public $cObj;
 
@@ -153,8 +157,6 @@ class Renderer implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected function createParser()
     {
-        return \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-            \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Parser::class
-        );
+        return GeneralUtility::makeInstance(Parser::class);
     }
 }

--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -14,7 +14,10 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Frontend\Http\Application;
 
 /**
  * Bootstrap for direct CLI Request
@@ -148,23 +151,20 @@ class RequestBootstrap
      */
     public function executeAndOutput()
     {
-        global $TT, $TSFE, $TYPO3_CONF_VARS, $BE_USER, $TYPO3_MISC;
+        global $TSFE, $BE_USER;
 
         $result = ['status' => 'failure', 'content' => null, 'error' => null];
 
         ob_start();
         try {
             chdir($_SERVER['DOCUMENT_ROOT']);
-            \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(
-                0,
-                \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_FE
-            );
-            $container = \TYPO3\CMS\Core\Core\Bootstrap::init($this->classLoader);
+            SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_FE);
+            $container = Bootstrap::init($this->classLoader);
             ArrayUtility::mergeRecursiveWithOverrule(
                 $GLOBALS,
                 $this->context->getGlobalSettings() ?? []
             );
-            $container->get(\TYPO3\CMS\Frontend\Http\Application::class)->run();
+            $container->get(Application::class)->run();
             $result['status'] = 'success';
             $result['content'] = static::getContent();
         } catch (\Exception $exception) {

--- a/Classes/Core/Functional/Framework/Frontend/Response.php
+++ b/Classes/Core/Functional/Framework/Frontend/Response.php
@@ -19,7 +19,6 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  */
 class Response
 {
-    const STATUS_Success = 'success';
     const STATUS_Failure = 'failure';
 
     /**

--- a/Classes/Core/Functional/Framework/Frontend/ResponseContent.php
+++ b/Classes/Core/Functional/Framework/Frontend/ResponseContent.php
@@ -35,11 +35,6 @@ class ResponseContent
     /**
      * @var array
      */
-    protected $structurePaths;
-
-    /**
-     * @var array
-     */
     protected $records;
 
     /**
@@ -106,14 +101,6 @@ class ResponseContent
             },
             $sectionIdentifiers
         );
-    }
-
-    /**
-     * @return array
-     */
-    public function getScope(): array
-    {
-        return $this->scope;
     }
 
     /**

--- a/Classes/Core/Functional/Framework/Frontend/ResponseSection.php
+++ b/Classes/Core/Functional/Framework/Frontend/ResponseSection.php
@@ -89,25 +89,9 @@ class ResponseSection
     /**
      * @return array
      */
-    public function getStructurePaths()
-    {
-        return $this->structurePaths;
-    }
-
-    /**
-     * @return array
-     */
     public function getRecords()
     {
         return $this->records;
-    }
-
-    /**
-     * @return array
-     */
-    public function getQueries()
-    {
-        return $this->queries;
     }
 
     /**

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -340,21 +340,6 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
-     * Get DatabaseConnection instance - $GLOBALS['TYPO3_DB']
-     *
-     * This method should be used instead of direct access to
-     * $GLOBALS['TYPO3_DB'] for easy IDE auto completion.
-     *
-     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
-     * @deprecated since TYPO3 v8, will be removed in TYPO3 v9
-     */
-    protected function getDatabaseConnection()
-    {
-        GeneralUtility::logDeprecatedFunction();
-        return $GLOBALS['TYPO3_DB'];
-    }
-
-    /**
      * @return ConnectionPool
      */
     protected function getConnectionPool()
@@ -862,6 +847,7 @@ abstract class FunctionalTestCase extends BaseTestCase
 
     /**
      * @param array $result
+     * @return InternalResponse
      */
     protected function reconstituteFrontendRequestResult(array $result): InternalResponse
     {
@@ -963,7 +949,6 @@ abstract class FunctionalTestCase extends BaseTestCase
      * + true: always allow, e.g. before actually importing data
      * + false: always deny, e.g. when importing data is finished
      *
-     * @param bool|null $allowIdentityInsert
      * @param bool|null $allowIdentityInsert
      * @throws DBALException
      */

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -16,13 +16,11 @@ namespace TYPO3\TestingFramework\Core;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -452,7 +450,7 @@ class Testbase
         $finalConfigurationArray = require ORIGINAL_ROOT . 'typo3/sysext/core/Configuration/FactoryConfiguration.php';
         $finalConfigurationArray = array_replace_recursive($finalConfigurationArray, $configuration);
         $finalConfigurationArray = array_replace_recursive($finalConfigurationArray, $overruleConfiguration);
-        $result = $this->writeFile(
+        $result = file_put_contents(
             $instancePath . '/typo3conf/LocalConfiguration.php',
             '<?php' . chr(10) .
             'return ' .
@@ -521,7 +519,7 @@ class Testbase
             ];
         }
 
-        $result = $this->writeFile(
+        $result = file_put_contents(
             $instancePath . '/typo3conf/PackageStates.php',
             '<?php' . chr(10) .
             'return ' .
@@ -767,7 +765,7 @@ class Testbase
      * Doing this once per insert is rather slow, but due to the soft reference behavior
      * this needs to be done after every row to ensure consistent results.
      *
-     * @param \TYPO3\CMS\Core\Database\Connection $connection
+     * @param Connection $connection
      * @param string $tableName
      * @throws \Doctrine\DBAL\DBALException
      */
@@ -820,8 +818,8 @@ class Testbase
     /**
      * Copy a directory structure $from a source $to a destination,
      *
-     * @param $from Absolute source path
-     * @param $to Absolute target path
+     * @param string $from Absolute source path
+     * @param string $to Absolute target path
      * @return bool True if all went well
      */
     protected function copyRecursive($from, $to) {
@@ -899,26 +897,5 @@ class Testbase
             $path = $this->getPackagesPath() . '/' . str_replace('PACKAGE:', '',$path);
         }
         return $path;
-    }
-
-    /**
-     * Writes $content to the file $file. This is a simplified version
-     * of GeneralUtility::writeFile that does not fix permissions.
-     *
-     * @param string $file Filepath to write to
-     * @param string $content Content to write
-     * @return bool TRUE if the file was successfully opened and written to.
-     */
-    protected function writeFile($file, $content)
-    {
-        if ($fd = fopen($file, 'wb')) {
-            $res = fwrite($fd, $content);
-            fclose($fd);
-            if ($res === false) {
-                return false;
-            }
-            return true;
-        }
-        return false;
     }
 }

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -70,35 +70,12 @@ abstract class UnitTestCase extends BaseTestCase
     protected $testFilesToDelete = [];
 
     /**
-     * @var int Backup variable of current error reporting
-     */
-    private static $backupErrorReporting;
-
-    /**
      * Holds state of TYPO3\CMS\Core\Core\Environment if
      * $this->backupEnvironment has been set to true in a test case
      *
      * @var array
      */
     private $backedUpEnvironment = [];
-
-    /**
-     * Set error reporting to always fail on E_NOTICE
-     */
-    public static function setUpBeforeClass(): void
-    {
-        $errorReporting = self::$backupErrorReporting = error_reporting();
-        // Always fail on notice level errors
-        error_reporting($errorReporting | E_NOTICE);
-    }
-
-    /**
-     * Reset error reporting to original state
-     */
-    public static function tearDownAfterClass(): void
-    {
-        error_reporting(self::$backupErrorReporting);
-    }
 
     /**
      * Generic setUp()
@@ -130,8 +107,8 @@ abstract class UnitTestCase extends BaseTestCase
             $this->restoreEnvironment();
         }
 
-        // Flush the two static $indpEnvCache and $idnaStringCache
-        // between test runs to prevent side effects from these caches.
+        // Flush the static $indpEnvCache
+        // between test runs to prevent side effects from this cache.
         GeneralUtility::flushInternalRuntimeCaches();
 
         // GeneralUtility::makeInstance() singleton handling
@@ -141,7 +118,7 @@ abstract class UnitTestCase extends BaseTestCase
         } else {
             // But fail if there are instances left and the test did not ask for reset
             $singletonInstances = GeneralUtility::getSingletonInstances();
-            // Reset singletons anyway to not let all futher tests fail
+            // Reset singletons anyway to not let all further tests fail
             GeneralUtility::resetSingletonInstances([]);
             self::assertEmpty(
                 $singletonInstances,
@@ -157,8 +134,8 @@ abstract class UnitTestCase extends BaseTestCase
             $declaringClass = $property->getDeclaringClass()->getName();
             if (
                 !$property->isStatic()
-                && $declaringClass !== \TYPO3\TestingFramework\Core\Unit\UnitTestCase::class
-                && $declaringClass !== \TYPO3\TestingFramework\Core\BaseTestCase::class
+                && $declaringClass !== UnitTestCase::class
+                && $declaringClass !== BaseTestCase::class
                 && strpos($property->getDeclaringClass()->getName(), 'PHPUnit') !== 0
             ) {
                 $propertyName = $property->getName();

--- a/Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -13,10 +13,12 @@ namespace TYPO3\TestingFramework\Fluid\Unit\ViewHelpers;
  *
  * The TYPO3 project - inspiring people to share!
  */
+
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use TYPO3\CMS\Extbase\Error\Result;
 use TYPO3\CMS\Extbase\Reflection\ReflectionService;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 use TYPO3\TestingFramework\Fluid\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
@@ -26,7 +28,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 /**
  * Base test class for testing view helpers
  */
-abstract class ViewHelperBaseTestcase extends \TYPO3\TestingFramework\Core\Unit\UnitTestCase
+abstract class ViewHelperBaseTestcase extends UnitTestCase
 {
     /**
      * @var ViewHelperVariableContainer|ObjectProphecy

--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -4,6 +4,7 @@
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
 	forceCoversAnnotation="false"
 	processIsolation="false"
 	stopOnError="false"

--- a/Resources/Core/Build/UnitTestsDeprecated.xml
+++ b/Resources/Core/Build/UnitTestsDeprecated.xml
@@ -4,6 +4,7 @@
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertNoticesToExceptions="true"
 	convertDeprecationsToExceptions="false"
 	forceCoversAnnotation="false"
 	processIsolation="false"


### PR DESCRIPTION
- Use FQDN for use statements
- Fix some variable names and phpdoc info (typos mostly)
- Remove unused functionality
- Simplify code (e.g. notices via PHPunit directly)
- Use native PHP functionality over Core APIs when useful