### PR TITLE
[TASK] Add missing setContentObjectRenderer methods

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/Collector.php
+++ b/Classes/Core/Functional/Framework/Frontend/Collector.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -201,5 +202,16 @@ class Collector implements SingletonInterface
         $this->structure = [];
         $this->structurePaths = [];
         $this->records = [];
+    }
+
+    /**
+     * This is called from UserContentObject via ContentObjectRenderer->callUserFunction()
+     * for nested menu items - those use a USER content object for getDataAsJson().
+     *
+     * @param ContentObjectRenderer $cObj
+     */
+    public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
+    {
+        $this->cObj = $cObj;
     }
 }

--- a/Classes/Core/Functional/Framework/Frontend/Renderer.php
+++ b/Classes/Core/Functional/Framework/Frontend/Renderer.php
@@ -158,4 +158,15 @@ class Renderer implements SingletonInterface
     {
         return GeneralUtility::makeInstance(Parser::class);
     }
+
+    /**
+     * This is called from UserContentObject via ContentObjectRenderer->callUserFunction()
+     * for nested menu items - those use a USER content object for getDataAsJson().
+     *
+     * @param ContentObjectRenderer $cObj
+     */
+    public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
+    {
+        $this->cObj = $cObj;
+    }
 }


### PR DESCRIPTION
https://review.typo3.org/c/Packages/TYPO3.CMS/+/70717 deprecates 
the public `$cObj` and starts calling `setContentObjectRenderer()` if existing, 
otherwise triggering user deprecation messages.

Testing Framework provides a content object which missing this new method
and as such generating a lot of deprecation messages.

This commit adds this method to classes missing them to mitigate this issue,
leaving `$cObj` as public property to be backwards compatible with testing 
core v10.
