### PR TITLE
[TASK] Efficient sqlite db handling in functional tests

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -624,8 +624,15 @@ class Testbase
      * Used in functional tests for test #2 and further ones to not create
      * the full database over and over again in between tests.
      */
-    public function initializeTestDatabaseAndTruncateTables(): void
+    public function initializeTestDatabaseAndTruncateTables(string $dbPathSqlite = '', string $dbPathSqliteEmpty = ''): void
     {
+        $driver = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['driver'];
+        if ($driver === 'pdo_sqlite' && $dbPathSqlite && $dbPathSqliteEmpty) {
+            // Optimization for sqlite: Just copy the "empty" file created by first test.
+            copy($dbPathSqliteEmpty, $dbPathSqlite);
+            return;
+        }
+
         /** @var Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);


### PR DESCRIPTION
sqlite databases are no longer created in
typo3temp/var/tests/functional-"hash"/test.sqlite,
but instead in a parallel directory
typo3temp/var/tests/functional-sqlite-dbs/test_"hash".sqlite.

This allows defining this directory as tmpfs (eg. in runTests.sh),
which significantly improves functional test performance.

Additionally, when the first test created the database schema,
the db file is copied as test_"hash".empty.sqlite. Instead of
truncating the database in consecutive tests of the test case,
the "empty" file is simply copied around to avoid truncate queries.