### PR TITLE
[TASK] Use session snapshots to speed up tests with BE login

### DIFF
--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -39,33 +39,37 @@ class Login extends Module
      */
     public function useExistingSession($role = '')
     {
+
         /** @var Module\WebDriver $wd */
         $wd = $this->getModule('WebDriver');
-        $wd->amOnPage('/typo3/index.php');
-        $wd->waitForElement('body[data-typo3-login-ready]');
+//        if ($wd->loadSessionSnapshot('login') === false) {
+            $wd->amOnPage('/typo3/index.php');
+            $wd->waitForElement('body[data-typo3-login-ready]');
 
-        $sessionCookie = '';
-        if ($role) {
-            if (!isset($this->config['sessions'][$role])) {
-                throw new ConfigurationException("Helper\Login doesn't have `sessions` defined for $role");
+            $sessionCookie = '';
+            if ($role) {
+                if (!isset($this->config['sessions'][$role])) {
+                    throw new ConfigurationException("Helper\Login doesn't have `sessions` defined for $role");
+                }
+                $sessionCookie = $this->config['sessions'][$role];
             }
-            $sessionCookie = $this->config['sessions'][$role];
-        }
 
-        // @todo: There is a bug in PhantomJS / firefox (?) where adding a cookie fails.
-        // This bug will be fixed in the next PhantomJS version but i also found
-        // this workaround. First reset / delete the cookie and than set it and catch
-        // the webdriver exception as the cookie has been set successful.
-        try {
-            $wd->resetCookie('be_typo_user');
-            $wd->setCookie('be_typo_user', $sessionCookie);
-        } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
-        }
-        try {
-            $wd->resetCookie('be_lastLoginProvider');
-            $wd->setCookie('be_lastLoginProvider', '1433416747');
-        } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
-        }
+            // @todo: There is a bug in PhantomJS / firefox (?) where adding a cookie fails.
+            // This bug will be fixed in the next PhantomJS version but i also found
+            // this workaround. First reset / delete the cookie and than set it and catch
+            // the webdriver exception as the cookie has been set successful.
+            try {
+                $wd->resetCookie('be_typo_user');
+                $wd->setCookie('be_typo_user', $sessionCookie);
+            } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
+            }
+            try {
+                $wd->resetCookie('be_lastLoginProvider');
+                $wd->setCookie('be_lastLoginProvider', '1433416747');
+            } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
+            }
+//            $wd->saveSessionSnapshot('login');
+//        }
 
         // reload the page to have a logged in backend
         $wd->amOnPage('/typo3/index.php');

--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -42,7 +42,7 @@ class Login extends Module
 
         /** @var Module\WebDriver $wd */
         $wd = $this->getModule('WebDriver');
-//        if ($wd->loadSessionSnapshot('login') === false) {
+        if ($wd->loadSessionSnapshot('login') === false) {
             $wd->amOnPage('/typo3/index.php');
             $wd->waitForElement('body[data-typo3-login-ready]');
 
@@ -68,8 +68,8 @@ class Login extends Module
                 $wd->setCookie('be_lastLoginProvider', '1433416747');
             } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
             }
-//            $wd->saveSessionSnapshot('login');
-//        }
+            $wd->saveSessionSnapshot('login');
+        }
 
         // reload the page to have a logged in backend
         $wd->amOnPage('/typo3/index.php');


### PR DESCRIPTION
BE login on each and every test adds a small amount of time to
each test setup. Codeception provides a possibility
to save a snapshot of such a session that can be reused, reducing
the set up time for tests.