### PR TITLE
[BUGFIX] Require phpunit/phpunit with minimal of 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
-    "phpunit/phpunit": "^8.3",
+    "phpunit/phpunit": "^8.4",
     "mikey179/vfsstream": "~1.6.8",
     "typo3fluid/fluid": "^2.5",
     "typo3/cms-core": "10.*.*@dev",


### PR DESCRIPTION
PHPUnit 8.4 is incompatible to 8.3 since some error classes were moved
into a different namespace.