### PR TITLE
Allow switching backend user in the test

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -371,8 +371,6 @@ abstract class FunctionalTestCase extends BaseTestCase
      */
     protected function setUpBackendUser($userUid): BackendUserAuthentication
     {
-        $this->importDataSet($this->backendUserFixture);
-
         $queryBuilder = $this->getConnectionPool()
             ->getQueryBuilderForTable('be_users');
         $queryBuilder->getRestrictions()->removeAll();

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -347,6 +347,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 
+
     /**
      * Initialize backend user
      *
@@ -355,6 +356,20 @@ abstract class FunctionalTestCase extends BaseTestCase
      * @throws Exception
      */
     protected function setUpBackendUserFromFixture($userUid)
+    {
+        $this->importDataSet($this->backendUserFixture);
+
+        return $this->setUpBackendUser($userUid);
+    }
+
+    /**
+     * Sets up Backend User which is already available in db
+     *
+     * @param int $userUid
+     * @return BackendUserAuthentication
+     * @throws Exception
+     */
+    protected function setUpBackendUser($userUid): BackendUserAuthentication
     {
         $this->importDataSet($this->backendUserFixture);
 

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -347,7 +347,6 @@ abstract class FunctionalTestCase extends BaseTestCase
         return GeneralUtility::makeInstance(ConnectionPool::class);
     }
 
-
     /**
      * Initialize backend user
      *


### PR DESCRIPTION
Sometimes it's useful to be able to switch backend user in the test 
(e.g. import data with admin, and then execute test with regular user)
To achieve that a new method is introduced setUpBackendUser which 
sets up backend user which is already in the db.

my case showing usage of the new method:
```

    protected function setUp(): void
    {
        parent::setUp();
        //admin user for importing yaml dataset
        $this->backendUser = $this->setUpBackendUserFromFixture(1);

        Bootstrap::initializeLanguageObject();

        $scenarioFile = __DIR__ . '/../../Fixtures/CommonScenario.yaml';
        $factory = DataHandlerFactory::fromYamlFile($scenarioFile);
        $writer = DataHandlerWriter::withBackendUser($this->backendUser);
        $writer->invokeFactory($factory);
        static::failIfArrayIsNotEmpty(
            $writer->getErrors()
        );

        //regular editor, non admin for executing tests
        $this->backendUser = $this->setUpBackendUser(9);
        $this->subject = $this->getAccessibleMock(TreeController::class, ['dummy']);
    }
```