### PR TITLE
[BUGFIX] Properly annotate variable type of coreExtensionsToLoad

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -115,7 +115,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      * A default list of core extensions is always loaded.
      *
      * @see FunctionalTestCaseUtility $defaultActivatedCoreExtensions
-     * @var array
+     * @var array<int, string>
      */
     protected $coreExtensionsToLoad = [];
 


### PR DESCRIPTION
### Changes proposed in this pull request

Fix PHPDoc annotation of property type.

### Steps to test the solution

1. Reproduce accordingly to issue https://github.com/TYPO3/testing-framework/issues/298
2. Clear cache of PHPStan, e.g. in `/tmp/phpstan`
3. Apply change and try to reproduce again, no errors should be shown this time.

### Results

I don't have that setup.

Fixes: #298