### PR TITLE
[TASK] Check existence of div.module only

### DIFF
--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -17,6 +17,7 @@ namespace TYPO3\TestingFramework\Core\Acceptance\Helper;
 
 use Codeception\Exception\ConfigurationException;
 use Codeception\Module;
+use Codeception\Util\Locator;
 
 /**
  * Helper class to log in backend users and load backend
@@ -69,7 +70,7 @@ class Login extends Module
 
         // Ensure main content frame is fully loaded, otherwise there are load-race-conditions
         $wd->switchToIFrame('list_frame');
-        $wd->waitForText('Web Content Management System');
+        $wd->seeElement(Locator::firstElement('div.module'));
         // And switch back to main frame preparing a click to main module for the following main test case
         $wd->switchToIFrame();
     }


### PR DESCRIPTION
Due to issue https://forge.typo3.org/issues/91127 the module "Help >
About" can't be the default anymore, thus the acceptance tests must not
rely on this.

As a replacement, we check whether `div.module` can be found, which
should be sufficient for the intended check.