### PR TITLE
[TASK] Update to codeception v4 and allow phpunit v9

### DIFF
--- a/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
@@ -15,7 +15,6 @@ namespace TYPO3\TestingFramework\Core\Acceptance\Extension;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\Extension;

--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -52,7 +52,7 @@ abstract class AbstractPageTree
         foreach ($path as $pageName) {
             $context = $this->ensureTreeNodeIsOpen($pageName, $context);
         }
-        $context->findElement(\WebDriverBy::cssSelector(self::$treeItemAnchorSelector))->click();
+        $context->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(self::$treeItemAnchorSelector))->click();
     }
 
     /**
@@ -65,7 +65,7 @@ abstract class AbstractPageTree
         $I = $this->tester;
         $I->switchToIFrame();
         return $I->executeInSelenium(function (\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
-            return $webdriver->findElement(\WebDriverBy::cssSelector(self::$pageTreeSelector));
+            return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(self::$pageTreeSelector));
         });
     }
 
@@ -84,11 +84,11 @@ abstract class AbstractPageTree
         /** @var RemoteWebElement $context */
         $context = $I->executeInSelenium(function () use ($nodeText, $context
         ) {
-            return $context->findElement(\WebDriverBy::xpath('//*[text()=\'' . $nodeText . '\']/..'));
+            return $context->findElement(\Facebook\WebDriver\WebDriverBy::xpath('//*[text()=\'' . $nodeText . '\']/..'));
         });
 
         try {
-            $context->findElement(\WebDriverBy::cssSelector('.chevron.collapsed'))->click();
+            $context->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector('.chevron.collapsed'))->click();
         } catch (\Facebook\WebDriver\Exception\NoSuchElementException $e) {
             // element not found so it may be already opened...
         } catch (\Facebook\WebDriver\Exception\ElementNotVisibleException $e) {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
-    "phpunit/phpunit": "^8.4",
+    "phpunit/phpunit": "^8.4 || ^9.0",
     "mikey179/vfsstream": "~1.6.8",
     "typo3fluid/fluid": "^2.5",
     "typo3/cms-core": "10.*.*@dev",
@@ -36,7 +36,7 @@
     "typo3/cms-recordlist": "10.*.*@dev"
   },
   "suggest": {
-    "codeception/codeception": "^3",
+    "codeception/codeception": "^4.0",
     "typo3/cms-styleguide": "^9.0"
   },
   "config": {


### PR DESCRIPTION
This change updates the dependencies:

* Testing framework now suggests codeception v4 (this is a requirement to allow codeception+phpunit9)
* Testing framework now allows phpunit 8 and phpunit9 as dependency