### PR TITLE
[TASK] Adjust for minimum php8.1 raise from core main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '8.1' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "issues": "https://github.com/TYPO3/testing-framework/issues"
   },
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.1",
     "phpunit/phpunit": "^9.5.10",
     "psr/container": "^1.0",
     "mikey179/vfsstream": "~1.6.10",


### PR DESCRIPTION
Minimum version for core main has been raised to PHP8.1,
thus failing testing against main development branch if
used PHP <8.1.

* remove PHP7.4 and PHP8.0 from github action matrix
* raise required PHP version to 8.1 in composer.json

used commands:

composer req php:^8.1
