### PR TITLE
[BUGFIX] Functional test path checks

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -85,7 +85,7 @@ class Testbase
             define('ORIGINAL_ROOT', $this->getWebRoot());
         }
 
-        if (!file_exists(ORIGINAL_ROOT . 'typo3/sysext/core/bin/typo3')) {
+        if (!file_exists(ORIGINAL_ROOT . 'index.php')) {
             $this->exitWithMessage('Unable to determine path to entry script. Please check your path or set an environment variable \'TYPO3_PATH_ROOT\' to your root path.');
         }
     }


### PR DESCRIPTION
typo3/sysext/core/bin/typo3 is no longer written
since https://review.typo3.org/c/Packages/TYPO3.CMS/+/71407
when testing-framework is used for extensions.

The patch adapts the path check to frontend index.php.
