### PR TITLE
[FEATURE] Add subpath instance functional testing

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -46,16 +46,25 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Package\PackageArtifactBuil
 class Testbase
 {
     /**
+     * Flag if current instance is a subpath install. Needed for calculating relative path
+     * for symlink in setUpInstanceCoreLinks.
+     *
+     * @var bool
+     */
+    protected $isSubPathInstance;
+
+    /**
      * This class must be called in CLI environment as a security measure
      * against path disclosures and other stuff. Check this within
      * constructor to make sure this check can't be circumvented.
      */
-    public function __construct()
+    public function __construct(bool $isSubPathInstance = false)
     {
         // Ensure cli only as security measure
         if (PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg') {
             die('This script supports command line usage only. Please check your command.');
         }
+        $this->isSubpathInstance = (bool)$isSubPathInstance;
     }
 
     /**
@@ -172,7 +181,7 @@ class Testbase
     public function setUpInstanceCoreLinks($instancePath): void
     {
         $linksToSet = [
-            '../../../../' => $instancePath . '/typo3_src',
+            '../../../../' . ($this->isSubpathInstance ? '../' : '' ) => $instancePath . '/typo3_src',
             'typo3_src/typo3' => $instancePath . '/typo3',
             'typo3_src/index.php' => $instancePath . '/index.php',
         ];
@@ -962,6 +971,16 @@ class Testbase
             $webRoot = getcwd();
         }
         return rtrim(strtr($webRoot, '\\', '/'), '/') . '/';
+    }
+
+    /**
+     * Returns if test case instance is subpath instance or not.
+     *
+     * @return bool
+     */
+    public function isSubPathInstance(): bool
+    {
+        return $this->isSubpathInstance;
     }
 
     /**


### PR DESCRIPTION
Add the option to create subpath instances. 

If  `static::$createSubPathInstance` is set to true, the framework
will create a subpath instance instead.

The calculated class identifier will be reused to create the subfolder.

Created instance paths:

```
ROOT......: typo3temp/var/tests/functional-$identifier/
SUBPATH...: typo3temp/var/tests/functional-$identifier/$identifier
```

Frontend requests providing correct scriptName for the request,
so the core can regonize that the request is comming as subpath
request.

Flag property is static, because it is needed for instance/database
creation which are static, and also run without testcase instance.
This is also needed, do get the information that it is a subpath
instance in dataProvider methods, because the are run before.

Tested with core master and core 10.4 branch



### Changes proposed in this pull request

1. Add property to flag if subPath instance is needed
2. Add static methods to retrieve subPath and if it is a subPath instance
3. FrontendRequest (old) and FrontendSubRequests (v11) use this and create proper request that it seems to be subPath requests (scriptName)


### Steps to test the solution

Theres a core patch which has a subinstance test for example:
[70640: [WIP][BUGFIX] Ensure domain.tls/(|subpath)/index.php works](https://review.typo3.org/c/Packages/TYPO3.CMS/+/70640)

```
$ git fetch https://review.typo3.org/Packages/TYPO3.CMS refs/changes/40/70640/13 \
   && git cherry-pick FETCH_HEAD
$ Build/Scripts/runTests.sh -s composerInstall
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d sqlite \
   typo3/sysext/frontend/Tests/Functional/SiteHandling/SiteRequestSubInstanceTest.php
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d sqlite \
   typo3/sysext/frontend/Tests/Functional/SiteHandling/SlugSiteRequestSubInstanceTest.php
$ Build/Scripts/runTests.sh -s functional -p 7.4 -d sqlite \
   typo3/sysext/frontend/Tests/Functional/SiteHandling/EidRequestSubInstanceTest.php   
```

Have a look in the DataProvider / Tests for that functional testcase

### Results

See core patch, pipeline is green. (nightly not working because of fork )

Functional tests with subpath can be created and call to it works.

The feature is working in v10/master.

Fixes: #258 
