### PR TITLE
[TASK] Include support for Lit v2 in JSUnit Bootstrap

### DIFF
--- a/Resources/Core/Build/Configuration/JSUnit/Bootstrap.js
+++ b/Resources/Core/Build/Configuration/JSUnit/Bootstrap.js
@@ -24,9 +24,19 @@ var packages = [
 		main: 'lit-html'
 	},
 	{
+		name: '@lit/reactive-element',
+		location: '/base/typo3/sysext/core/Resources/Public/JavaScript/Contrib/@lit/reactive-element',
+		main: 'reactive-element'
+	},
+	{
 		name: 'lit-element',
 		location: '/base/typo3/sysext/core/Resources/Public/JavaScript/Contrib/lit-element',
 		main: 'lit-element'
+	},
+	{
+		name: 'lit',
+		location: '/base/typo3/sysext/core/Resources/Public/JavaScript/Contrib/lit',
+		main: 'index'
 	},
 ];
 


### PR DESCRIPTION
The javascript modules `@lit/reactive-element` and `lit`
will be available as of Lit v2.

Issue on Forge:
https://forge.typo3.org/issues/93965

Related change for TYPO3 core:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/68104