### PR TITLE
Backported #189 and #190 to `9` branch

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -159,6 +159,10 @@ class RequestBootstrap
                 \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_FE
             );
             $container = \TYPO3\CMS\Core\Core\Bootstrap::init($this->classLoader);
+            if (\TYPO3\CMS\Core\Core\Environment::isComposerMode() &&
+                \TYPO3\CMS\Core\Core\ClassLoadingInformation::isClassLoadingInformationAvailable()) {
+                \TYPO3\CMS\Core\Core\ClassLoadingInformation::registerClassLoadingInformation();
+            }
             ArrayUtility::mergeRecursiveWithOverrule(
                 $GLOBALS,
                 $this->context->getGlobalSettings() ?? []

--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -60,8 +60,7 @@ class RequestBootstrap
 
     private function initialize()
     {
-        $directory = dirname(realpath($this->documentRoot . '/index.php'));
-        $this->classLoader = require_once $directory . '/vendor/autoload.php';
+        $this->classLoader = require_once __DIR__ . '/../../../../../../../autoload.php';
     }
 
     /**


### PR DESCRIPTION
Hey there,

first of all, many thanks for the `testing-framework` extension, its really great.

On the basis of the work from @alexander-nitsche i backported the changes to the `9` branch. All tests are running fine now with Composer. #144 should be fixed for TYPO3 9.x too.

@bmack Can you please look at the changes?

Thanks for your help.