### PR TITLE
[FEATURE] Add subpath instance functional testing

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -78,6 +78,13 @@ use TYPO3\TestingFramework\Core\Testbase;
 abstract class FunctionalTestCase extends BaseTestCase
 {
     /**
+     * Flag to control if this test case needs to be a subfolder instance.
+     *
+     * @var bool
+     */
+    protected static $createSubPathInstance = false;
+
+    /**
      * An unique identifier for this test case. Location of the test
      * instance and database name depend on this. Calculated early in setUp()
      *
@@ -86,7 +93,9 @@ abstract class FunctionalTestCase extends BaseTestCase
     protected $identifier;
 
     /**
-     * Absolute path to test instance document root. Depends on $identifier.
+     * Absolute path to test instance application root. Depends on $identifier and $createSubpathInstance.
+     * If $createSubpathInstan is false, this is equal to $instanceRootPath, otherwise
+     * $instanteRootPath . $instancePathPrefix.
      * Calculated early in setUp()
      *
      * @var string
@@ -268,11 +277,11 @@ abstract class FunctionalTestCase extends BaseTestCase
         }
 
         $this->identifier = self::getInstanceIdentifier();
-        $this->instancePath = self::getInstancePath();
+        $this->instancePath = self::getInstancePath() . self::getInstancePathPrefix();
         putenv('TYPO3_PATH_ROOT=' . $this->instancePath);
         putenv('TYPO3_PATH_APP=' . $this->instancePath);
 
-        $testbase = new Testbase();
+        $testbase = new Testbase(self::isSubPathInstance());
         $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
@@ -286,6 +295,11 @@ abstract class FunctionalTestCase extends BaseTestCase
         // sqlite db path preparation
         $dbPathSqlite = dirname($this->instancePath) . '/functional-sqlite-dbs/test_' . $this->identifier . '.sqlite';
         $dbPathSqliteEmpty = dirname($this->instancePath) . '/functional-sqlite-dbs/test_' . $this->identifier . '.empty.sqlite';
+        if (self::isSubPathInstance()) {
+            $dbPathSqlite = dirname(dirname($this->instancePath)) . '/functional-sqlite-dbs/test_' . $this->identifier . '.sqlite';
+            $dbPathSqliteEmpty = dirname(dirname($this->instancePath)) . '/functional-sqlite-dbs/test_' . $this->identifier . '.empty.sqlite';
+        }
+
 
         if (!$isFirstTest) {
             // Reusing an existing instance. This typically happens for the second, third, ... test
@@ -297,7 +311,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             }
             $testbase->loadExtensionTables();
         } else {
-            $testbase->removeOldInstanceIfExists($this->instancePath);
+            $testbase->removeOldInstanceIfExists(self::isSubPathInstance() ? dirname($this->instancePath) : $this->instancePath);
             // Basic instance directory structure
             $testbase->createDirectory($this->instancePath . '/fileadmin');
             $testbase->createDirectory($this->instancePath . '/typo3temp/var/transient');
@@ -962,7 +976,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         // instead of 'vendor/phpunit/phpunit/phpunit', used eg. in TypoScriptFrontendController absRefPrefix='auto'
         // See second data provider of UriPrefixRenderingTest
         // @todo: Make TSFE not use getIndpEnv() anymore
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
+        $_SERVER['SCRIPT_NAME'] = self::getInstancePathPrefix() . '/index.php';
 
         $requestUrlParts = parse_url($request->getUri());
         $_SERVER['HTTP_HOST'] = $_SERVER['SERVER_NAME'] = isset($requestUrlParts['host']) ? $requestUrlParts['host'] : 'localhost';
@@ -1000,9 +1014,9 @@ abstract class FunctionalTestCase extends BaseTestCase
         // attribute relies on these. Note the access to $_SERVER should be dropped when the
         // above getIndpEnv() can be dropped, too.
         $serverParams = [
-            'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
-            'HTTP_HOST'  => $_SERVER['HTTP_HOST'],
-            'SERVER_NAME' => $_SERVER['SERVER_NAME'],
+            'SCRIPT_NAME' => self::getInstancePathPrefix() . '/index.php',
+            'HTTP_HOST' => $requestUrlParts['host'] ?? 'localhost',
+            'SERVER_NAME' => $requestUrlParts['host'] ?? 'localhost',
             'HTTPS' => $uri->getScheme() === 'https' ? 'on' : 'off',
             'REMOTE_ADDR' => '127.0.0.1',
         ];
@@ -1104,7 +1118,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             'context' => json_encode($context),
         ];
 
-        $vendorPath = (new Testbase())->getPackagesPath();
+        $vendorPath = (new Testbase(self::isSubPathInstance()))->getPackagesPath();
 
         // @todo Hard switch to class name in if condition after phpunit v9 is minimum requirement
         $templateClass = \Text_Template::class;
@@ -1313,11 +1327,36 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
+     * Get absolute instance docroot path.
+     *
      * @return string
      */
     protected static function getInstancePath(): string
     {
         $identifier = self::getInstanceIdentifier();
         return ORIGINAL_ROOT . 'typo3temp/var/tests/functional-' . $identifier;
+    }
+
+    /**
+     * Get the instance prefix path (subPath), if subpath instances are enabled.
+     * Could be used in dataProviders to create probler calling urls for requests.
+     *
+     * @return string
+     */
+    protected static function getInstancePathPrefix(): string
+    {
+        $pathPrefix = '/' . self::getInstanceIdentifier();
+        return self::isSubPathInstance() ? $pathPrefix : '';
+    }
+
+    /**
+     * State if testcase instance a subpath instance.
+     * Can be used in dataProvider, if needed.
+     *
+     * @return bool
+     */
+    protected static function isSubPathInstance(): bool
+    {
+        return (bool)static::$createSubPathInstance;
     }
 }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -45,16 +45,25 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class Testbase
 {
     /**
+     * Flag if current instance is a subpath install. Needed for calculating relative path
+     * for symlink in setUpInstanceCoreLinks.
+     *
+     * @var bool
+     */
+    protected $isSubPathInstance;
+
+    /**
      * This class must be called in CLI environment as a security measure
      * against path disclosures and other stuff. Check this within
      * constructor to make sure this check can't be circumvented.
      */
-    public function __construct()
+    public function __construct(bool $isSubPathInstance = false)
     {
         // Ensure cli only as security measure
         if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
             die('This script supports command line usage only. Please check your command.');
         }
+        $this->isSubpathInstance = (bool)$isSubPathInstance;
     }
 
     /**
@@ -171,7 +180,7 @@ class Testbase
     public function setUpInstanceCoreLinks($instancePath): void
     {
         $linksToSet = [
-            '../../../../' => $instancePath . '/typo3_src',
+            '../../../../' . ($this->isSubpathInstance ? '../' : '' ) => $instancePath . '/typo3_src',
             'typo3_src/typo3' => $instancePath . '/typo3',
             'typo3_src/index.php' => $instancePath . '/index.php',
         ];
@@ -962,6 +971,16 @@ class Testbase
             $webRoot = getcwd();
         }
         return rtrim(strtr($webRoot, '\\', '/'), '/') . '/';
+    }
+
+    /**
+     * Returns if test case instance is subpath instance or not.
+     *
+     * @return bool
+     */
+    public function isSubPathInstance(): bool
+    {
+        return $this->isSubpathInstance;
     }
 
     /**


### PR DESCRIPTION
Add the option to create subpath instances. 

If static `::$createSubPathInstance` is set to true, the framework
will create a subpath instance instead.

The calculated class identifier will be reused to create the subfolder.

Created instance paths:

```
ROOT......: typo3temp/var/tests/functional-$identifier/
SUBPATH: typo3temp/var/tests/functional-$identifier/$identifier
```

Frontend requests providing correct scriptName for the request,
so the core can regonize that the request is comming as subpath
request.

Flag property is static, because it is needed for instance/database
creation which are static, and also run without testcase instance.
This is also needed, do get the information that it is a subpath
instance in dataProvider methods, because the are run before.

Tested with core master and core 10.4 branch



### Changes proposed in this pull request

1. Add property to flag if subPath instance is needed
2. Add static methods to retrieve subPath and if it is a subPath instance
3. FrontendRequest (old) and FrontendSubRequests (v11) use this and create proper request that it seems to be subPath requests (scriptName)


### Steps to test the solution

For all, use this commit/pr in vendor/typo3/testing-framework

Option 1 (simple/instance paths):

- create core functional test wit $createSubPathInstance = true
- add a simple test method to the functional tests, could be a simple one (asserting true = true or something like that)
- Clear temp folder -> `rm -rf typo3temp/var/tests`
- run only that functional testcase
- check typo3/temp/var/tests
=> there should be `functional-<identifier>/<identifier>/<files for instance`

Option 2 (advances)
- same as Option 1, but create a working request which calls the url with subfolder -> self::getInstancePathPrefix()

Option 3:
```
$ cd /tmp && rm -rf /tmp/t3-core && git clone git://github.com/typo3/typo3 /tmp/t3-core && cd /tmp/t3-core
$ git fetch https://review.typo3.org/Packages/TYPO3.CMS refs/changes/40/70640/10 && git cherry-pick FETCH_HEAD
$ Build/Scripts/runTests.sh -s composerInstall
$ rm -rf vendor/typo3/testing-framework && git clone git@github.com:sbuerk/testing-framework.git vendor/typo3/testing-framework
$ cd vendor/typo3/testing-framework && git checkout feature/subpath-instance-functional-tests && cd ../../..
$ Build/Scripts/runTests.sh -s composerInstall
$ Build/Scripts/runTests.sh -s functional
```

Have a look in the DataProvider / Tests for that functional testcase

### Results

Functional tests with subpath can be created and call to it works.

#### core master
- testing-framework unit: green
- Core unit tests => green
- Core functional tests => green
- Core acceptance tests => green
- Core unit tests with gerrit patch 70640(without fix in PageRouter) => green
- Core functional tests with gerrit patch 70640 (without fix in PageRouter) => red (expected)
- Core acceptance tests with gerrit patch 70640(without fix in PageRouter) => green
- Core unit tests with gerrit patch 70640(without fix in PageRouter) => green
- Core functional tests with gerrit patch 70640 (without fix in PageRouter) => green
- Core acceptance tests with gerrit patch 70640(without fix in PageRouter) => green

#### core branch 10.4

Testing framework for 10.4 is broken through #255 - had to revert it to test this pr.

With "reverted #255 " and my core patch:

Adjustments on core patch for v10:
- replace `executeFrontendSubRequest` with `executeFrontendRequest`
- adjust expected header of response (remove: `'X-Redirect-By' => ['TYPO3 Shortcut/Mountpoint'], `)
- not really green, as tests expecting ?type=0 to be removed after shortcut redirect, which is not done in v10 as it seems)

- testing-framework unit: green
- Core unit tests => green
- Core functional tests => green
- Core acceptance tests => green
- Core unit tests with gerrit patch 70640(without fix in PageRouter) => green
- Core functional tests with gerrit patch 70640 (without fix in PageRouter) => red (expected)
- Core acceptance tests with gerrit patch 70640(without fix in PageRouter) => green
- Core unit tests with gerrit patch 70640(without fix in PageRouter) => green
- Core functional tests with gerrit patch 70640 (without fix in PageRouter) => red (subrequests okay, but one test case with ?type=0 are not handled the same way in core between v10 / v11 / master )
- Core acceptance tests with gerrit patch 70640(without fix in PageRouter) => green

The feature is working in v10/master.

Fixes: #258 
