### PR TITLE
[TASK] Only truncate touched MySQL tables using real row counts

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -620,23 +620,19 @@ class Testbase
     }
 
     /**
-     * Truncates all tables.
-     *
-     * For functional tests.
-     *
-     * @throws Exception
+     * Truncates all tables that need truncation.
+     * Used in functional tests for test #2 and further ones to not create
+     * the full database over and over again in between tests.
      */
     public function initializeTestDatabaseAndTruncateTables(): void
     {
         /** @var Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
-
         $platform = $connection->getDatabasePlatform();
         if ($platform instanceof MySqlPlatform) {
             $this->truncateAllTablesForMysql();
         } else {
-            // @todo: Optimize truncation for other platforms, too.
             $this->truncateAllTablesForOtherDatabases();
         }
     }
@@ -657,39 +653,35 @@ class Testbase
         /** @var Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
-
         $databaseName = $connection->getDatabase();
         $tableNames = $connection->getSchemaManager()->listTableNames();
 
-        // no tables to process;
-        if (!$tableNames) {
+        if (empty($tableNames)) {
+            // No tables to process
             return;
         }
 
-        // build subselect to get joinable table with information if table has at least one row.
+        // Build a sub select to get joinable table with information if table has at least one row.
         // This is needed because information_schema.table_rows is not reliable enough for innodb engine.
         // see https://dev.mysql.com/doc/mysql-infoschema-excerpt/5.7/en/information-schema-tables-table.html TABLE_ROWS
         $fromTableUnionSubSelectQuery = [];
         foreach($tableNames as $tableName) {
             $fromTableUnionSubSelectQuery[] = sprintf(
-                ' select %s as table_name, exists(select * from %s limit 1) as has_rows',
+                ' SELECT %s AS table_name, exists(SELECT * FROm %s LIMIT 1) AS has_rows',
                 $connection->quote($tableName),
                 $connection->quoteIdentifier($tableName)
             );
         }
         $fromTableUnionSubSelectQuery = implode(' UNION ', $fromTableUnionSubSelectQuery);
-
-        $query = sprintf(
-            "
-                select
-                    table_real_rowcounts.*,
-                    information_schema.tables.AUTO_INCREMENT as auto_increment
-                from (%s) as table_real_rowcounts
-                inner join information_schema.tables ON (
-                        information_schema.tables.TABLE_SCHEMA = %s
-                    and information_schema.tables.TABLE_NAME = table_real_rowcounts.table_name
-                )
-                ",
+        $query = sprintf("
+            SELECT
+                table_real_rowcounts.*,
+                information_schema.tables.AUTO_INCREMENT AS auto_increment
+            FROM (%s) AS table_real_rowcounts
+            INNER JOIN information_schema.tables ON (
+                information_schema.tables.TABLE_SCHEMA = %s
+                AND information_schema.tables.TABLE_NAME = table_real_rowcounts.table_name
+            )",
             $fromTableUnionSubSelectQuery,
             $connection->quote($databaseName)
         );


### PR DESCRIPTION
This is a follow up to mitigate reliable issues for mysql introduced by #262 .

Using information schema for row counts is not reliable enough for innodb tables, and for mysql 8.0 it fail hard. 

Using subquery as a joinable table building information if tables has at least one row mitigates this issue.
