### PR TITLE
[TASK] Inject the request for frontend user auth

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
@@ -59,7 +59,7 @@ class FrontendUserHandler implements MiddlewareInterface
             $frontendUserAuthentication->user = $frontendUserAuthentication->fetchUserSession();
             // v11+
             if (method_exists($frontendUserAuthentication, 'createUserAspect')) {
-                $frontendUserAuthentication->fetchGroupData();
+                $frontendUserAuthentication->fetchGroupData($request);
                 $userAspect = $frontendUserAuthentication->createUserAspect();
                 GeneralUtility::makeInstance(Context::class)->setAspect('frontend.user', $userAspect);
             } else {


### PR DESCRIPTION
With change https://github.com/TYPO3/typo3/commit/0c455114f5e8b5a1fff29c128125d923597988a7
it is now possible to inject the $request object,
which should be used in TF as well to ensure
forward-compatibility with v12.