### PR TITLE
Revert "[TASK] Add new Acceptance Tests folder to splitter script"

### DIFF
--- a/Resources/Core/Build/Scripts/splitAcceptanceTests.php
+++ b/Resources/Core/Build/Scripts/splitAcceptanceTests.php
@@ -80,7 +80,7 @@ class SplitAcceptanceTests extends NodeVisitorAbstract
         // Find functional test files
         $testFiles = (new Finder())
             ->files()
-            ->in([__DIR__ . '/../../../../../../../typo3/sysext/core/Tests/Acceptance/Backend', __DIR__ . '/../../../../../../../typo3/sysext/core/Tests/Acceptance/InstallTool'])
+            ->in(__DIR__ . '/../../../../../../../typo3/sysext/core/Tests/Acceptance/Backend')
             ->name('/Cest\.php$/')
         ;
 


### PR DESCRIPTION
This reverts commit 391f5595f04039dc7e79aa23ac55ef52858da658.

The tests are not picked up by execution, even after they are
included into the splitting.

A stand alone test suite will take care now to execute them, and
the inclusion into split tests action is hereby reverted