### PR TITLE
[BUGFIX] Load ext:fluid for all functional tests

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -324,6 +324,7 @@ abstract class FunctionalTestCase extends BaseTestCase
                 'extbase',
                 'install',
                 'recordlist',
+                'fluid',
             ];
             $testbase->setUpPackageStates(
                 $this->instancePath,


### PR DESCRIPTION
With introduction of Dependency Injection it became obivous, that
ext:backend carries a hard dependency to ext:fluid via the TemplateView.

Usually it is no problem for functional tests, that can define
their dependencies to load. But now the core has a workaround
only for testing framework, so cases without ext:fluid loaded
will not suffer from errors.