### PR TITLE
[BUGFIX] Avoid deprecated doctrine/dbal exception and method

### DIFF
--- a/Classes/Core/DatabaseConnectionWrapper.php
+++ b/Classes/Core/DatabaseConnectionWrapper.php
@@ -15,7 +15,7 @@ namespace TYPO3\TestingFramework\Core;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use TYPO3\CMS\Core\Database\Connection;
 

--- a/Classes/Core/DatabaseConnectionWrapper.php
+++ b/Classes/Core/DatabaseConnectionWrapper.php
@@ -111,7 +111,7 @@ class DatabaseConnectionWrapper extends Connection
                 $tableName,
                 $enable ? 'ON' : 'OFF'
             );
-            $this->exec($statement);
+            $this->executeStatement($statement);
             return true;
         } catch (DBALException $e) {
             // Some tables like sys_refindex don't have an auto-increment uid field and thus no

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -585,7 +585,7 @@ abstract class FunctionalTestCase extends BaseTestCase
                     $sqlServerIdentityDisabled = false;
                     if ($platform instanceof SQLServerPlatform) {
                         try {
-                            $connection->exec('SET IDENTITY_INSERT ' . $tableName . ' ON');
+                            $connection->executeStatement('SET IDENTITY_INSERT ' . $tableName . ' ON');
                             $sqlServerIdentityDisabled = true;
                         } catch (DBALException $e) {
                             // Some tables like sys_refindex don't have an auto-increment uid field and thus no
@@ -607,7 +607,7 @@ abstract class FunctionalTestCase extends BaseTestCase
 
                     if ($sqlServerIdentityDisabled) {
                         // Reset identity if it has been changed
-                        $connection->exec('SET IDENTITY_INSERT ' . $tableName . ' OFF');
+                        $connection->executeStatement('SET IDENTITY_INSERT ' . $tableName . ' OFF');
                     }
                 } catch (DBALException $e) {
                     $this->fail('SQL Error for table "' . $tableName . '": ' . LF . $e->getMessage());

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -14,7 +14,7 @@ namespace TYPO3\TestingFramework\Core\Functional;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use PHPUnit\Framework\RiskyTestError;
@@ -264,7 +264,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      * This method should be called with parent::setUp() in your test cases!
      *
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     protected function setUp(): void
     {
@@ -587,7 +587,7 @@ abstract class FunctionalTestCase extends BaseTestCase
                         try {
                             $connection->exec('SET IDENTITY_INSERT ' . $tableName . ' ON');
                             $sqlServerIdentityDisabled = true;
-                        } catch (\Doctrine\DBAL\DBALException $e) {
+                        } catch (DBALException $e) {
                             // Some tables like sys_refindex don't have an auto-increment uid field and thus no
                             // IDENTITY column. Instead of testing existance, we just try to set IDENTITY ON
                             // and catch the possible error that occurs.

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -844,7 +844,7 @@ class Testbase
             $sqlServerIdentityDisabled = false;
             if ($platform instanceof SQLServerPlatform) {
                 try {
-                    $connection->exec('SET IDENTITY_INSERT ' . $tableName . ' ON');
+                    $connection->executeStatement('SET IDENTITY_INSERT ' . $tableName . ' ON');
                     $sqlServerIdentityDisabled = true;
                 } catch (DBALException $e) {
                     // Some tables like sys_refindex don't have an auto-increment uid field and thus no
@@ -866,7 +866,7 @@ class Testbase
 
             if ($sqlServerIdentityDisabled) {
                 // Reset identity if it has been changed
-                $connection->exec('SET IDENTITY_INSERT ' . $tableName . ' OFF');
+                $connection->executeStatement('SET IDENTITY_INSERT ' . $tableName . ' OFF');
             }
 
             static::resetTableSequences($connection, $tableName);
@@ -912,7 +912,7 @@ class Testbase
                 ->execute()
                 ->fetchAssociative();
             if ($row !== false) {
-                $connection->exec(
+                $connection->executeStatement(
                     sprintf(
                         'SELECT SETVAL(%s, COALESCE(MAX(%s), 0)+1, FALSE) FROM %s',
                         $connection->quote($row['schemaname'] . '.' . $row['relname']),
@@ -923,7 +923,7 @@ class Testbase
             }
         } elseif ($platform instanceof SqlitePlatform) {
             // Drop eventually existing sqlite sequence for this table
-            $connection->exec(
+            $connection->executeStatement(
                 sprintf(
                     'DELETE FROM sqlite_sequence WHERE name=%s',
                     $connection->quote($tableName)

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -14,7 +14,7 @@ namespace TYPO3\TestingFramework\Core;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
@@ -789,7 +789,7 @@ class Testbase
      *
      * @param string $path Absolute path to the XML file containing the data set to load
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
@@ -846,7 +846,7 @@ class Testbase
                 try {
                     $connection->exec('SET IDENTITY_INSERT ' . $tableName . ' ON');
                     $sqlServerIdentityDisabled = true;
-                } catch (\Doctrine\DBAL\DBALException $e) {
+                } catch (DBALException $e) {
                     // Some tables like sys_refindex don't have an auto-increment uid field and thus no
                     // IDENTITY column. Instead of testing existance, we just try to set IDENTITY ON
                     // and catch the possible error that occurs.
@@ -885,7 +885,7 @@ class Testbase
      *
      * @param Connection $connection
      * @param string $tableName
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     public static function resetTableSequences(Connection $connection, string $tableName): void
     {


### PR DESCRIPTION
### Changes proposed in this pull request

As preparation to raise doctrine/dbal to ^3.2 in core, we need to ensure
that removed things are replaced with corresponding methods. The replacements
are already available in 2.13.x, thus we can replace them beforehand, to stay
compatible with current used version, but have no blocker for the raise.

This pull-requests contains two commits, each commit doing only one thing.

1. Replace `\Doctrine\DBAL\DBALException` with `\Doctrine\DBAL\Exception`
2. Replace `exec()` with `executeStatement()`

> Both commits are marked to be backported to 7 to make future backports
> eventually a little bit easier.

