### PR TITLE
[BUGFIX] Create PackageArtifact if needed

### DIFF
--- a/Classes/Core/Functional/Framework/Package/PackageArtifactBuilder.php
+++ b/Classes/Core/Functional/Framework/Package/PackageArtifactBuilder.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Core\Functional\Framework\Package;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Package\Cache\PackageCacheEntry;
+use TYPO3\CMS\Core\Package\Package;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\TestingFramework\Core\Exception;
+
+/**
+ * Very basic artifact builder, which does not take ordering by dependency into account at all
+ */
+class PackageArtifactBuilder
+{
+    /**
+     * @var string
+     */
+    private $instancePath;
+
+    public function __construct(string $instancePath)
+    {
+        $this->instancePath = $instancePath;
+    }
+
+    public function writePackageArtifact($packageStatesConfiguration): void
+    {
+        $packageManager = new PackageManager(new DependencyOrderingService(), '', '');
+        $composerNameToPackageKeyMap = [];
+        $packageAliasMap = [];
+        $packages = [];
+
+        foreach ($packageStatesConfiguration['packages'] as $extensionKey => $stateConfig) {
+            $packagePath = $this->instancePath . '/' . $stateConfig['packagePath'];
+            $package = new Package($packageManager, $extensionKey, $packagePath);
+            $composerNameToPackageKeyMap[$package->getValueFromComposerManifest('name')] = $extensionKey;
+            $packages[$extensionKey] = $package;
+            foreach ($package->getPackageReplacementKeys() as $packageToReplace => $versionConstraint) {
+                $packageAliasMap[$packageToReplace] = $extensionKey;
+            }
+        }
+
+        $cacheEntry = PackageCacheEntry::fromPackageData(
+            $packageStatesConfiguration,
+            $packageAliasMap,
+            $composerNameToPackageKeyMap,
+            $packages
+        )->withIdentifier(md5('typo3-testing-' . $this->instancePath));
+
+        $buildDir = $this->instancePath . '/typo3temp/var/build';
+        $this->ensureDirectoryExists($buildDir);
+
+        $result = file_put_contents(
+            $buildDir . '/PackageArtifact.php',
+            '<?php' . PHP_EOL . 'return ' . PHP_EOL . $cacheEntry->serialize() . ';'
+        );
+
+        if (!$result) {
+            throw new Exception('Can not write PackageArtifact', 1630268883);
+        }
+    }
+
+    private function ensureDirectoryExists(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+    }
+}

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -23,14 +23,15 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Psr\Container\ContainerInterface;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Schema\SchemaMigrator;
 use TYPO3\CMS\Core\Database\Schema\SqlReader;
+use TYPO3\CMS\Core\Package\Cache\PackageCacheEntry;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Package\PackageArtifactBuilder;
 
 /**
  * This is a helper class used by unit, functional and acceptance test
@@ -444,9 +445,9 @@ class Testbase
     }
 
     /**
-     * Compile typo3conf/PackageStates.php containing default packages like core,
-     * a test specific list of additional core extensions, and a list of
-     * test extensions.
+     * Compile typo3conf/PackageStates.php or var/build/PackageArtifact.php
+     * containing default packages like core, a test specific list of additional core extensions,
+     * and a list of test extensions.
      * For functional and acceptance tests.
      *
      * @param string $instancePath Absolute path to test instance
@@ -498,6 +499,11 @@ class Testbase
             ];
         }
 
+        if ($this->isPackageArtifactNeeded()) {
+            (new PackageArtifactBuilder($instancePath))->writePackageArtifact($packageStates);
+            return;
+        }
+
         $result = file_put_contents(
             $instancePath . '/typo3conf/PackageStates.php',
             '<?php' . chr(10) .
@@ -511,6 +517,18 @@ class Testbase
         if (!$result) {
             throw new Exception('Can not write PackageStates', 1381612729);
         }
+    }
+
+    /**
+     * TYPO3 11 comes with a different way package information is stored in Composer mode.
+     * Since testing e.g. extension results in the installation being marked as Composer managed,
+     * we need to create the package artifact to make the PackageManager happy
+     *
+     * @return bool
+     */
+    private function isPackageArtifactNeeded(): bool
+    {
+        return defined('TYPO3_COMPOSER_MODE') && class_exists(PackageCacheEntry::class);
     }
 
     /**
@@ -578,24 +596,6 @@ class Testbase
 
         $classLoader = require __DIR__ . '/../../../../autoload.php';
         SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);
-
-        // Functional and acceptance test environments are non-composer instances. When
-        // executing functional tests from a composer enabled instance
-        // (eg. tests of ext:styleguide), the "isComposerMode" depends on constant TYPO3_COMPOSER_MODE
-        // which may be set to true already in this context. We can't change this currently,
-        // so the solution for now is to re-init Environment and force composer mode false.
-        Environment::initialize(
-            Environment::getContext(),
-            Environment::isCli(),
-            false,
-            Environment::getProjectPath(),
-            Environment::getPublicPath(),
-            Environment::getVarPath(),
-            Environment::getConfigPath(),
-            Environment::getCurrentScript(),
-            Environment::isWindows() ? 'WINDOWS' : 'UNIX'
-        );
-
         $container = Bootstrap::init($classLoader);
         // Make sure output is not buffered, so command-line output can take place and
         // phpunit does not whine about changed output bufferings in tests.


### PR DESCRIPTION
Instead of manually disabling Composer mode by
overriding the Environment, create a
PackageArtifact for the desired packages if required
instead of the PackageStates.php file.