### PR TITLE
Fix PHP 8.1 compatibility.

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -974,10 +974,13 @@ abstract class FunctionalTestCase extends BaseTestCase
         // carry that information.
         $_SERVER['X_TYPO3_TESTING_FRAMEWORK']['context'] = $context;
         $_SERVER['X_TYPO3_TESTING_FRAMEWORK']['request'] = $request;
-        ArrayUtility::mergeRecursiveWithOverrule(
-            $GLOBALS,
-            $context->getGlobalSettings() ?? []
-        );
+        // The $GLOBALS array may not be passed by reference, but its elements may be.
+        $override = $context->getGlobalSettings() ?? [];
+        foreach ($GLOBALS as $k => $v) {
+            if (isset($override[$k])) {
+                ArrayUtility::mergeRecursiveWithOverrule($GLOBALS[$k], $override[$k]);
+            }
+        }
         $result = [
             'status' => 'failure',
             'content' => null,


### PR DESCRIPTION
### Changes proposed in this pull request

Since PHP 8.1, it's no longer possible to pass `$GLOBALS` by reference.  cf: https://wiki.php.net/rfc/restrict_globals_usage

The functional tests, however, do that on every single subrequest, which causes... a few thousand failures.  Fortunately there's an easy workaround.

(I'm not certain if this fixes all PHP 8.1 issues, but it is certainly the lion's share of them that can be found so far.)

Fixes: #<!-- Issue ID -->
