### PR TITLE
[BUGFIX] Re-add TYPO3_CONTEXT assignment

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -233,6 +233,8 @@ abstract class BackendEnvironment extends Extension
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
+        $testbase->defineTypo3ModeBe();
+        $testbase->setTypo3TestingContext();
 
         $testbase->removeOldInstanceIfExists($instancePath);
         // Basic instance directory structure

--- a/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
@@ -93,6 +93,8 @@ class InstallMysqlCoreEnvironment extends Extension
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
+        $testbase->defineTypo3ModeBe();
+        $testbase->setTypo3TestingContext();
 
         // Drop db from a previous run if exists
         $connectionParameters = [

--- a/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
@@ -99,6 +99,8 @@ class InstallPostgresqlCoreEnvironment extends Extension
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
+        $testbase->defineTypo3ModeBe();
+        $testbase->setTypo3TestingContext();
 
         // Drop db from a previous run if exists
         $connectionParameters = [

--- a/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
@@ -50,6 +50,8 @@ class InstallSqliteCoreEnvironment extends Extension
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
+        $testbase->defineTypo3ModeBe();
+        $testbase->setTypo3TestingContext();
 
         $testbase->createDirectory($instancePath);
         $testbase->setUpInstanceCoreLinks($instancePath);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -249,6 +249,8 @@ abstract class FunctionalTestCase extends BaseTestCase
         putenv('TYPO3_PATH_APP=' . $this->instancePath);
 
         $testbase = new Testbase();
+        $testbase->defineTypo3ModeBe();
+        $testbase->setTypo3TestingContext();
 
         $isFirstTest = false;
         $currentTestCaseClass = get_called_class();

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -99,6 +99,17 @@ class Testbase
     }
 
     /**
+     * Sets the environment variable TYPO3_CONTEXT to testing.
+     * Needs to be called after each Functional executing a frontend request
+     *
+     * @return void
+     */
+    public function setTypo3TestingContext()
+    {
+        putenv('TYPO3_CONTEXT=Testing');
+    }
+
+    /**
      * Creates directories, recursively if required.
      *
      * @param string $directory Absolute path to directories to create


### PR DESCRIPTION
Functionals need to have each TYPO3_CONTEXT=Testing
applied as they also execute Frontend Requests
where the context might be modified.