### PR TITLE
[TASK] Add class-string annotation

### DIFF
--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -28,7 +28,8 @@ abstract class BaseTestCase extends TestCase
     /**
      * Creates a mock object which allows for calling protected methods and access of protected properties.
      *
-     * @param string $originalClassName name of class to create the mock object of, must not be empty
+     * @template T
+     * @param class-string<T> $originalClassName name of class to create the mock object of, must not be empty
      * @param string[]|null $methods name of the methods to mock, null for "mock no methods"
      * @param array $arguments arguments to pass to constructor
      * @param string $mockClassName the class name to use for the mock class
@@ -36,7 +37,7 @@ abstract class BaseTestCase extends TestCase
      * @param bool $callOriginalClone whether to call the __clone method
      * @param bool $callAutoload whether to call any autoload function
      *
-     * @return MockObject|AccessibleObjectInterface
+     * @return MockObject|AccessibleObjectInterface&T
      *         a mock of $originalClassName with access methods added
      *
      * @throws \InvalidArgumentException
@@ -74,14 +75,15 @@ abstract class BaseTestCase extends TestCase
      * of protected properties. Concrete methods to mock can be specified with
      * the last parameter
      *
-     * @param string $originalClassName Full qualified name of the original class
+     * @template T
+     * @param class-string<T> $originalClassName Full qualified name of the original class
      * @param array $arguments
      * @param string $mockClassName
      * @param bool $callOriginalConstructor
      * @param bool $callOriginalClone
      * @param bool $callAutoload
      * @param array $mockedMethods
-     * @return MockObject|AccessibleObjectInterface
+     * @return MockObject|AccessibleObjectInterface&T
      *
      * @throws \InvalidArgumentException
      *


### PR DESCRIPTION
Similar to a pending core patch [1], the `$originalClassName` parameters of `getAccessibleMock` and `getAccessibleMockForAbstractClass` are annotated as `class-string` and both methods return an object intersecting the incoming class name to enable code completion support in major IDEs.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/70872