### PR TITLE
[TASK] Remove unused fields for BE user fixtures

### DIFF
--- a/Resources/Core/Acceptance/Fixtures/be_users.xml
+++ b/Resources/Core/Acceptance/Fixtures/be_users.xml
@@ -14,11 +14,9 @@
 		<crdate>1366642540</crdate>
 		<cruser_id>0</cruser_id>
 		<workspace_perms>1</workspace_perms>
-		<disableIPlock>1</disableIPlock>
 		<deleted>0</deleted>
 		<TSconfig>NULL</TSconfig>
 		<lastlogin>1371033743</lastlogin>
-		<createdByAction>0</createdByAction>
 		<workspace_id>0</workspace_id>
 		<realName>Klaus Admin</realName>
 	</be_users>
@@ -36,11 +34,9 @@
 		<crdate>1452944912</crdate>
 		<cruser_id>1</cruser_id>
 		<workspace_perms>1</workspace_perms>
-		<disableIPlock>1</disableIPlock>
 		<deleted>0</deleted>
 		<TSconfig>NULL</TSconfig>
 		<lastlogin>1452944915</lastlogin>
-		<createdByAction>0</createdByAction>
 		<workspace_id>0</workspace_id>
 		<db_mountpoints>1</db_mountpoints>
 		<usergroup>1</usergroup>

--- a/Resources/Core/Functional/Fixtures/be_users.xml
+++ b/Resources/Core/Functional/Fixtures/be_users.xml
@@ -14,11 +14,9 @@
 		<crdate>1366642540</crdate>
 		<cruser_id>0</cruser_id>
 		<workspace_perms>1</workspace_perms>
-		<disableIPlock>1</disableIPlock>
 		<deleted>0</deleted>
 		<TSconfig>NULL</TSconfig>
 		<lastlogin>1371033743</lastlogin>
-		<createdByAction>0</createdByAction>
 		<workspace_id>0</workspace_id>
 	</be_users>
 </dataset>


### PR DESCRIPTION
These fields should not be included in the
test fixtures for backend users, as they
are possibly be removed in TYPO3 v11.0.