### PR TITLE
[BUGFIX] Raise mikey179/vfsstream:"~1.6.10"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "php": ">= 7.2",
     "phpunit/phpunit": "^8.4 || ^9.0",
     "psr/container": "^1.0",
-    "mikey179/vfsstream": "~1.6.8",
+    "mikey179/vfsstream": "~1.6.10",
     "typo3fluid/fluid": "^2.5|^3",
     "typo3/cms-core": "10.*.*@dev || 11.*.*@dev",
     "typo3/cms-backend": "10.*.*@dev || 11.*.*@dev",


### PR DESCRIPTION
We need to raise this mikey179/vfsstream:~1.6.10 to avoid E_DEPRECATED warnings
in core testing with PHP 8.1 and E_ALL activated in nightly composerMin
test executions.