### PR TITLE
[BUGFIX] Drop TYPO3 custom error handler in ac bootstrap

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -280,6 +280,12 @@ abstract class BackendEnvironment extends Extension
         $testbase->loadExtensionTables();
         $testbase->createDatabaseStructure();
 
+        // Unregister core error handler again, which has been initialized by
+        // $testbase->setUpBasicTypo3Bootstrap($instancePath); for DB schema
+        // migration.
+        // @todo: See which other possible state should be dropped here again (singletons, ...?)
+        restore_error_handler();
+
         // Unset a closure or phpunit kicks in with a 'serialization of \Closure is not allowed'
         // Alternative solution:
         // unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys']['extbase']);


### PR DESCRIPTION
codeception needs to bootstrap up until a point where
DB schema migrator can be executed. This automatically
registers the typo3 error handler, which is active when
the test runner executes suites.
This can lead to happy little side effects. Unregister
our custom error handler after DB schema has been created
for system under test.