### PR TITLE
Streamline testing-framework for min php version and avoid deprecated doctrine methods

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -33,7 +33,7 @@ Also used by github actions for test execution.
 
 Usage: $0 [options]
 
-No arguments: Run all unit tests with PHP 7.2
+No arguments: Run all unit tests with PHP 8.1
 
 Options:
     -s <...>
@@ -42,11 +42,9 @@ Options:
             - lint: PHP linting
             - unit (default): PHP unit tests
 
-    -p <7.2|7.3|7.4|8.0|8.1>
+    -p <8.1>
         Specifies the PHP minor version to be used
-            - 7.2 (default): use PHP 7.2
-            - 7.3: use PHP 7.3
-            - 7.4: use PHP 7.4
+            - 8.1 (default): use PHP 8.1
 
     -v
         Enable verbose script output. Shows variables and docker commands.
@@ -58,8 +56,8 @@ Examples:
     # Run unit tests using default PHP version
     ./Build/Scripts/runTests.sh
 
-    # Run unit tests using PHP 7.4
-    ./Build/Scripts/runTests.sh -p 7.4
+    # Run unit tests using PHP 8.1
+    ./Build/Scripts/runTests.sh -p 8.1
 EOF
 
 # Test if docker-compose exists, else exit out with error
@@ -79,7 +77,7 @@ cd ../testing-docker || exit 1
 # Option defaults
 ROOT_DIR=`readlink -f ${PWD}/../../`
 TEST_SUITE="unit"
-PHP_VERSION="7.2"
+PHP_VERSION="8.1"
 SCRIPT_VERBOSE=0
 
 # Option parsing

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -535,7 +535,7 @@ class ActionService
                     $queryBuilder->createNamedParameter($workspaceId, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative();
         if (!empty($row['uid'])) {
             return (int)$row['uid'];
@@ -567,7 +567,7 @@ class ActionService
                     $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
                 )
             )
-            ->execute()
+            ->executeQuery()
             ->fetchAssociative();
         if (!empty($row)) {
             // This is effectively the same record as $liveUid, but only if the constraints from above match

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -95,7 +95,7 @@ class DatabaseAccessor
     {
         return $this->createQueryBuilder()
             ->select('*')->from($tableName)
-            ->execute()->fetchAll(FetchMode::ASSOCIATIVE);
+            ->executeQuery()->fetchAllAssociative(FetchMode::ASSOCIATIVE);
     }
 
     /**

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -461,7 +461,7 @@ abstract class FunctionalTestCase extends BaseTestCase
         $result = $queryBuilder->select('*')
             ->from('be_users')
             ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($userId, \PDO::PARAM_INT)))
-            ->execute();
+            ->executeQuery();
         return $result->fetchAssociative() ?: null;
     }
 
@@ -697,10 +697,10 @@ abstract class FunctionalTestCase extends BaseTestCase
         $statement = $queryBuilder
             ->select('*')
             ->from($tableName)
-            ->execute();
+            ->executeQuery();
 
         if (!$hasUidField && !$hasHashField) {
-            return $statement->fetchAll();
+            return $statement->fetchAllAssociative();
         }
 
         if ($hasUidField) {

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -909,7 +909,7 @@ class Testbase
                     $queryBuilder->expr()->eq('PGT.tablename', $queryBuilder->quote($tableName))
                 )
                 ->setMaxResults(1)
-                ->execute()
+                ->executeQuery()
                 ->fetchAssociative();
             if ($row !== false) {
                 $connection->executeStatement(


### PR DESCRIPTION
### Description of pull-request

This pull-requests contains two self-containing commits
to streamline testing-framework:

1. `[TASK] Streamline Build/Scripts/runTests.sh`
2. `[TASK] Avoid deprecated dbal/doctrine methods`

Both are for `main` only. No backport needed.

### [TASK] Streamline Build/Scripts/runTests.sh
testing-framework main has been aligned to core main
requirements. However removing support for older php
versions in `Build/Scripts/runTests.sh` has been missed.

This change removes traces of old php versions from
central `Build/Scripts/runTests.sh` to be aligned
with core again.

### [TASK] Avoid deprecated dbal/doctrine methods
Replaces deprecated dbal/doctrine methods with proper
replacements:

* `QueryBuilder->execute()` with `executeQuery()` for
  SELECT or COUNT queries (retrieving result set)
* `fetchAll()` with `fetchAllAssociative()`