### PR TITLE
[BUGFIX] Do not set sitetitle to empty value if none is given

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -752,7 +752,6 @@ abstract class FunctionalTestCase extends BaseTestCase
         $templateFields = array_merge(
             [
                 'title' => '',
-                'sitetitle' => '',
                 'constants' => '',
                 'config' => '',
             ],


### PR DESCRIPTION
This ensures compatibility with TYPO3 v10 and v11.