### PR TITLE
[BUGFIX] Preserve locale in FrameworkState

### DIFF
--- a/Classes/Core/Functional/Framework/FrameworkState.php
+++ b/Classes/Core/Functional/Framework/FrameworkState.php
@@ -40,6 +40,7 @@ class FrameworkState
     public static function push()
     {
         $state = [];
+        $state['locale'] = setlocale(LC_ALL, 0);
         $state['globals-server'] = $GLOBALS['_SERVER'];
         $state['globals-beUser'] = $GLOBALS['BE_USER'] ?? null;
         // InternalRequestContext->withGlobalSettings() may override globals, especially TYPO3_CONF_VARS
@@ -105,6 +106,7 @@ class FrameworkState
     {
         $state = array_pop(self::$state);
 
+        setlocale(LC_ALL, $state['locale']);
         $GLOBALS['_SERVER'] = $state['globals-server'];
         if ($state['globals-beUser'] !== null) {
             $GLOBALS['BE_USER'] = $state['globals-beUser'];


### PR DESCRIPTION
### Changes proposed in this pull request

`locale` state shall be preserved in `FrameworkState` to avoid side-effects of simulating a frontend request in the very same PHP process.

### Steps to test the solution

Without this change running `\TYPO3\CMS\Frontend\Tests\Functional\SiteHandling\SiteRequestTest` fails - if locale `zh_CN.UTF-8` is not present in the corresponding test infrastructure.

---

### References

* https://bugs.php.net/bug.php?id=52923