### PR TITLE
[TASK] Include lit-html/element in JSUnit Bootstrap

### DIFF
--- a/Resources/Core/Build/Configuration/JSUnit/Bootstrap.js
+++ b/Resources/Core/Build/Configuration/JSUnit/Bootstrap.js
@@ -17,6 +17,19 @@ var paths = {
 	'jquery/autocomplete': '/base/typo3/sysext/core/Resources/Public/JavaScript/Contrib/jquery.autocomplete'
 };
 
+var packages = [
+	{
+		name: 'lit-html',
+		location: '/base/typo3/sysext/core/Resources/Public/JavaScript/Contrib/lit-html',
+		main: 'lit-html'
+	},
+	{
+		name: 'lit-element',
+		location: '/base/typo3/sysext/core/Resources/Public/JavaScript/Contrib/lit-element',
+		main: 'lit-element'
+	},
+];
+
 /**
  * Collect test files and define namespace mapping for RequireJS config
  */
@@ -75,6 +88,8 @@ requirejs.config({
 	baseUrl: '/base',
 
 	paths: paths,
+
+	packages: packages,
 
 	shim: {},
 


### PR DESCRIPTION
lit-html is added to TYPO3 core as client side
template engine. Therefore this library needs
to be loadable in unit tests.

Issue on Forge:
https://forge.typo3.org/issues/91810

Related change for TYPO3 core:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/67092