### PR TITLE
[BUGFIX] Avoid passing $GLOBALS by reference for executeFrontendRequest

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -170,10 +170,13 @@ class RequestBootstrap
             if (Environment::isComposerMode() && ClassLoadingInformation::isClassLoadingInformationAvailable()) {
                 ClassLoadingInformation::registerClassLoadingInformation();
             }
-            ArrayUtility::mergeRecursiveWithOverrule(
-                $GLOBALS,
-                $this->context->getGlobalSettings() ?? []
-            );
+            // The $GLOBALS array may not be passed by reference, but its elements may be.
+            $override = $this->context->getGlobalSettings() ?? [];
+            foreach ($GLOBALS as $k => $v) {
+                if (isset($override[$k])) {
+                    ArrayUtility::mergeRecursiveWithOverrule($GLOBALS[$k], $override[$k]);
+                }
+            }
             $container->get(Application::class)->run();
             $result['status'] = 'success';
             $result['content'] = static::getContent();


### PR DESCRIPTION
Passing $GLOBALS by reference is not supported since PHP 8.1.

This was fixed for v11 subRequests through #276, but exists for
executeFrontendRequest() also.

So far core master should use new subRequests, this should not be an issue
for core itself. Tests for v11+ must be fixed through as core patch moving
them to new subRequest testing.

Besides this extensions could and are using the testing-framework also for
testing it could be that moving forward to v11, but tests are still on
executeFrontedRequest() calls and not changed to executeFrontendSubRequests(),
and testing on php8.1. Thus this is fixed also, even if executeFrontend() will
be removed in the future from the testing-framework.

Fixes: #277
