### PR TITLE
[TASK] Allow switching backend user in the test (#171)

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -377,6 +377,18 @@ abstract class FunctionalTestCase extends BaseTestCase
     {
         $this->importDataSet($this->backendUserFixture);
 
+        return $this->setUpBackendUser($userUid);
+    }
+
+    /**
+     * Sets up Backend User which is already available in db
+     *
+     * @param int $userUid
+     * @return BackendUserAuthentication
+     * @throws Exception
+     */
+    protected function setUpBackendUser($userUid): BackendUserAuthentication
+    {
         $queryBuilder = $this->getConnectionPool()
             ->getQueryBuilderForTable('be_users');
         $queryBuilder->getRestrictions()->removeAll();


### PR DESCRIPTION
* Allow switching backend user in the test

Sometimes it's useful to be able to switch backend user in the test 
(e.g. import data with admin, and then execute test with regular user)
To achieve that a new method is introduced setUpBackendUser which 
sets up backend user which is already in the db.

This is a backport of the same change merged in master (https://github.com/TYPO3/testing-framework/pull/171)