### PR TITLE
Resolve PHP 8 stricter variable handling.

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -747,15 +747,17 @@ abstract class FunctionalTestCase extends BaseTestCase
                 continue;
             }
 
+            $recordValue = $record[$field] ?? null;
+
             if (strpos($value, '<?xml') === 0) {
                 try {
-                    $this->assertXmlStringEqualsXmlString((string)$value, (string)$record[$field]);
+                    $this->assertXmlStringEqualsXmlString((string)$value, (string)$recordValue);
                 } catch (\PHPUnit\Framework\ExpectationFailedException $e) {
                     $differentFields[] = $field;
                 }
-            } elseif ($value === null && $record[$field] !== $value) {
+            } elseif ($value === null && $recordValue !== $value) {
                 $differentFields[] = $field;
-            } elseif ((string)$record[$field] !== (string)$value) {
+            } elseif ((string)$recordValue !== (string)$value) {
                 $differentFields[] = $field;
             }
         }


### PR DESCRIPTION
This is causing `Undefined array key 'deleted'` warnings when run on core's master branch.

I'm not sure if we should be suppressing these errors (as this PR does) or figuring out why there's a `deleted` field that isn't defined.  I don't know the testing system well enough yet for the latter, but if we want the simple solution, this is it.