### PR TITLE
[TASK] Prepare for younger selenium-chrome

### DIFF
--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -93,6 +93,8 @@ abstract class AbstractPageTree
             // element not found so it may be already opened...
         } catch (\Facebook\WebDriver\Exception\ElementNotVisibleException $e) {
             // element not found so it may be already opened...
+        } catch (\Facebook\WebDriver\Exception\ElementNotInteractableException $e) {
+            // another possible exception if the chevron isn't there ... depends on facebook driver version
         }
 
         return $context;


### PR DESCRIPTION
Some more recent webdriver detail seems to throw a different
exception when an element is not found. Adapt the page tree
helper to deal with this.