### PR TITLE
[TASK] Avoid fetchUserSession() for frontenduser initalization

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
@@ -18,13 +18,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
-use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Session\UserSessionManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\RequestBootstrap;
 
 /**
@@ -46,41 +42,25 @@ class FrontendUserHandler implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        /** @var FrontendUserAuthentication $frontendUserAuthentication */
-        $frontendUserAuthentication = $request->getAttribute('frontend.user');
-        $frontendUserAuthentication->checkPid = 0;
-
         $frontendUser = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('fe_users')
             ->select(['*'], 'fe_users', ['uid' => $context->getFrontendUserId()])
             ->fetchAssociative();
+
         if (is_array($frontendUser)) {
-            $context = GeneralUtility::makeInstance(Context::class);
-            $frontendUserAuthentication->createUserSession($frontendUser);
-            $frontendUserAuthentication->user = $frontendUserAuthentication->fetchUserSession();
-            // v11+
-            if (method_exists($frontendUserAuthentication, 'createUserAspect')) {
-                $frontendUserAuthentication->fetchGroupData($request);
-                $userAspect = $frontendUserAuthentication->createUserAspect();
-                GeneralUtility::makeInstance(Context::class)->setAspect('frontend.user', $userAspect);
-            } else {
-                // v10
-                $this->setFrontendUserAspect($context, $frontendUserAuthentication);
-            }
+            $userSessionManager = UserSessionManager::create('FE');
+            $userSession = $userSessionManager->createAnonymousSession();
+            $userSessionManager->elevateToFixatedUserSession($userSession, $context->getFrontendUserId());
+            $request = $request->withCookieParams(
+                array_replace(
+                    $request->getCookieParams(),
+                    [
+                        'fe_typo_user' => $userSession->getIdentifier(),
+                    ]
+                )
+            );
         }
 
         return $handler->handle($request);
     }
-
-    /**
-     * Register the frontend user as aspect
-     *
-     * @param Context $context
-     * @param AbstractUserAuthentication $user
-     */
-    protected function setFrontendUserAspect(Context $context, AbstractUserAuthentication $user)
-    {
-        $context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $user));
-    }
-
 }

--- a/Resources/Core/Functional/Extensions/json_response/Configuration/RequestMiddlewares.php
+++ b/Resources/Core/Functional/Extensions/json_response/Configuration/RequestMiddlewares.php
@@ -14,10 +14,10 @@ return [
         'typo3/json-response/frontend-user-authentication' => [
             'target' => \TYPO3\JsonResponse\Middleware\FrontendUserHandler::class,
             'after' => [
-                'typo3/cms-frontend/frontend-user-authentication'
+                'typo3/cms-frontend/backend-user-authentication',
             ],
             'before' => [
-                'typo3/cms-frontend/base-redirect-resolver',
+                'typo3/cms-frontend/authentication',
             ],
         ],
         'typo3/json-response/backend-user-authentication' => [


### PR DESCRIPTION
FrontendUserAuthenticator::fetchUserSession() is deprecated in v11 and should
be removed in v12, which is blocked because the json_response frontenduser
middleware uses this method to set signed in frontenduser for testcases
defined over InternalRequestContext.

This commit moves the middleware before core frontend user authentication
middleware and initialize a frontenduser session and inject afterwards
the needed sessionId into the request object, thus avoid to set a real
cookie but still simulate a valid frontenduser session.

Prepares deprecation removal for, tested with patchset 2: 

72476: [!!!][WIP][TASK] Remove deprecated code from Authentication
https://review.typo3.org/c/Packages/TYPO3.CMS/+/72476

