### PR TITLE
[TASK] Add support for acceptance sqlite test execution

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -249,12 +249,21 @@ abstract class BackendEnvironment extends Extension
         $testbase->linkTestExtensionsToInstance($instancePath, $testExtensionsToLoad);
         $testbase->linkPathsInTestInstance($instancePath, $this->config['pathsToLinkInTestInstance']);
         $localConfiguration['DB'] = $testbase->getOriginalDatabaseSettingsFromEnvironmentOrLocalConfiguration($this->config);
-        $originalDatabaseName = $localConfiguration['DB']['Connections']['Default']['dbname'];
-        // Append the unique identifier to the base database name to end up with a single database per test case
-        $localConfiguration['DB']['Connections']['Default']['dbname'] = $originalDatabaseName . '_at';
-
-        $this->output->debug('Database Connection: ' . json_encode($localConfiguration['DB']));
-        $testbase->testDatabaseNameIsNotTooLong($originalDatabaseName, $localConfiguration);
+        $dbDriver = $localConfiguration['DB']['Connections']['Default']['driver'];
+        $originalDatabaseName = '';
+        if ($dbDriver !== 'pdo_sqlite') {
+            $this->output->debug('Database Connection: ' . json_encode($localConfiguration['DB']));
+            $originalDatabaseName = $localConfiguration['DB']['Connections']['Default']['dbname'];
+            // Append the unique identifier to the base database name to end up with a single database per test case
+            $localConfiguration['DB']['Connections']['Default']['dbname'] = $originalDatabaseName . '_at';
+            $testbase->testDatabaseNameIsNotTooLong($originalDatabaseName, $localConfiguration);
+        } else {
+            // sqlite dbs of all tests are stored in a dir parallel to instance roots. Allows defining this path as tmpfs.
+            $this->output->debug('Database Connection: ' . json_encode($localConfiguration['DB']));
+            $testbase->createDirectory(dirname($instancePath) . '/acceptance-sqlite-dbs');
+            $dbPathSqlite = dirname($instancePath) . '/acceptance-sqlite-dbs/test_acceptance.sqlite';
+            $localConfiguration['DB']['Connections']['Default']['path'] = $dbPathSqlite;
+        }
         // Set some hard coded base settings for the instance. Those could be overruled by
         // $this->config['configurationToUseInTestInstance ']if needed again.
         $localConfiguration['BE']['debug'] = true;
@@ -275,7 +284,11 @@ abstract class BackendEnvironment extends Extension
         $testbase->setUpPackageStates($instancePath, [], $coreExtensionsToLoad, $testExtensionsToLoad, $frameworkExtensionPaths);
         $this->output->debug('Loaded Extensions: ' . json_encode(array_merge($coreExtensionsToLoad, $testExtensionsToLoad)));
         $testbase->setUpBasicTypo3Bootstrap($instancePath);
-        $testbase->setUpTestDatabase($localConfiguration['DB']['Connections']['Default']['dbname'], $originalDatabaseName);
+        if ($dbDriver !== 'pdo_sqlite') {
+            $testbase->setUpTestDatabase($localConfiguration['DB']['Connections']['Default']['dbname'], $originalDatabaseName);
+        } else {
+            $testbase->setUpTestDatabase($localConfiguration['DB']['Connections']['Default']['path'], $originalDatabaseName);
+        }
         $testbase->loadExtensionTables();
         $testbase->createDatabaseStructure();
 


### PR DESCRIPTION
This change is needed to add support for acceptance testing
with sqlite dbms backend, thus give us the ability to start
with it in Typo3 Core Development and for typo3/styleguide.

### Changes proposed in this pull request

1. Add switche based sqlite configuration based on database driver to acceptance enviroment

### Steps to test the solution

1. See core-patch: https://review.typo3.org/c/Packages/TYPO3.CMS/+/72446

The core patch enables sqlite acceptance testing through runTests.sh.
This is currently red, because there are issues in styleguide for sqlite,
so not all needed data is imported - or not correctly.

### Results

This change itself is self-containing and do not break currently implementations,
but gives us the ability to get the other pieces working (styleguide), so we can
fix and run core sqlite acceptance tests.

Merging this pull-requets would make it easier to start with this work.
