### PR TITLE
[TASK] Remove unused functionality

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -19,7 +19,6 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Extension;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Styleguide\TcaDataGenerator\Generator;
@@ -260,7 +259,6 @@ abstract class BackendEnvironment extends Extension
         // Set some hard coded base settings for the instance. Those could be overruled by
         // $this->config['configurationToUseInTestInstance ']if needed again.
         $localConfiguration['BE']['debug'] = true;
-        $localConfiguration['BE']['lockHashKeyWords'] = '';
         $localConfiguration['BE']['installToolPassword'] = '$P$notnotnotnotnotnot.validvalidva';
         $localConfiguration['SYS']['displayErrors'] = false;
         $localConfiguration['SYS']['debugExceptionHandler'] = '';

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -271,7 +271,6 @@ abstract class FunctionalTestCase extends BaseTestCase
             GeneralUtility::purgeInstances();
             $this->container = $testbase->setUpBasicTypo3Bootstrap($this->instancePath);
             $testbase->initializeTestDatabaseAndTruncateTables();
-            Bootstrap::initializeBackendRouter();
             $testbase->loadExtensionTables();
         } else {
             $testbase->removeOldInstanceIfExists($this->instancePath);
@@ -339,7 +338,6 @@ abstract class FunctionalTestCase extends BaseTestCase
             } else {
                 $testbase->setUpTestDatabase($dbPath, $originalDatabaseName);
             }
-            Bootstrap::initializeBackendRouter();
             $testbase->loadExtensionTables();
             $testbase->createDatabaseStructure();
         }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -572,7 +572,6 @@ class Testbase
 
         // Reset state from a possible previous run
         GeneralUtility::purgeInstances();
-        GeneralUtility::resetApplicationContext();
 
         $classLoader = require __DIR__ . '/../../../../autoload.php';
         SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);


### PR DESCRIPTION
Several properties and methods are unused in TYPO3 v10
and do not need to be instantiated anymore, so they
can be removed.