### PR TITLE
[TASK] Simplify DatabaseSnapshot usage in functional tests

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
@@ -18,7 +18,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot
 use Doctrine\DBAL\Connection;
 
 /**
- * @internal Use the helper methods of FunctionalTestCase
+ * @internal Use FunctionalTestCase->withDatabaseSnapshot() to leverage this.
  */
 class DatabaseSnapshot
 {
@@ -27,74 +27,26 @@ class DatabaseSnapshot
      */
     private const VALUE_IN_MEMORY_THRESHOLD = 1024**2 * 10;
 
-    /**
-     * @var static
-     */
     private static $instance;
-
-    /**
-     * @var string
-     */
     private $sqliteDir;
-
-    /**
-     * @var string
-     */
     private $identifier;
-
-    /**
-     * @var array
-     */
     private $inMemoryImport;
 
-    public static function initialize(string $sqliteDir, string $identifier): self
+    public static function initialize(string $sqliteDir, string $identifier): void
     {
-        if (self::$instance === null) {
-            self::$instance = new self($sqliteDir, $identifier);
-            return self::$instance;
-        }
-        throw new \LogicException(
-            'Snapshot can only be initialized once',
-            1535487361
-        );
+        self::$instance = new self($sqliteDir, $identifier);
     }
 
     public static function instance(): self
     {
-        if (self::$instance !== null) {
-            return self::$instance;
-        }
-        throw new \LogicException(
-            'Snapshot needs to be initialized first',
-            1535487361
-        );
-    }
-
-    public static function destroy(): bool
-    {
-        if (self::$instance === null) {
-            return false;
-        }
-        self::$instance->purge();
-        self::$instance = null;
-        return true;
+        return self::$instance;
     }
 
     private function __construct(string $sqliteDir, string $identifier)
     {
         $this->identifier = $identifier;
         $this->sqliteDir = $sqliteDir;
-    }
-
-    public function exists(): bool
-    {
-        return !empty($this->inMemoryImport);
-    }
-
-    public function purge(): bool
-    {
-        unset($this->inMemoryImport);
-        return true;
+        $this->inMemoryImport = [];
     }
 
     public function create(DatabaseAccessor $accessor, Connection $connection): void
@@ -113,10 +65,7 @@ class DatabaseSnapshot
             if (strlen($serialized) <= self::VALUE_IN_MEMORY_THRESHOLD) {
                 $this->inMemoryImport = $export;
             } else {
-                throw new \RuntimeException(
-                    'Export data set too large. Reduce data set or do not use snapshot.',
-                    1630203176
-                );
+                throw new \RuntimeException('Export data set too large. Reduce data set or do not use snapshot.', 1630203176);
             }
         }
     }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -246,21 +246,17 @@ abstract class FunctionalTestCase extends BaseTestCase
      */
     protected $initializeDatabase = true;
 
-    /**
-     * @var ContainerInterface
-     */
     private $container;
 
     /**
-     * This internal variable tracks if the given test is the first test of
+     * These two internal variable track if the given test is the first test of
      * that test case. This variable is set to current calling test case class.
      * Consecutive tests then optimize and do not create a full
      * database structure again but instead just truncate all tables which
      * is much quicker.
-     *
-     * @var string
      */
-    private static $currestTestCaseClass;
+    private static $currestTestCaseClass = '';
+    private $isFirstTest = true;
 
     /**
      * Set up creates a test instance and database.
@@ -285,18 +281,19 @@ abstract class FunctionalTestCase extends BaseTestCase
         $testbase->defineTypo3ModeBe();
         $testbase->setTypo3TestingContext();
 
-        $isFirstTest = false;
+        // See if we're the first test of this test case.
         $currentTestCaseClass = get_called_class();
         if (self::$currestTestCaseClass !== $currentTestCaseClass) {
-            $isFirstTest = true;
             self::$currestTestCaseClass = $currentTestCaseClass;
+        } else {
+            $this->isFirstTest = false;
         }
 
         // sqlite db path preparation
         $dbPathSqlite = dirname($this->instancePath) . '/functional-sqlite-dbs/test_' . $this->identifier . '.sqlite';
         $dbPathSqliteEmpty = dirname($this->instancePath) . '/functional-sqlite-dbs/test_' . $this->identifier . '.empty.sqlite';
 
-        if (!$isFirstTest) {
+        if (!$this->isFirstTest) {
             // Reusing an existing instance. This typically happens for the second, third, ... test
             // in a test case, so environment is set up only once per test case.
             GeneralUtility::purgeInstances();
@@ -306,6 +303,7 @@ abstract class FunctionalTestCase extends BaseTestCase
             }
             $testbase->loadExtensionTables();
         } else {
+            DatabaseSnapshot::initialize(dirname($this->getInstancePath()) . '/functional-sqlite-dbs/', $this->identifier);
             $testbase->removeOldInstanceIfExists($this->instancePath);
             // Basic instance directory structure
             $testbase->createDirectory($this->instancePath . '/fileadmin');
@@ -1446,48 +1444,46 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
-     * Invokes database snapshot and either restores data from existing
+     * Invokes a database snapshot and either restores data from existing
      * snapshot or otherwise invokes $callback and creates a new snapshot.
      *
-     * @param callable $callback
-     * @throws DBALException
+     * Using this can speed up tests when expensive setUp() operations are
+     * needed in all tests of a test case: The first test performs the
+     * expensive operations in $callback, sub sequent tests of this test
+     * case then just import the resulting database rows.
+     *
+     * An example to this are the "SiteHandling" core tests, which create
+     * a starter scenario using DataHandler based on Yaml files.
      */
-    protected function withDatabaseSnapshot(callable $callback)
+    protected function withDatabaseSnapshot(callable $callback): void
     {
         $connection = $this->getConnectionPool()->getConnectionByName(
             ConnectionPool::DEFAULT_CONNECTION_NAME
         );
         $accessor = new DatabaseAccessor($connection);
         $snapshot = DatabaseSnapshot::instance();
-
-        if ($snapshot->exists()) {
-            $snapshot->restore($accessor, $connection);
-        } else {
+        if ($this->isFirstTest) {
             $callback();
             $snapshot->create($accessor, $connection);
+        } else {
+            $snapshot->restore($accessor, $connection);
         }
     }
 
     /**
-     * Initializes database snapshot and storage.
+     * @deprecated No-op, don't call anymore. Handled by testing-framework internally.
      */
     protected static function initializeDatabaseSnapshot()
     {
-        $snapshot = DatabaseSnapshot::initialize(
-            dirname(static::getInstancePath()) . '/functional-sqlite-dbs/',
-            static::getInstanceIdentifier()
-        );
-        if ($snapshot->exists()) {
-            $snapshot->purge();
-        }
+        // no-op
     }
 
     /**
-     * Destroys database snapshot (if available).
+     * @deprecated No-op, don't call anymore. Handled by testing-framework internally.
      */
     protected static function destroyDatabaseSnapshot()
     {
-        DatabaseSnapshot::destroy();
+        // no-op
     }
 
     /**


### PR DESCRIPTION
Database snapshotting is a useful trick to speed up
consecutive tests of a test case if setUp() needs to do
expensive operations to set up the test environment.

It's usage can be simplified down to withDatabaseSnapshot()
by handling snapshot related internals in setUp() directly.
Doing this, FunctionalTestCase::initializeDatabaseSnapshot()
and FunctionalTestCase::destroyDatabaseSnapshot() can be
obsoleted and are marked @deprecated now.