### PR TITLE
Do not unset private properties in tearDown

### DIFF
--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -133,7 +133,8 @@ abstract class UnitTestCase extends BaseTestCase
         foreach ($reflection->getProperties() as $property) {
             $declaringClass = $property->getDeclaringClass()->getName();
             if (
-                !$property->isStatic()
+                !$property->isPrivate()
+                && !$property->isStatic()
                 && $declaringClass !== UnitTestCase::class
                 && $declaringClass !== BaseTestCase::class
                 && strpos($property->getDeclaringClass()->getName(), 'PHPUnit') !== 0


### PR DESCRIPTION
private properties can not be unset from this scope.
Classes and traits introducing private properties should unset them.

Relates: #178