### PR TITLE
[TASK] Use PHPunit specs instead of custom Testbase code

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -226,8 +226,6 @@ abstract class BackendEnvironment extends Extension
             return;
         }
         $testbase = new Testbase();
-        $testbase->enableDisplayErrors();
-        $testbase->defineBaseConstants();
         $testbase->defineOriginalRootPath();
         $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance');
         $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
@@ -236,8 +234,6 @@ abstract class BackendEnvironment extends Extension
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
 
-        $testbase->defineTypo3ModeBe();
-        $testbase->setTypo3TestingContext();
         $testbase->removeOldInstanceIfExists($instancePath);
         // Basic instance directory structure
         $testbase->createDirectory($instancePath . '/fileadmin');

--- a/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
@@ -26,7 +26,7 @@ use TYPO3\TestingFramework\Core\Testbase;
  * This codeception extension creates a basic TYPO3 instance within
  * typo3temp. It is used as a basic acceptance test that clicks through
  * the TYPO3 installation steps.
- * 
+ *
  * @internal Used by core, do not use in extensions, may vanish later.
  */
 class InstallMysqlCoreEnvironment extends Extension
@@ -87,10 +87,7 @@ class InstallMysqlCoreEnvironment extends Extension
     public function bootstrapTypo3Environment(TestEvent $event)
     {
         $testbase = new Testbase();
-        $testbase->enableDisplayErrors();
-        $testbase->defineBaseConstants();
         $testbase->defineOriginalRootPath();
-        $testbase->setTypo3TestingContext();
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         $testbase->removeOldInstanceIfExists($instancePath);

--- a/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
@@ -26,7 +26,7 @@ use TYPO3\TestingFramework\Core\Testbase;
  * This codeception extension creates a basic TYPO3 instance within
  * typo3temp. It is used as a basic acceptance test that clicks through
  * the TYPO3 installation steps.
- * 
+ *
  * @internal Used by core, do not use in extensions, may vanish later.
  */
 class InstallPostgresqlCoreEnvironment extends Extension
@@ -93,10 +93,7 @@ class InstallPostgresqlCoreEnvironment extends Extension
     public function bootstrapTypo3Environment(TestEvent $event)
     {
         $testbase = new Testbase();
-        $testbase->enableDisplayErrors();
-        $testbase->defineBaseConstants();
         $testbase->defineOriginalRootPath();
-        $testbase->setTypo3TestingContext();
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         $testbase->removeOldInstanceIfExists($instancePath);

--- a/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
@@ -44,10 +44,7 @@ class InstallSqliteCoreEnvironment extends Extension
     public function bootstrapTypo3Environment()
     {
         $testbase = new Testbase();
-        $testbase->enableDisplayErrors();
-        $testbase->defineBaseConstants();
         $testbase->defineOriginalRootPath();
-        $testbase->setTypo3TestingContext();
 
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         $testbase->removeOldInstanceIfExists($instancePath);

--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -26,13 +26,6 @@ use PHPUnit\Framework\TestCase;
 abstract class BaseTestCase extends TestCase
 {
     /**
-     * Whether global variables should be backed up
-     *
-     * @var bool
-     */
-    protected $backupGlobals = true;
-
-    /**
      * Creates a mock object which allows for calling protected methods and access of protected properties.
      *
      * @param string $originalClassName name of class to create the mock object of, must not be empty

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -249,8 +249,6 @@ abstract class FunctionalTestCase extends BaseTestCase
         putenv('TYPO3_PATH_APP=' . $this->instancePath);
 
         $testbase = new Testbase();
-        $testbase->defineTypo3ModeBe();
-        $testbase->setTypo3TestingContext();
 
         $isFirstTest = false;
         $currentTestCaseClass = get_called_class();

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -55,32 +55,6 @@ class Testbase
     }
 
     /**
-     *  Makes sure error messages during the tests get displayed no matter what is set in php.ini
-     *
-     * @return void
-     */
-    public function enableDisplayErrors()
-    {
-        @ini_set('display_errors', 1);
-    }
-
-    /**
-     * Defines a list of basic constants that are used by GeneralUtility and other
-     * helpers during tests setup. Those are sanitized in SystemEnvironmentBuilder
-     * to be not defined again.
-     *
-     * @return void
-     * @see SystemEnvironmentBuilder::defineBaseConstants()
-     */
-    public function defineBaseConstants()
-    {
-        // A linefeed, a carriage return, a CR-LF combination
-        defined('LF') ?: define('LF', chr(10));
-        defined('CR') ?: define('CR', chr(13));
-        defined('CRLF') ?: define('CRLF', CR . LF);
-    }
-
-    /**
      * Sets $_SERVER['SCRIPT_NAME'].
      * For unit tests only
      *
@@ -122,16 +96,6 @@ class Testbase
         if (!defined('TYPO3_MODE')) {
             define('TYPO3_MODE', 'BE');
         }
-    }
-
-    /**
-     * Sets the environment variable TYPO3_CONTEXT to testing.
-     *
-     * @return void
-     */
-    public function setTypo3TestingContext()
-    {
-        putenv('TYPO3_CONTEXT=Testing');
     }
 
     /**

--- a/Resources/Core/Build/FunctionalTests.xml
+++ b/Resources/Core/Build/FunctionalTests.xml
@@ -26,4 +26,9 @@
 			<directory>../../../../../../typo3/sysext/*/Tests/Functional/</directory>
 		</testsuite>
 	</testsuites>
+    <php>
+        <const name="TYPO3_MODE" value="BE" />
+        <ini name="display_errors" value="1" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
 </phpunit>

--- a/Resources/Core/Build/FunctionalTestsBootstrap.php
+++ b/Resources/Core/Build/FunctionalTestsBootstrap.php
@@ -19,8 +19,6 @@
  */
 call_user_func(function () {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
-    $testbase->enableDisplayErrors();
-    $testbase->defineBaseConstants();
     $testbase->defineOriginalRootPath();
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');

--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -24,4 +24,9 @@
             <directory>../../../../../../typo3/sysext/*/Classes/</directory>
         </whitelist>
     </filter>
+    <php>
+        <const name="TYPO3_MODE" value="BE" />
+        <ini name="display_errors" value="1" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
 </phpunit>

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -28,8 +28,6 @@
  */
 call_user_func(function () {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
-    $testbase->enableDisplayErrors();
-    $testbase->defineBaseConstants();
 
     // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
     // not create the autoload-include.php file that sets these env vars and sets composer
@@ -46,8 +44,6 @@ call_user_func(function () {
     }
 
     $testbase->defineSitePath();
-    $testbase->defineTypo3ModeBe();
-    $testbase->setTypo3TestingContext();
 
     $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
     \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::run(0, $requestType);
@@ -61,13 +57,9 @@ call_user_func(function () {
     $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
     \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
 
-    \TYPO3\CMS\Core\Core\Bootstrap::baseSetup();
-
     // Initialize default TYPO3_CONF_VARS
     $configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
     $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
-    // Avoid failing tests that rely on HTTP_HOST retrieval
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
 
     $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
         'core',
@@ -79,11 +71,7 @@ call_user_func(function () {
     \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
 
-    if (!\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {
-        // Dump autoload info if in non composer mode
-        \TYPO3\CMS\Core\Core\ClassLoadingInformation::dumpClassLoadingInformation();
-        \TYPO3\CMS\Core\Core\ClassLoadingInformation::registerClassLoadingInformation();
-    }
+    $testbase->dumpClassLoadingInformation();
 
     \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
 });

--- a/Resources/Core/Build/UnitTestsDeprecated.xml
+++ b/Resources/Core/Build/UnitTestsDeprecated.xml
@@ -25,4 +25,9 @@
             <directory>../../../../../../typo3/sysext/*/Classes/</directory>
         </whitelist>
     </filter>
+    <php>
+        <const name="TYPO3_MODE" value="BE" />
+        <ini name="display_errors" value="1" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
 </phpunit>


### PR DESCRIPTION
phpunit has advanced since 2012, so we can
get rid of lots of functionality that TYPO3 built
on its own by using phpunit-built-in functionality:

* Use the .xml specs to define constants, env variables and init settings
* No need to set $backupGlobals=true as this is set by .xml spec
* Do not rely on workarounds for old core versions (like trustedHostsPattern settings)

This makes especially the BaseTestCase and the UnitTests Bootstrap
less complicated.