### PR TITLE
[BUGFIX] Fix class loader path resolution in RequestBootstrap

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -63,8 +63,7 @@ class RequestBootstrap
 
     private function initialize()
     {
-        $directory = dirname(realpath($this->documentRoot . '/index.php'));
-        $this->classLoader = require_once $directory . '/vendor/autoload.php';
+        $this->classLoader = require_once __DIR__ . '/../../../../../../../autoload.php';
     }
 
     /**


### PR DESCRIPTION
Resolving the class loader path by using the public path is unreliable: The vendor folder does not have to be a child of the public folder but can have an arbitrary path. The most reliable and most used class loader path resolution in this extension is based on the fact that this extension itself resides within the vendor folder and thus has a fixed relation to the class loader file.

Resolves: #106, #144
Releases: master