### PR TITLE
[TASK] Configure frontend caches with NullBackend

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -340,6 +340,14 @@ abstract class FunctionalTestCase extends BaseTestCase
             $localConfiguration['SYS']['trustedHostsPattern'] = '.*';
             $localConfiguration['SYS']['encryptionKey'] = 'i-am-not-a-secure-encryption-key';
             $localConfiguration['GFX']['processor'] = 'GraphicsMagick';
+            // Set cache backends to null backend instead of database backend let us save time for creating
+            // database schema for it and reduces selects/inserts to the database for cache operations, which
+            // are generally not really needed for functional tests. Specific tests may restore this in if needed.
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['hash']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['imagesizes']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['pages']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['pagesection']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['rootline']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
             $testbase->setUpLocalConfiguration($this->instancePath, $localConfiguration, $this->configurationToUseInTestInstance);
             $defaultCoreExtensionsToLoad = [
                 'core',


### PR DESCRIPTION
This commit configures the frontend related caches to
use the NullBackend, which avoids creating corresponding
tables and reduces SELECT and INSERT database statements.

However, some core tests specificly tests against these
tables needs to specify the database backend again to
avoid test failing tests.

Configuration preparation has been prepared as core patch:

72706: [TASK] Use database cache backend for specific tests
https://review.typo3.org/c/Packages/TYPO3.CMS/+/72706

Merging this pull-request should be done with raising the
testing-framework hash in that patch and merging the core
patch shortly after the merge into the testing-framework
to avoid failing nightlies with composerInstallMax tests.
