### PR TITLE
[TASK] Declare a PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
+    "php": ">= 7.2",
     "phpunit/phpunit": "^8.4 || ^9.0",
     "psr/container": "^1.0",
     "mikey179/vfsstream": "~1.6.8",


### PR DESCRIPTION
This helps IDEs like PhpStorm determing the appropriate language level
when opening the testing framework.

### Changes proposed in this pull request
- declare a PHP version dependency in the `composer.json`

### Steps to test the solution

1. Open the project in PHPStorm.
2. In the lower margin, check the PHP language level.
3. Check that is it "PHP: 7.2" instead of 7.1 or something else.