### PR TITLE
Explicitly check for valid input data

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -747,6 +747,10 @@ abstract class FunctionalTestCase extends BaseTestCase
                 continue;
             }
 
+            if (!isset($record[$field])) {
+                throw new \ValueError(sprintf('"%s" column not found in the input data.', $field));
+            }
+
             if (strpos($value, '<?xml') === 0) {
                 try {
                     $this->assertXmlStringEqualsXmlString((string)$value, (string)$record[$field]);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -747,7 +747,7 @@ abstract class FunctionalTestCase extends BaseTestCase
                 continue;
             }
 
-            if (!isset($record[$field])) {
+            if (!array_key_exists($field, $record)) {
                 throw new \ValueError(sprintf('"%s" column not found in the input data.', $field));
             }
 


### PR DESCRIPTION
Replaces #230 with a more draconian approach.  The root issue is invalid data that doesn't have a given field.  In that case, the input data is bad and should feel bad, so stop immediately.

This version uses a `ValueError`, because the input data is generally developer provided CSVs and thus a developer problem, not user problem.