### PR TITLE
[TASK] Remove unnecessary dependencies to TYPO3

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -20,7 +20,6 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\StringUtility;
 use TYPO3\CMS\Workspaces\Service\WorkspaceService;
 use TYPO3\TestingFramework\Core\Exception;
 
@@ -74,7 +73,7 @@ class ActionService
             if (!isset($recordData['pid'])) {
                 $recordData['pid'] = $pageId;
             }
-            $currentUid = StringUtility::getUniqueId('NEW');
+            $currentUid = $this->getUniqueIdForNewRecords();
             $newTableIds[$tableName][] = $currentUid;
             $dataMap[$tableName][$currentUid] = $recordData;
             if ($previousTableName !== null && $previousUid !== null) {
@@ -147,7 +146,7 @@ class ActionService
             $recordData = $this->resolvePreviousUid($recordData, $currentUid);
             $currentUid = $recordData['uid'];
             if ($recordData['uid'] === '__NEW') {
-                $currentUid = StringUtility::getUniqueId('NEW');
+                $currentUid = $this->getUniqueIdForNewRecords();
             }
             if (strpos((string)$currentUid, 'NEW') === 0) {
                 $recordData['pid'] = $pageId;
@@ -540,5 +539,16 @@ class ActionService
     protected function getBackendUser(): BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'];
+    }
+
+    /**
+     * This function generates a unique id by using the more entropy parameter, so it can be used
+     * in DataHandler.
+     *
+     * @return string
+     */
+    private function getUniqueIdForNewRecords(): string
+    {
+        return str_replace('.', '', uniqid('NEW', true));
     }
 }

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
@@ -16,7 +16,6 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Scenario
  */
 
 use Symfony\Component\Yaml\Yaml;
-use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**
  * Factory for DataHandler information parsed from a structured array
@@ -62,9 +61,7 @@ class DataHandlerFactory
      */
     public static function fromYamlFile(string $yamlFile): self
     {
-        $yamlContent = file_get_contents($yamlFile);
-        $settings = Yaml::parse($yamlContent);
-        return new static($settings);
+        return new static(Yaml::parseFile($yamlFile));
     }
 
     public function __construct(array $settings)
@@ -134,7 +131,7 @@ class DataHandlerFactory
 
         $workspaceId = $itemSettings['version']['workspace'] ?? 0;
         $tableName = $entityConfiguration->getTableName();
-        $newId = StringUtility::getUniqueId('NEW');
+        $newId = $this->getUniqueIdForNewRecords();
         $this->setInDataMap($tableName, $newId, $values, (int)$workspaceId);
 
         foreach ($itemSettings['versionVariants'] ?? [] as $versionVariantSettings) {
@@ -198,7 +195,7 @@ class DataHandlerFactory
         );
 
         $tableName = $entityConfiguration->getTableName();
-        $newId = StringUtility::getUniqueId('NEW');
+        $newId = $this->getUniqueIdForNewRecords();
         $workspaceId = $itemSettings['version']['workspace'] ?? 0;
         $this->setInDataMap($tableName, $newId, $values, (int)$workspaceId);
 
@@ -503,5 +500,16 @@ class DataHandlerFactory
         $regularPageId = substr($normalizePageId, 1);
         $resolvedPageId = $this->dataMapPerWorkspace[$workspaceId]['pages'][$regularPageId]['pid'] ?? null;
         return $this->resolveDataMapPageId($workspaceId, $resolvedPageId);
+    }
+
+    /**
+     * This function generates a unique id by using the more entropy parameter, so it can be used
+     * in DataHandler.
+     *
+     * @return string
+     */
+    private function getUniqueIdForNewRecords(): string
+    {
+        return str_replace('.', '', uniqid('NEW', true));
     }
 }

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -17,7 +17,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot
 
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Schema\Table;
-use TYPO3\CMS\Core\Database\Connection;
+use Doctrine\DBAL\Connection;
 
 class DatabaseAccessor
 {
@@ -114,7 +114,6 @@ class DatabaseAccessor
         $this->connection->truncate($tableName);
 
         $columnNames = array_keys($columns);
-        $columnTypes = array_values($columns);
         foreach ($items as $item) {
             $this->connection->insert(
                 $tableName,

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
@@ -23,7 +23,7 @@ class DatabaseSnapshot
     private const VALUE_IN_MEMORY_THRESHOLD = 1024**2;
 
     /**
-     * @var self
+     * @var static
      */
     private static $instance;
 


### PR DESCRIPTION
Functional tests can be streamlined, in order
to rely less on a specific TYPO3 version.