### PR TITLE
[!!!][TASK] Drop support for "callInaccessibleMethod" and "inject"

### DIFF
--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -147,61 +147,6 @@ abstract class BaseTestCase extends TestCase
     }
 
     /**
-     * Helper function to call protected or private methods
-     *
-     * @param object $object The object to be invoked
-     * @param string $name the name of the method to call
-     * @param mixed $arguments
-     * @return mixed
-     */
-    protected function callInaccessibleMethod($object, $name, ...$arguments)
-    {
-        $reflectionObject = new \ReflectionObject($object);
-        $reflectionMethod = $reflectionObject->getMethod($name);
-        $reflectionMethod->setAccessible(true);
-        return $reflectionMethod->invokeArgs($object, $arguments);
-    }
-
-    /**
-     * Injects $dependency into property $name of $target
-     *
-     * This is a convenience method for setting a protected or private property in
-     * a test subject for the purpose of injecting a dependency.
-     *
-     * @param object $target The instance which needs the dependency
-     * @param string $name Name of the property to be injected
-     * @param mixed $dependency The dependency to inject – usually an object but can also be any other type
-     * @return void
-     * @throws \RuntimeException
-     * @throws \InvalidArgumentException
-     */
-    protected function inject($target, $name, $dependency)
-    {
-        if (!is_object($target)) {
-            throw new \InvalidArgumentException('Wrong type for argument $target, must be object.', 1476107338);
-        }
-
-        $objectReflection = new \ReflectionObject($target);
-        $methodNamePart = strtoupper($name[0]) . substr($name, 1);
-        if ($objectReflection->hasMethod('set' . $methodNamePart)) {
-            $methodName = 'set' . $methodNamePart;
-            $target->$methodName($dependency);
-        } elseif ($objectReflection->hasMethod('inject' . $methodNamePart)) {
-            $methodName = 'inject' . $methodNamePart;
-            $target->$methodName($dependency);
-        } elseif ($objectReflection->hasProperty($name)) {
-            $property = $objectReflection->getProperty($name);
-            $property->setAccessible(true);
-            $property->setValue($target, $dependency);
-        } else {
-            throw new \RuntimeException(
-                'Could not inject ' . $name . ' into object of type ' . get_class($target),
-                1476107339
-            );
-        }
-    }
-
-    /**
      * Create and return a unique id optionally prepended by a given string
      *
      * This function is used because on windows and in cygwin environments uniqid() has a resolution of one second which


### PR DESCRIPTION
The two helper functions in the "BaseTestCase" should
either be built manually by using the accessible mock
or by using closures to change the scope of the method.