### PR TITLE
[TASK] Set instancePath as docroot for createServerRequest

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -492,7 +492,7 @@ abstract class FunctionalTestCase extends BaseTestCase
     private function createServerRequest(string $url, string $method = 'GET'): ServerRequestInterface
     {
         $requestUrlParts = parse_url($url);
-        $docRoot = '';
+        $docRoot = $this->instancePath;
         $serverParams = [
             'DOCUMENT_ROOT' => $docRoot,
             'HTTP_USER_AGENT' => 'TYPO3 Functional Test Request',


### PR DESCRIPTION
Use instancePath as docroot for server request creation, used to add cookie information as beuser initialisation for tests.