### PR TITLE
[BUGFIX] Provide minimal serverParams for Frontend functional subrequest

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -971,11 +971,21 @@ abstract class FunctionalTestCase extends BaseTestCase
         $uriString = (string)$uri;
         $uri = new Uri($uriString);
 
+        // build minimal serverParams for normalizedparamsAttribute initialzation
+        $serverParams = [
+            'SCRIPT_NAME'           => $_SERVER['SCRIPT_NAME'],
+            'HTTP_HOST'             => $_SERVER['HTTP_HOST'],
+            'SERVER_NAME'           => $_SERVER['SERVER_NAME'],
+            'HTTPS'                 => $uri->getScheme() === 'https' ? 'on' : 'off',
+            'REMOTE_ADDR'           => '127.0.0.1',
+        ];
+
         $serverRequest = new ServerRequest(
             $uri,
             $request->getMethod(),
             'php://input',
-            $request->getHeaders()
+            $request->getHeaders(),
+            $serverParams
         );
         $requestUrlParts = [];
         parse_str($uri->getQuery(), $requestUrlParts);


### PR DESCRIPTION
Provide minimal serverParams array for core v11 compatible frontend subrequest, so the normalized param attributes are set through corresponding frontend middleware, which is needed for some functional tests, ex. PageTypeSuffixDecorator tests.

See https://forge.typo3.org/issues/94537

Resolves #246