### PR TITLE
[FEATURE] Support custom user agent in functional tests

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -118,7 +118,7 @@ class RequestBootstrap
             'withJsonResponse' => $this->requestArguments['withJsonResponse'] ?? true,
         ];
         $_SERVER['DOCUMENT_ROOT'] = $this->requestArguments['documentRoot'];
-        $_SERVER['HTTP_USER_AGENT'] = 'TYPO3 Functional Test Request';
+        $_SERVER['HTTP_USER_AGENT'] = $this->request->getHeader('User-Agent')[0] ?? 'TYPO3 Functional Test Request';
         $_SERVER['HTTP_HOST'] = $_SERVER['SERVER_NAME'] = isset($requestUrlParts['host']) ? $requestUrlParts['host'] : 'localhost';
         $_SERVER['SERVER_ADDR'] = $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
         $_SERVER['SCRIPT_NAME'] = $_SERVER['PHP_SELF'] = '/index.php';


### PR DESCRIPTION


### Changes proposed in this pull request

1. Respect header "User-Agent" which might be set in InternalRequest.

### Steps to test the solution

Add the following line to the submitted request:

```php
$request = $request->withHeader('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0');
```

Debug the value of `$_SERVER['HTTP_USER_AGENT']`.

### Results

Should be the set value, or original as fallback.

Fixes: #256
