### PR TITLE
[BUGFIX] Use renamed class in phpunit v9

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -891,7 +891,12 @@ abstract class FunctionalTestCase extends BaseTestCase
         ];
 
         $vendorPath = (new Testbase())->getPackagesPath();
-        $template = new \Text_Template($vendorPath . '/typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
+        // @todo remove condition and if branch after phpunit v9 is minimum requirement
+        if (class_exists(\Text_Template::class)) {
+            $template = new \Text_Template($vendorPath . '/typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
+        } else {
+            $template = new \SebastianBergmann\Template\Template($vendorPath . '/typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
+        }
         $template->setVar(
             [
                 'arguments' => var_export($arguments, true),

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -891,12 +891,14 @@ abstract class FunctionalTestCase extends BaseTestCase
         ];
 
         $vendorPath = (new Testbase())->getPackagesPath();
-        // @todo remove condition and if branch after phpunit v9 is minimum requirement
-        if (class_exists(\Text_Template::class)) {
-            $template = new \Text_Template($vendorPath . '/typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
-        } else {
-            $template = new \SebastianBergmann\Template\Template($vendorPath . '/typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
+
+        // @todo Hard switch to class name in if condition after phpunit v9 is minimum requirement
+        $templateClass = \Text_Template::class;
+        if (!class_exists($templateClass)) {
+            $templateClass = \SebastianBergmann\Template\Template::class;
         }
+        $template = new $templateClass($vendorPath . '/typo3/testing-framework/Resources/Core/Functional/Fixtures/Frontend/request.tpl');
+
         $template->setVar(
             [
                 'arguments' => var_export($arguments, true),


### PR DESCRIPTION
class \Text_Template was available in phpunit/php-text-template
in version 1, but was renamed to \SebastianBergmann\Template\Template
in version 2.
So, using phpunit v9 and composer max conditions, the old class name
is not available anymore and causes failures in functional tests.