### PR TITLE
[TASK] Use GraphicsMagick for functional tests by default

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -325,6 +325,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             $localConfiguration['SYS']['trustedHostsPattern'] = '.*';
             $localConfiguration['SYS']['encryptionKey'] = 'i-am-not-a-secure-encryption-key';
             $localConfiguration['SYS']['caching']['cacheConfigurations']['extbase_object']['backend'] = NullBackend::class;
+            $localConfiguration['GFX']['processor'] = 'GraphicsMagick';
             $testbase->setUpLocalConfiguration($this->instancePath, $localConfiguration, $this->configurationToUseInTestInstance);
             $defaultCoreExtensionsToLoad = [
                 'core',


### PR DESCRIPTION
GraphicsMagick is included in default 'runTests.sh'
typo3/core-testing-php images since it adds only a
couple of MB to the image in comparison to
ImageMagick which adds ~100MB.
So we configure functional test TYPO3 instances to
use GM now. This should hopefully have little impact
on existing core and extension tests.