### PR TITLE
[WIP][TASK] Set dependencies to TYPO3 v11 and phpunit v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4']
+        php: ['7.3', '7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
+        php: ['7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use PHPUnit\Util\PHP\AbstractPhpProcess;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
@@ -70,6 +71,8 @@ use TYPO3\TestingFramework\Core\Testbase;
  */
 abstract class FunctionalTestCase extends BaseTestCase
 {
+    use ProphecyTrait;
+    
     /**
      * An unique identifier for this test case. Location of the test
      * instance and database name depend on this. Calculated early in setUp()

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -14,6 +14,7 @@ namespace TYPO3\TestingFramework\Core\Unit;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -31,6 +32,8 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
  */
 abstract class UnitTestCase extends BaseTestCase
 {
+    use ProphecyTrait;
+
     /**
      * If set to true, setUp() will back up the state of the
      * TYPO3\CMS\Core\Core\Environment class and restore it

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,17 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
-    "phpunit/phpunit": "^8.4 || ^9.0",
+    "phpunit/phpunit": "^9.1",
+    "phpspec/prophecy-phpunit": "^2.0",
     "psr/container": "^1.0",
     "mikey179/vfsstream": "~1.6.8",
     "typo3fluid/fluid": "^2.5|^3",
-    "typo3/cms-core": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-backend": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-frontend": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-extbase": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-fluid": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-recordlist": "10.*.*@dev || 11.*.*@dev"
+    "typo3/cms-core": "11.*.*@dev",
+    "typo3/cms-backend": "11.*.*@dev",
+    "typo3/cms-frontend": "11.*.*@dev",
+    "typo3/cms-extbase": "11.*.*@dev",
+    "typo3/cms-fluid": "11.*.*@dev",
+    "typo3/cms-recordlist": "11.*.*@dev"
   },
   "suggest": {
     "codeception/codeception": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -25,17 +25,18 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
+    "php": "^7.3",
     "phpunit/phpunit": "^9.1",
     "phpspec/prophecy-phpunit": "^2.0",
     "psr/container": "^1.0",
     "mikey179/vfsstream": "~1.6.8",
     "typo3fluid/fluid": "^2.5|^3",
-    "typo3/cms-core": "11.*.*@dev",
-    "typo3/cms-backend": "11.*.*@dev",
-    "typo3/cms-frontend": "11.*.*@dev",
-    "typo3/cms-extbase": "11.*.*@dev",
-    "typo3/cms-fluid": "11.*.*@dev",
-    "typo3/cms-recordlist": "11.*.*@dev"
+    "typo3/cms-core": "10.*.*@dev || 11.*.*@dev",
+    "typo3/cms-backend": "10.*.*@dev || 11.*.*@dev",
+    "typo3/cms-frontend": "10.*.*@dev || 11.*.*@dev",
+    "typo3/cms-extbase": "10.*.*@dev || 11.*.*@dev",
+    "typo3/cms-fluid": "10.*.*@dev || 11.*.*@dev",
+    "typo3/cms-recordlist": "10.*.*@dev || 11.*.*@dev"
   },
   "suggest": {
     "codeception/codeception": "^4.0",


### PR DESCRIPTION
this is preparation for testing-framework branch for TYPO3 v11 only. PHPUnit v9 will be required.