### PR TITLE
[BUGFIX] Add compatibility for guzzlehttp/psr7 2.0

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -227,8 +227,8 @@ class InternalRequest extends Request implements \JsonSerializable
             );
         }
 
-        $parameters = \GuzzleHttp\Psr7\parse_query($query);
+        $parameters = \GuzzleHttp\Psr7\Query::parse($query);
         $parameters[$parameterName] = $value;
-        return \GuzzleHttp\Psr7\build_query($parameters);
+        return \GuzzleHttp\Psr7\Query::build($parameters);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "typo3/cms-frontend": "10.*.*@dev || 11.*.*@dev",
     "typo3/cms-extbase": "10.*.*@dev || 11.*.*@dev",
     "typo3/cms-fluid": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-recordlist": "10.*.*@dev || 11.*.*@dev"
+    "typo3/cms-recordlist": "10.*.*@dev || 11.*.*@dev",
+    "guzzlehttp/psr7": "^1.7 || ^2.0"
   },
   "conflict": {
     "doctrine/dbal": "2.13.0 || 2.13.1"


### PR DESCRIPTION
This change allows to use guzzlehttp/psr7
in version 2.0 and 1.7+.

