### PR TITLE
[!!!][TASK] Modernize AccessibleObjectInterface

### DIFF
--- a/Classes/Core/AccessibleObjectInterface.php
+++ b/Classes/Core/AccessibleObjectInterface.php
@@ -16,6 +16,7 @@ namespace TYPO3\TestingFramework\Core;
 
 /**
  * This interface defines the methods provided by TYPO3\TestingFramework\Core\TestCase::getAccessibleMock.
+ * Do not implement this interface in own classes. This should only be implemented by testing-framework classes.
  */
 interface AccessibleObjectInterface
 {
@@ -23,28 +24,24 @@ interface AccessibleObjectInterface
      * Calls the method $method using call_user_func* and returns its return value.
      *
      * @param string $methodName name of method to call, must not be empty
-     *
      * @return mixed the return value from the method $methodName
      */
-    public function _call($methodName);
+    public function _call(string $methodName, mixed ...$methodArguments): mixed;
 
     /**
      * Sets the value of a property.
      *
      * @param string $propertyName name of property to set value for, must not be empty
      * @param mixed $value the new value for the property defined in $propertyName
-     *
      * @return void
      */
-    public function _set($propertyName, $value);
+    public function _set(string $propertyName, mixed $value): void;
 
     /**
      * Gets the value of the given property.
      *
      * @param string $propertyName name of property to return value of, must not be empty
-     *
      * @return mixed the value of the property $propertyName
      */
-    public function _get($propertyName);
-
+    public function _get(string $propertyName): mixed;
 }

--- a/Classes/Core/AccessibleProxyTrait.php
+++ b/Classes/Core/AccessibleProxyTrait.php
@@ -15,19 +15,20 @@ namespace TYPO3\TestingFramework\Core;
  * The TYPO3 project - inspiring people to share!
  */
 
+/**
+ * @internal Do not use this trait in own classes.
+ */
 trait AccessibleProxyTrait
 {
-    public function _call($methodName)
+    public function _call(string $methodName, mixed ...$methodArguments): mixed
     {
         if ($methodName === '') {
             throw new \InvalidArgumentException($methodName . ' must not be empty.', 1334663993);
         }
-        $args = func_get_args();
-        array_shift($args);
-        return $this->$methodName(...$args);
+        return $this->$methodName(...$methodArguments);
     }
 
-    public function _set($propertyName, $value)
+    public function _set(string $propertyName, mixed $value): void
     {
         if ($propertyName === '') {
             throw new \InvalidArgumentException($propertyName . ' must not be empty.', 1334664355);
@@ -35,7 +36,7 @@ trait AccessibleProxyTrait
         $this->$propertyName = $value;
     }
 
-    public function _get($propertyName)
+    public function _get(string $propertyName): mixed
     {
         if ($propertyName === '') {
             throw new \InvalidArgumentException($propertyName . ' must not be empty.', 1334664967);


### PR DESCRIPTION
The AccessibleObjectInterface used for
BaseTestCase getAccessibleMock() and
getAccessibleMockForAbstractClass() should
have some syntactic sugar.

Especially _call() should hint for method
arguments to make IDE's more happy.

Strictly speaking, this interface change
is breaking, but consuming tests should not
implement this on its own. We mark the
interface and trait accordingly, now.