### PR TITLE
[BUGFIX] Support switching of TYPO3 backend user in Login - TYPO3 v9

### DIFF
--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -17,9 +17,11 @@ namespace TYPO3\TestingFramework\Core\Acceptance\Helper;
 
 use Codeception\Exception\ConfigurationException;
 use Codeception\Module;
+use Codeception\Module\WebDriver;
+use Codeception\Util\Locator;
 
 /**
- * Helper class to log in backend users and load backend
+ * Helper class to log in backend users and load backend.
  */
 class Login extends Module
 {
@@ -31,48 +33,107 @@ class Login extends Module
     ];
 
     /**
-     * Set a session cookie and load backend index.php
+     * Set a backend user session cookie and load the backend index.php.
      *
-     * @param string $role
+     * Use this action to change the backend user and avoid switching between users in the backend module
+     * "Backend Users" as this will change the user session ID and make it useless for subsequent calls of this action.
+     *
+     * @param string $role The backend user who should be logged in.
      * @throws ConfigurationException
      */
     public function useExistingSession($role = '')
     {
-        /** @var Module\WebDriver $wd */
-        $wd = $this->getModule('WebDriver');
-        $wd->amOnPage('/typo3/index.php');
-        $wd->waitForElement('body[data-typo3-login-ready]');
+        $webDriver = $this->getWebDriver();
 
-        $sessionCookie = '';
-        if ($role) {
-            if (!isset($this->config['sessions'][$role])) {
-                throw new ConfigurationException("Helper\Login doesn't have `sessions` defined for $role");
-            }
-            $sessionCookie = $this->config['sessions'][$role];
+        $newUserSessionId = $this->getUserSessionIdByRole($role);
+
+        $hasSession = $this->_loadSession();
+        if ($hasSession && $newUserSessionId !== '' && $newUserSessionId !== $this->getUserSessionId()) {
+            $this->_deleteSession();
+            $hasSession = false;
         }
 
-        // @todo: There is a bug in PhantomJS / firefox (?) where adding a cookie fails.
-        // This bug will be fixed in the next PhantomJS version but i also found
-        // this workaround. First reset / delete the cookie and than set it and catch
-        // the webdriver exception as the cookie has been set successful.
-        try {
-            $wd->resetCookie('be_typo_user');
-            $wd->setCookie('be_typo_user', $sessionCookie);
-        } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
-        }
-        try {
-            $wd->resetCookie('be_lastLoginProvider');
-            $wd->setCookie('be_lastLoginProvider', '1433416747');
-        } catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {
+        if (!$hasSession) {
+            $webDriver->amOnPage('/typo3/index.php');
+            $webDriver->waitForElement('body[data-typo3-login-ready]');
+            $this->_createSession($newUserSessionId);
         }
 
-        // reload the page to have a logged in backend
-        $wd->amOnPage('/typo3/index.php');
+        // Reload the page to have a logged in backend.
+        $webDriver->amOnPage('/typo3/index.php');
 
-        // Ensure main content frame is fully loaded, otherwise there are load-race-conditions
-        $wd->switchToIFrame('list_frame');
-        $wd->waitForText('Web Content Management System');
-        // And switch back to main frame preparing a click to main module for the following main test case
-        $wd->switchToIFrame();
+        // Ensure main content frame is fully loaded, otherwise there are load-race-conditions ..
+        $webDriver->waitForElement('iframe[name="list_frame"]');
+        $webDriver->switchToIFrame('list_frame');
+        $webDriver->waitForElement(Locator::firstElement('div.module'));
+        // .. and switch back to main frame.
+        $webDriver->switchToIFrame();
+    }
+
+    /**
+     * @param string $role
+     * @return string
+     * @throws ConfigurationException
+     */
+    protected function getUserSessionIdByRole($role)
+    {
+        if (empty($role)) {
+            return '';
+        }
+
+        if (!isset($this->_getConfig('sessions')[$role])) {
+            throw new ConfigurationException(sprintf(
+                'Backend user session ID cannot be resolved for role "%s": ' .
+                'Set session ID explicitly in configuration of module Login.',
+                $role
+            ), 1627554106);
+        }
+
+        return $this->_getConfig('sessions')[$role];
+    }
+
+    /**
+     * @return bool
+     */
+    public function _loadSession()
+    {
+        return $this->getWebDriver()->loadSessionSnapshot('login');
+    }
+
+    public function _deleteSession()
+    {
+        $webDriver = $this->getWebDriver();
+        $webDriver->resetCookie('be_typo_user');
+        $webDriver->resetCookie('be_lastLoginProvider');
+        $webDriver->deleteSessionSnapshot('login');
+    }
+
+    /**
+     * @param string $userSessionId
+     */
+    public function _createSession($userSessionId)
+    {
+        $webDriver = $this->getWebDriver();
+        $webDriver->setCookie('be_typo_user', $userSessionId);
+        $webDriver->setCookie('be_lastLoginProvider', '1433416747');
+        $webDriver->saveSessionSnapshot('login');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getUserSessionId()
+    {
+        $userSessionId = $this->getWebDriver()->grabCookie('be_typo_user');
+        return $userSessionId ?? '';
+    }
+
+    /**
+     * @return WebDriver
+     * @throws \Codeception\Exception\ModuleException
+     */
+    protected function getWebDriver()
+    {
+        return $this->getModule('WebDriver');
     }
 }

--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -109,11 +109,18 @@ class Login extends Module
     }
 
     /**
+     * Note: The "be_typo_user" and "be_lastLoginProvider" cookies may already be set in the bootstrapping process of
+     * the acceptance tests. They pose a problem because they are created with a different cookie path that still takes
+     * precedence over the cookies set in this method. The cookies that already exist are therefore deleted as a
+     * precaution.
+     *
      * @param string $userSessionId
      */
     public function _createSession($userSessionId)
     {
         $webDriver = $this->getWebDriver();
+        $webDriver->resetCookie('be_typo_user');
+        $webDriver->resetCookie('be_lastLoginProvider');
         $webDriver->setCookie('be_typo_user', $userSessionId);
         $webDriver->setCookie('be_lastLoginProvider', '1433416747');
         $webDriver->saveSessionSnapshot('login');


### PR DESCRIPTION
This PR is the back-port of PR #250 for TYPO3 v9. It additionally resets the TYPO3 backend user cookies which have been set when bootstrapping the acceptance tests in TYPO3 v9. This reset is not required any longer in TYPO3 v10 and v11.

Runs of all acceptance tests of

* TYPO3 v9

with and without this PR showed the same results, so this PR does not introduce regressions.

Fixes: #235