### PR TITLE
[!!!][TASK] Don't define TYPO3_MODE anymore

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -232,7 +232,6 @@ abstract class BackendEnvironment extends Extension
         $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
-        $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
         $testbase->removeOldInstanceIfExists($instancePath);

--- a/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
@@ -93,7 +93,6 @@ class InstallMysqlCoreEnvironment extends Extension
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
-        $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
         // Drop db from a previous run if exists

--- a/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
@@ -98,7 +98,6 @@ class InstallPostgresqlCoreEnvironment extends Extension
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
-        $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
         // Drop db from a previous run if exists

--- a/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallSqliteCoreEnvironment.php
@@ -50,7 +50,6 @@ class InstallSqliteCoreEnvironment extends Extension
         $testbase->removeOldInstanceIfExists($instancePath);
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
-        $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
         $testbase->createDirectory($instancePath);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -279,7 +279,6 @@ abstract class FunctionalTestCase extends BaseTestCase
         putenv('TYPO3_PATH_APP=' . $this->instancePath);
 
         $testbase = new Testbase();
-        $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
         $isFirstTest = false;

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -89,19 +89,6 @@ class Testbase
     }
 
     /**
-     * Define TYPO3_MODE to BE
-     *
-     * @return void
-     * @deprecated Will be dropped with 7.x major version.
-     */
-    public function defineTypo3ModeBe(): void
-    {
-        if (!defined('TYPO3_MODE')) {
-            define('TYPO3_MODE', 'BE');
-        }
-    }
-
-    /**
      * Sets the environment variable TYPO3_CONTEXT to testing.
      * Needs to be called after each Functional executing a frontend request
      *


### PR DESCRIPTION
Constant TYPO3_MODE has been deprecated with core v11
and removed in v12. The patch drops it from functional
and acceptance test setups together with method
Testbase->defineTypo3ModeBe().