### PR TITLE
[TASK] Only truncate MySQL tables that have been touched

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -113,7 +113,7 @@ class DatabaseAccessor
             );
         }
 
-        $this->connection->truncate($tableName);
+        $this->truncate($tableName);
 
         $columnNames = array_keys($columns);
         foreach ($items as $item) {
@@ -122,6 +122,17 @@ class DatabaseAccessor
                 array_combine($columnNames, $item),
                 $columns
             );
+        }
+    }
+
+    private function truncate(string $tableName): void
+    {
+        $databaseName = $this->connection->getDatabase();
+        $query = "SHOW TABLE STATUS FROM $databaseName LIKE '$tableName'";
+        $tableData = $this->connection->executeQuery($query)->fetchAssociative();
+        $isChanged = ((int) $tableData['Auto_increment']) > 1 || ((int) $tableData['Rows']) > 0;
+        if ($isChanged) {
+            $this->connection->truncate($tableName);
         }
     }
 

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -16,7 +16,6 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot
  */
 
 use Doctrine\DBAL\FetchMode;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Connection;
@@ -114,7 +113,7 @@ class DatabaseAccessor
             );
         }
 
-        $this->truncate($tableName);
+        $this->connection->truncate($tableName);
 
         $columnNames = array_keys($columns);
         foreach ($items as $item) {
@@ -123,41 +122,6 @@ class DatabaseAccessor
                 array_combine($columnNames, $item),
                 $columns
             );
-        }
-    }
-
-    private function truncate(string $tableName): void
-    {
-        $platform = $this->connection->getDatabasePlatform();
-        if ($platform instanceof MySqlPlatform) {
-            $this->truncateForMySql($tableName);
-        } else {
-            // @todo: Optimize truncation for other platforms, too.
-            $this->connection->truncate($tableName);
-        }
-    }
-
-    /**
-     * Truncates a table for MySQL databases in an optimized way.
-     *
-     * This method tries to avoid the (expensive) truncate if possible:
-     * - If the table has an auto-increment value (which usually is the `uid` column`) and that value has changed,
-     *   this method will truncate the table.
-     * - If the table does not have an auto-increment value, but it has at least one row (where the exact number does
-     *   not matter), this method will truncate the table.
-     * - Otherwise, this method will skip the truncate. (For tables without an auto-increment value, this means that
-     *   the table either has not been touched at all beforehand, or that all records have already been deleted).
-     */
-    private function truncateForMySql(string $tableName): void
-    {
-        $databaseName = $this->connection->getDatabase();
-        $query = "SHOW TABLE STATUS FROM $databaseName LIKE '$tableName'";
-        $tableData = $this->connection->executeQuery($query)->fetchAssociative();
-        $hasChangedAutoIncrement = ((int)$tableData['Auto_increment']) > 1;
-        $hasAtLeastOneRow = ((int)$tableData['Rows']) > 0;
-        $isChanged = $hasChangedAutoIncrement || $hasAtLeastOneRow;
-        if ($isChanged) {
-            $this->connection->truncate($tableName);
         }
     }
 

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -620,11 +620,11 @@ class Testbase
     }
 
     /**
-     * Truncate all tables.
+     * Truncates all tables.
+     *
      * For functional tests.
      *
      * @throws Exception
-     * @return void
      */
     public function initializeTestDatabaseAndTruncateTables(): void
     {
@@ -634,28 +634,59 @@ class Testbase
 
         $platform = $connection->getDatabasePlatform();
         if ($platform instanceof MySqlPlatform) {
-            // Optimized truncation for mysql
-            // * Tables with auto increment (typically uid) > 0 - a row has been inserted, but may have been deleted
-            // * Tables that have rows
-            $databaseName = $connection->getDatabase();
-            $query = "SHOW TABLE STATUS FROM $databaseName";
-            // @todo: Switch to fetchAllAssociative() when core v10 compat is dropped.
-            $result = $connection->executeQuery($query)->fetchAll();
-            foreach ($result as $tableData) {
-                $isChanged = ((int)$tableData['Auto_increment']) > 1 || ((int)$tableData['Rows']) > 0;
-                if ($isChanged) {
-                    $tableName = $tableData['Name'];
-                    $connection->truncate($tableName);
-                    self::resetTableSequences($connection, $tableName);
-                }
-            }
+            $this->truncateAllTablesForMysql();
         } else {
             // @todo: Optimize truncation for other platforms, too.
-            $schemaManager = $connection->getSchemaManager();
-            foreach ($schemaManager->listTables() as $table) {
-                $connection->truncate($table->getName());
-                self::resetTableSequences($connection, $table->getName());
+            $this->truncateAllTablesForOtherDatabases();
+        }
+    }
+
+    /**
+     * Truncates all tables for MySQL databases in an optimized way.
+     *
+     * This method tries to avoid the (expensive) truncate if possible:
+     * - If the table has an auto-increment value (which usually is the `uid` column`) and that value has changed,
+     *   this method will truncate the table.
+     * - If the table does not have an auto-increment value, but it has at least one row (where the exact number does
+     *   not matter), this method will truncate the table.
+     * - Otherwise, this method will skip the truncate. (For tables without an auto-increment value, this means that
+     *   the table either has not been touched at all beforehand, or that all records have already been deleted).
+     */
+    private function truncateAllTablesForMysql(): void
+    {
+        /** @var Connection $connection */
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+
+        $databaseName = $connection->getDatabase();
+        $query = "SHOW TABLE STATUS FROM $databaseName";
+        // @todo: Switch to fetchAllAssociative() when core v10 compat is dropped.
+        $result = $connection->executeQuery($query)->fetchAll();
+        foreach ($result as $tableData) {
+            $hasChangedAutoIncrement = ((int)$tableData['Auto_increment']) > 1;
+            $hasAtLeastOneRow = ((int)$tableData['Rows']) > 0;
+            $isChanged = $hasChangedAutoIncrement || $hasAtLeastOneRow;
+            if ($isChanged) {
+                $tableName = $tableData['Name'];
+                $connection->truncate($tableName);
+                self::resetTableSequences($connection, $tableName);
             }
+        }
+    }
+
+    /**
+     * Truncates all tables without any database-specific optimizations.
+     */
+    private function truncateAllTablesForOtherDatabases(): void
+    {
+        /** @var Connection $connection */
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+
+        $schemaManager = $connection->getSchemaManager();
+        foreach ($schemaManager->listTables() as $table) {
+            $connection->truncate($table->getName());
+            self::resetTableSequences($connection, $table->getName());
         }
     }
 


### PR DESCRIPTION
"Touched" means "the auto increment has been changed (if there is
one)" or "there are some records in it".

This massively speeds up functional tests (as the table truncation
usually is the slowest part of the test setup).