### PR TITLE
[BUGFIX] Include dataProvider Generators into splitting

### DIFF
--- a/Resources/Core/Build/Scripts/splitFunctionalTests.php
+++ b/Resources/Core/Build/Scripts/splitFunctionalTests.php
@@ -110,7 +110,12 @@ class SplitFunctionalTests extends NodeVisitorAbstract
                 if (isset($test['dataProvider'])) {
                     // Test uses a data provider - get number of data sets
                     $dataProviderMethodName = $test['dataProvider'];
-                    $numberOfDataSets = count((new $fqcn)->$dataProviderMethodName());
+                    $methods = (new $fqcn)->$dataProviderMethodName();
+                    if ($methods instanceof Generator) {
+                        $numberOfDataSets = iterator_count($methods);
+                    } else {
+                        $numberOfDataSets = count($methods);
+                    }
                     $testStats[$relativeFilename] += $numberOfDataSets;
                 } else {
                     // Just a single test


### PR DESCRIPTION
The Generator functions (using yield) do not implement the Countable
Interface and therefor are not included into the count function
that evaluates the splitting of existing tests. By retrieving the
count in the Traversable Interface way, the number is now correct.