### PR TITLE
[BUGFIX] Reset sequence values after importing snapshotted data

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Connection;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder as TYPO3QueryBuilder;
+use TYPO3\TestingFramework\Core\Testbase;
 
 /**
  * @internal Use the helper methods of FunctionalTestCase
@@ -146,6 +147,10 @@ class DatabaseAccessor
                 );
             }
         }
+        // reset table sequences after inserting snapshot data. Dataset contains primary key column data which
+        // leads to out-of-sync sequence values for some dbms platforms, thus resetting sequence values
+        // is needed.
+        Testbase::resetTableSequences($this->connection, $tableName);
     }
 
     /**


### PR DESCRIPTION
Importing snapshotted data through DatabaseSnapshot/DatabaseAccessor
classes records with fixed PK field values (uid) are inserted. For some dbms
platforms this leads to invalid squence values, which errors on further inserts
executed omitting the pk field value (autoincrement insert behaviour).

Thus after inserting the snapshot dataset for a table, reset of table sequence
value is done now to mitigate this issues.

As result one core patch disabled for postgres could be activated again,
which stumpeled into this scenario.

Related core test:

typo3/sysext/frontend/Tests/Functional/SiteHandling/MountPointTest.php
mountPointPagesShowContentAsConfigured


### Changes proposed in this pull request

To mitigate the duplicateKey erros reseting sequences after deleting records
solves the issue. 

As such adding existing `Testbase::resetSequences()` to after deletion in `setupFrontendRootPage` is proposed.

### Steps to test the solution

See patch https://review.typo3.org/c/Packages/TYPO3.CMS/+/70897

Simply comment out  `Testbase::resetSequences()` in `FunctionalTestCase::setupFrontendRootPage()`

### Results

Using See patch https://review.typo3.org/c/Packages/TYPO3.CMS/+/70897

```
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d postgres -k 9.6
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d postgres -k 10
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d postgres -k 11
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d postgres -k 12
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d postgres -k 13
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 8.0 -d postgres -k 9.6
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 8.0 -d postgres -k 10
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 8.0 -d postgres -k 11
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 8.0 -d postgres -k 12
```
=> green

```
$ Build/Scripts/runTests.sh -s functional -p 8.0 -d postgres -k 13
```
=> green


Fixes: #274 
