### PR TITLE
[BUGFIX] Allow to csv assert empty table

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -499,7 +499,8 @@ abstract class FunctionalTestCase extends BaseTestCase
             $hasUidField = ($dataSet->getIdIndex($tableName) !== null);
             $hasHashField = ($dataSet->getHashIndex($tableName) !== null);
             $records = $this->getAllRecords($tableName, $hasUidField, $hasHashField);
-            foreach ($dataSet->getElements($tableName) as $assertion) {
+            $assertions = (array)$dataSet->getElements($tableName);
+            foreach ($assertions as $assertion) {
                 $result = $this->assertInRecords($assertion, $records);
                 if ($result === false) {
                     if ($hasUidField && empty($records[$assertion['uid']])) {


### PR DESCRIPTION
Having a .csv file with a table name and table field list but
no rows triggers a PHP warning. The patch fixes this to allow
asserting an empty table.