### PR TITLE
[TASK] Provide container instance in functional tests

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Psr\Container\ContainerInterface;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
@@ -562,9 +563,9 @@ class Testbase
      * For functional and acceptance tests.
      *
      * @param string $instancePath Absolute path to test instance
-     * @return void
+     * @return ContainerInterface
      */
-    public function setUpBasicTypo3Bootstrap($instancePath)
+    public function setUpBasicTypo3Bootstrap($instancePath): ContainerInterface
     {
         $_SERVER['PWD'] = $instancePath;
         $_SERVER['argv'][0] = 'index.php';
@@ -575,12 +576,14 @@ class Testbase
 
         $classLoader = require __DIR__ . '/../../../../autoload.php';
         SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);
-        Bootstrap::init($classLoader);
+        $container = Bootstrap::init($classLoader);
         // Make sure output is not buffered, so command-line output can take place and
         // phpunit does not whine about changed output bufferings in tests.
         ob_end_clean();
 
         $this->dumpClassLoadingInformation();
+
+        return $container;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   },
   "require": {
     "phpunit/phpunit": "^8.4 || ^9.0",
+    "psr/container": "^1.0",
     "mikey179/vfsstream": "~1.6.8",
     "typo3fluid/fluid": "^2.5|^3",
     "typo3/cms-core": "10.*.*@dev",


### PR DESCRIPTION
Many functional tests in TYPO3 core currently use
GeneralUtility::getContainer(). This function is marked @internal
and should therefore not be used by third party extensions.
In core we will remove it from functional tests to showcase
best practices. typo3/testing-framework will now provide
FunctionalTestCase::getContainer as API.

Issue on Forge:
https://forge.typo3.org/issues/91363

Related change for TYPO3 core:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/64456