### PR TITLE
Support withHeader() in InternalRequest

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -143,6 +143,16 @@ class InternalRequest extends Request implements \JsonSerializable
         return $target;
     }
 
+    public function withHeaders(array $headers): InternalRequest
+    {
+        $request = $this;
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $request;
+    }
+
     /**
      * @param array $parameters
      * @return InternalRequest

--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -143,7 +143,19 @@ class InternalRequest extends Request implements \JsonSerializable
         return $target;
     }
 
-    public function withHeaders(array $headers): InternalRequest
+    /**
+     * Helper method for with() of AssignablePropertyTrait to allow setting withHeader()
+     * from single $this->headers[] when this object is thawed using fromArray() in
+     * PHP process forking scenarios initiated by executeFrontendRequest().
+     *
+     * NOT relevant for executeFrontendSubRequest() where the request object is directly
+     * hand over to the frontend application.
+     *
+     * @param array $headers
+     * @return InternalRequest
+     * @deprecated Can be removed when retrieveFrontendRequestResult()
+     */
+    private function withHeaders(array $headers): InternalRequest
     {
         $request = $this;
         foreach ($headers as $name => $value) {


### PR DESCRIPTION
The request implements PSR-7 and therefore allows to call withHeader().
The AssignablePropertyTrait will be used to re build the request based
from serialization.
Headers are internally stored as array with name "headers".
The trait will therefore try to call withHeaders to add the stored
value.

This will break as no such method exists.
The message is added to stay compatible.

Resolves: #238