### PR TITLE
[FEATURE] Frontend functional tests as sub request

### DIFF
--- a/Classes/Core/Functional/Framework/FrameworkState.php
+++ b/Classes/Core/Functional/Framework/FrameworkState.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3\TestingFramework\Core\Functional\Framework;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Database\ReferenceIndex;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+/**
+ * This is an ugly helper class to manage some TYPO3 framework state.
+ *
+ * It is used in functional tests that fire a frontend request (->executeFrontendSubRequest()).
+ *
+ * Since TYPO3 still has a couple of static properties and globals that are 'tainted' after a
+ * request has been handled, this class is a helper to get rid of this state again.
+ *
+ * This class should not be needed. It is a manifest of technical core debt.
+ * It should shrink over time and vanish altogether in the end.
+ */
+class FrameworkState
+{
+    protected static $state = [];
+
+    /**
+     * Push current state to stack
+     */
+    public static function push()
+    {
+        $state = [];
+        $state['globals-server'] = $GLOBALS['_SERVER'];
+        $state['globals-beUser'] = $GLOBALS['BE_USER'] ?: null;
+        // InternalRequestContext->withGlobalSettings() may override globals, especially TYPO3_CONF_VARS
+        $state['globals-typo3-conf-vars'] = $GLOBALS['TYPO3_CONF_VARS'] ?: null;
+
+        // Backing up TCA *should* not be needed: TCA is (hopefully) never changed after bootstrap and identical in FE and BE.
+        // Some tests change TCA on the fly (eg. core DataHandling/Regular/Modify localizeContentWithEmptyTcaIntegrityColumns).
+        // A FE call then resets this TCA change since it initializes the global again. Then, after the FE call, the TCA is
+        // different. And code that runs after that within the test scope may fail (eg. the referenceIndex check in tearDown() that
+        // relies on TCA). So we backup TCA for now before executing frontend tests.
+        $state['globals-tca'] = $GLOBALS['TCA'];
+
+        // Can be dropped when GeneralUtility::getIndpEnv() is abandoned
+        $generalUtilityReflection = new \ReflectionClass(GeneralUtility::class);
+        $generalUtilityIndpEnvCache = $generalUtilityReflection->getProperty('indpEnvCache');
+        $generalUtilityIndpEnvCache->setAccessible(true);
+        $state['generalUtilityIndpEnvCache'] = $generalUtilityIndpEnvCache->getValue();
+
+        $state['generalUtilitySingletonInstances'] = GeneralUtility::getSingletonInstances();
+
+        // Infamous RootlineUtility carries various static state ...
+        $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
+        $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
+        $rootlineUtilityLocalCache->setAccessible(true);
+        $state['rootlineUtilityLocalCache'] = $rootlineUtilityLocalCache->getValue();
+        $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
+        $rootlineUtilityRootlineFields->setAccessible(true);
+        $state['rootlineUtilityRootlineFields'] = $rootlineUtilityRootlineFields->getValue();
+        $rootlineUtilityPageRecordCache = $rootlineUtilityReflection->getProperty('pageRecordCache');
+        $rootlineUtilityPageRecordCache->setAccessible(true);
+        $state['rootlineUtilityPageRecordCache'] = $rootlineUtilityPageRecordCache->getValue();
+
+        self::$state[] = $state;
+    }
+
+    /**
+     * Reset some state before functional frontend tests are executed
+     */
+    public static function reset()
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $generalUtilityReflection = new \ReflectionClass(GeneralUtility::class);
+        $generalUtilityIndpEnvCache = $generalUtilityReflection->getProperty('indpEnvCache');
+        $generalUtilityIndpEnvCache->setAccessible(true);
+        $generalUtilityIndpEnvCache = $generalUtilityIndpEnvCache->setValue([]);
+
+        GeneralUtility::resetSingletonInstances([]);
+
+        RootlineUtility::purgeCaches();
+        $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
+        $rootlineFieldsDefault = $rootlineUtilityReflection->getDefaultProperties();
+        $rootlineFieldsDefault = $rootlineFieldsDefault['rootlineFields'];
+        $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
+        $rootlineUtilityRootlineFields->setAccessible(true);
+        $state['rootlineUtilityRootlineFields'] = $rootlineFieldsDefault;
+    }
+
+    /**
+     * Pop state from stash and apply again to set state back to 'before frontend call'
+     */
+    public static function pop()
+    {
+        $state = array_pop(self::$state);
+
+        $GLOBALS['_SERVER'] = $state['globals-server'];
+        if ($state['globals-beUser'] !== null) {
+            $GLOBALS['BE_USER'] = $state['globals-beUser'];
+        }
+        if ($state['globals-typo3-conf-vars'] !== null) {
+            $GLOBALS['TYPO3_CONF_VARS'] = $state['globals-typo3-conf-vars'];
+        }
+
+        $GLOBALS['TCA'] = $state['globals-tca'];
+
+        $generalUtilityReflection = new \ReflectionClass(GeneralUtility::class);
+        $generalUtilityIndpEnvCache = $generalUtilityReflection->getProperty('indpEnvCache');
+        $generalUtilityIndpEnvCache->setAccessible(true);
+        $generalUtilityIndpEnvCache->setValue($state['generalUtilityIndpEnvCache']);
+
+        GeneralUtility::resetSingletonInstances($state['generalUtilitySingletonInstances']);
+
+        $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
+        $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
+        $rootlineUtilityLocalCache->setAccessible(true);
+        $rootlineUtilityLocalCache->setValue($state['rootlineUtilityLocalCache']);
+        $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
+        $rootlineUtilityRootlineFields->setAccessible(true);
+        $rootlineUtilityRootlineFields->setValue($state['rootlineUtilityRootlineFields']);
+        $rootlineUtilityPageRecordCache = $rootlineUtilityReflection->getProperty('pageRecordCache');
+        $rootlineUtilityPageRecordCache->setAccessible(true);
+        $rootlineUtilityPageRecordCache->setValue($state['rootlineUtilityPageRecordCache']);
+    }
+}

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -20,7 +20,11 @@ use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\AbstractInstruction;
 
 /**
- * Model of internal frontend request context
+ * Model of internal frontend request context.
+ *
+ * This is a helper class in testing-framework context used to execute frontend requests.
+ * It provides some convenient helper methods like ->withPageId() to easily set up a frontend request.
+ * It is later turned into a request implementing PSR-7 ServerRequestInterface.
  */
 class InternalRequest extends Request implements \JsonSerializable
 {
@@ -34,6 +38,8 @@ class InternalRequest extends Request implements \JsonSerializable
     /**
      * @param array $data
      * @return InternalRequest
+     * @internal
+     * @deprecated Can be removed when retrieveFrontendRequestResult() is dropped
      */
     public static function fromArray(array $data): InternalRequest
     {
@@ -72,6 +78,8 @@ class InternalRequest extends Request implements \JsonSerializable
 
     /**
      * @return array
+     * @internal
+     * @deprecated Can be removed when retrieveFrontendRequestResult() is dropped, also drop 'implements JsonSerializable'
      */
     public function jsonSerialize(): array
     {

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
@@ -17,7 +17,10 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
 use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 
 /**
- * Model of internal frontend request context
+ * Model of internal frontend request context.
+ *
+ * Helper class for frontend requests to hand over details like 'a backend user should be logged in'.
+ * This is used by testing-framework extension ext:json_response in its middlewares.
  */
 class InternalRequestContext implements \JsonSerializable
 {
@@ -46,6 +49,8 @@ class InternalRequestContext implements \JsonSerializable
     /**
      * @param array $data
      * @return InternalRequestContext
+     * @internal
+     * @deprecated Can be removed when retrieveFrontendRequestResult() is dropped
      */
     public static function fromArray(array $data)
     {
@@ -54,6 +59,8 @@ class InternalRequestContext implements \JsonSerializable
 
     /**
      * @return array
+     * @internal
+     * @deprecated Can be removed when retrieveFrontendRequestResult() is dropped, also drop 'implements JsonSerializable'
      */
     public function jsonSerialize(): array
     {

--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -23,6 +23,9 @@ use TYPO3\CMS\Frontend\Http\Application;
 
 /**
  * Bootstrap for direct CLI Request
+ *
+ * @internal
+ * @deprecated This class should be dropped or heavily reduced when retrieveFrontendRequestResult() is dropped.
  */
 class RequestBootstrap
 {

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -23,14 +23,21 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Http\Application;
 use TYPO3\TestingFramework\Core\BaseTestCase;
 use TYPO3\TestingFramework\Core\DatabaseConnectionWrapper;
 use TYPO3\TestingFramework\Core\Exception;
 use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
 use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot\DatabaseAccessor;
 use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot\DatabaseSnapshot;
+use TYPO3\TestingFramework\Core\Functional\Framework\FrameworkState;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalResponse;
@@ -847,10 +854,146 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
+     * Execute a TYPO3 frontend application request.
+     * Note this needs a core v11 and is experimental for extension developers for now.
+     *
      * @param InternalRequest $request
      * @param InternalRequestContext|null $context
      * @param bool $followRedirects Whether to follow HTTP location redirects
      * @return InternalResponse
+     */
+    protected function executeFrontendSubRequest(
+        InternalRequest $request,
+        InternalRequestContext $context = null,
+        bool $followRedirects = false
+    ): InternalResponse
+    {
+        if ($context === null) {
+            $context = new InternalRequestContext();
+        }
+        $locationHeaders = [];
+        do {
+            $result = $this->retrieveFrontendSubRequestResult($request, $context);
+            $response = $this->reconstituteFrontendRequestResult($result);
+            $locationHeader = $response->getHeaderLine('location');
+            if (in_array($locationHeader, $locationHeaders, true)) {
+                $this->fail(
+                    implode(LF . '* ', array_merge(
+                        ['Redirect loop detected:'],
+                        $locationHeaders,
+                        [$locationHeader]
+                    ))
+                );
+            }
+            $locationHeaders[] = $locationHeader;
+            $request = new InternalRequest($locationHeader);
+        } while ($followRedirects && !empty($locationHeader));
+        return $response;
+    }
+
+    /**
+     * The internal worker method that actually fires the frontend application request.
+     * The method is still a bit messy and needs to do some stuff that can be obsoleted
+     * when the core becomes more clean.
+     * It's main job is to turn the testing-framework internal request object into a
+     * a PSR-7 core/Http/ServerRequest, register the testing-framework InternalRequestContext
+     * object for the testing-framework ext:json_response middlewares to operate on, and
+     * to then call the ext:frontend Application.
+     * Note this method is in 'early' state and will change over time.
+     *
+     * @param InternalRequest $request
+     * @param InternalRequestContext $context
+     * @return array
+     * @internal Do not use directly, use ->executeFrontendSubRequest() instead
+     */
+    private function retrieveFrontendSubRequestResult(
+        InternalRequest $request,
+        InternalRequestContext $context
+    ): array
+    {
+        FrameworkState::push();
+        FrameworkState::reset();
+
+        // Needed for GeneralUtility::getIndpEnv('SCRIPT_NAME') to return correct value
+        // instead of 'vendor/phpunit/phpunit/phpunit', used eg. in TypoScriptFrontendController absRefPrefix='auto'
+        // See second data provider of UriPrefixRenderingTest
+        // @todo: Make TSFE not use getIndpEnv() anymore
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $requestUrlParts = parse_url($request->getUri());
+        $_SERVER['HTTP_HOST'] = $_SERVER['SERVER_NAME'] = isset($requestUrlParts['host']) ? $requestUrlParts['host'] : 'localhost';
+
+        $container = Bootstrap::init(ClassLoadingInformation::getClassLoader());
+
+        // The testing-framework registers extension 'json_response' that brings some middlewares which
+        // allow to eg. log in backend users in frontend application context. These globals are used to
+        // carry that information.
+        $_SERVER['X_TYPO3_TESTING_FRAMEWORK']['context'] = $context;
+        $_SERVER['X_TYPO3_TESTING_FRAMEWORK']['request'] = $request;
+        ArrayUtility::mergeRecursiveWithOverrule(
+            $GLOBALS,
+            $context->getGlobalSettings() ?? []
+        );
+        $result = [
+            'status' => 'failure',
+            'content' => null,
+            'error' => null
+        ];
+        // Create ServerRequest from testing-framework InternalRequest object
+        $uri = $request->getUri();
+
+        // Implement a side effect: String casting an uri object that has been created from 'https://website.local//'
+        // results in 'https://website.local/' (double slash at end missing). The old executeFrontendRequest() triggered
+        // this since it had to stringify the request to transfer it through the PHP process to later reconstitute it.
+        // We simulate this behavior here. See Test SlugSiteRequestTest->requestsAreRedirectedWithoutHavingDefaultSiteLanguage()
+        // with data set 'https://website.local//' relies on this behavior and leads to a different middleware redirect path
+        // if the double '//' is given.
+        // @todo: Resolve this, probably by a) changing Uri __toString() to not trigger that side effect and b) changing test
+        $uriString = (string)$uri;
+        $uri = new Uri($uriString);
+
+        $serverRequest = new ServerRequest(
+            $uri,
+            $request->getMethod(),
+            'php://input',
+            $request->getHeaders()
+        );
+        $requestUrlParts = [];
+        parse_str($uri->getQuery(), $requestUrlParts);
+        $serverRequest = $serverRequest->withQueryParams($requestUrlParts);
+        try {
+            $frontendApplication = $container->get(Application::class);
+            $jsonResponse = $frontendApplication->handle($serverRequest);
+            $result['status'] = 'success';
+            $result['content'] = json_decode($jsonResponse->getBody()->__toString(), true);
+        } catch (\Exception $exception) {
+            $result['error'] = $exception->__toString();
+            $result['exception'] = [
+                'type' => get_class($exception),
+                'message' => $exception->getMessage(),
+                'code' => $exception->getCode(),
+            ];
+        }
+        $content['stdout'] = json_encode($result);
+
+        // Somewhere an ob_start() is called in frontend that is not cleaned. Work around that for now.
+        ob_end_clean();
+
+        FrameworkState::pop();
+        return $content;
+    }
+
+    /**
+     * Old method to execute a TYPO3 frontend request. The internals feed
+     * the request to a php child process to isolate the call.
+     * This is needed for tests that run on a TYPO3 core <= v10, for
+     * tests with core v11, ->executeFrontendSubRequest() should be used.
+     *
+     * @param InternalRequest $request
+     * @param InternalRequestContext|null $context
+     * @param bool $followRedirects Whether to follow HTTP location redirects
+     * @return InternalResponse
+     * @deprecated Use executeFrontendSubRequest() instead
      */
     protected function executeFrontendRequest(
         InternalRequest $request,
@@ -884,10 +1027,14 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
+     * Internal implementation of executing a frontend request incapsulated
+     * in a PHP child process.
+     *
      * @param InternalRequest $request
      * @param InternalRequestContext $context
      * @param bool $withJsonResponse
      * @return array
+     * @deprecated Use executeFrontendSubRequest() instead
      */
     protected function retrieveFrontendRequestResult(
         InternalRequest $request,
@@ -926,6 +1073,7 @@ abstract class FunctionalTestCase extends BaseTestCase
     /**
      * @param array $result
      * @return InternalResponse
+     * @internal Never use directly. May vanish without further notice.
      */
     protected function reconstituteFrontendRequestResult(array $result): InternalResponse
     {
@@ -966,7 +1114,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      * @param bool $failOnFailure
      * @param int $frontendUserId
      * @return Response
-     * @deprecated Use retrieveFrontendRequestResult() instead
+     * @deprecated Use executeFrontendSubRequest() instead
      */
     protected function getFrontendResponse(
         $pageId,
@@ -1010,7 +1158,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      * @param int $workspaceId
      * @param int $frontendUserId
      * @return array containing keys 'stdout' and 'stderr'
-     * @deprecated Use retrieveFrontendRequestResult() instead
+     * @deprecated Use executeFrontendSubRequest() instead
      */
     protected function getFrontendResult(
         $pageId,

--- a/Resources/Core/Functional/Fixtures/Frontend/request.tpl
+++ b/Resources/Core/Functional/Fixtures/Frontend/request.tpl
@@ -1,4 +1,5 @@
 <?php
+// @deprecated Can be removed when retrieveFrontendRequestResult() is dropped
 require '{vendorPath}typo3/testing-framework/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php';
 (new \TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap('{documentRoot}', {arguments}))
     ->executeAndOutput();


### PR DESCRIPTION
Add a core v11 compatible method to execute frontend
functional tests as sub request instead of a PHP sub
process. Deprecate the old way.