### PR TITLE
[BUGFIX] Restore post-processing of tables after a truncate

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -701,6 +701,7 @@ class Testbase
             if ($isChanged) {
                 $tableName = $tableData['table_name'];
                 $connection->truncate($tableName);
+                self::resetTableSequences($connection, $tableName);
             }
         }
     }


### PR DESCRIPTION
This commit restores a line that accidentally was removed in #264.