### PR TITLE
[TASK] Avoid call_user_func()

### DIFF
--- a/Classes/Core/AccessibleProxyTrait.php
+++ b/Classes/Core/AccessibleProxyTrait.php
@@ -24,7 +24,7 @@ trait AccessibleProxyTrait
         }
         $args = func_get_args();
         array_shift($args);
-        return call_user_func_array([$this, $methodName], $args);
+        return $this->$methodName(...$args);
     }
 
     public function _set($propertyName, $value)

--- a/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
+++ b/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
@@ -53,13 +53,13 @@ trait AssignablePropertyTrait
         $data = array_filter($data);
         foreach ($data as $name => $value) {
             $methodName = 'with' . ucfirst($name);
-            if (!method_exists($this, $methodName)) {
+            if (!method_exists($target, $methodName)) {
                 throw new \RuntimeException(
                     sprintf('Method "%s" not found', $methodName),
                     1533632522
                 );
             }
-            $target = call_user_func([$target, $methodName], $value);
+            $target = $target->$methodName($value);
         }
         return $target;
     }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1396,7 +1396,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         if ($snapshot->exists()) {
             $snapshot->restore($accessor, $connection);
         } else {
-            call_user_func($callback);
+            $callback();
             $snapshot->create($accessor, $connection);
         }
     }

--- a/Resources/Core/Build/FunctionalTestsBootstrap.php
+++ b/Resources/Core/Build/FunctionalTestsBootstrap.php
@@ -22,9 +22,9 @@
  * This file is defined in FunctionalTests.xml and called by phpunit
  * before instantiating the test suites.
  */
-call_user_func(function () {
+(static function () {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
     $testbase->defineOriginalRootPath();
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
-});
+})();

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -26,7 +26,7 @@
  * according script within TYPO3 core's Build/Scripts directory and
  * adapt to extensions needs.
  */
-call_user_func(function () {
+(static function () {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
 
     // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
@@ -81,4 +81,4 @@ call_user_func(function () {
     $testbase->dumpClassLoadingInformation();
 
     \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
-});
+})();


### PR DESCRIPTION
This patch is a micro optimization and safes up to 70 percent execution
time per call by avoiding the usage of call_user_func().