### PR TITLE
Fix typo

### DIFF
--- a/Classes/Composer/ExtensionTestEnvironment.php
+++ b/Classes/Composer/ExtensionTestEnvironment.php
@@ -31,7 +31,7 @@ use Composer\Script\Event;
  *     "post-autoload-dump": [
  *       "@prepare-extension-test-environment"
  *     ],
- *     "prepare-extension-test-structure": [
+ *     "prepare-extension-test-environment": [
  *       "TYPO3\TestingFramework\Composer\ExtensionTestEnvironment::prepare"
  *     ]
  *   },


### PR DESCRIPTION
I think it should be the same name as the one used in `post-autoload-dump`.