### PR TITLE
[TASK] Deprecate BaseTestCase::getUniqueId() in favour of StringUtility::getUniqueId()

### DIFF
--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -16,6 +16,7 @@ namespace TYPO3\TestingFramework\Core;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**
  * The mother of all test cases.
@@ -136,7 +137,7 @@ abstract class BaseTestCase extends TestCase
      */
     protected function getUniqueId($prefix = '')
     {
-        $uniqueId = uniqid(mt_rand(), true);
-        return $prefix . str_replace('.', '', $uniqueId);
+        trigger_error('Method will be removed with next version. Use TYPO3\CMS\Core\Utility\StringUtility::getUniqueId() instead.', E_USER_DEPRECATED);
+        return StringUtility::getUniqueId($prefix);
     }
 }


### PR DESCRIPTION
The functions provide the same service, so there is no need to maintain two code places.

The core function will be used throughout core test code and extension authors
are encouraged to do the same.