### PR TITLE
Add phpunit configuration option convertDeprecationsToExceptions

### DIFF
--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -18,6 +18,7 @@
     backupGlobals="true"
     bootstrap="UnitTestsBootstrap.php"
     colors="true"
+    convertDeprecationsToExceptions="true"
     convertErrorsToExceptions="true"
     convertWarningsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
phpunit has changed his behaviour to not throw user depreactions as exceptions per default,
on which the core and eventually extension testings realy on, as it was the default.

To ensure the expected behavour we add convertDeprecationsToExceptions="true"
to the boilerplate *.xml for unittest runs.

Fixes: #282
