### PR TITLE
[BUGFIX] Still populate super globals $_GET, $_POST, $_REQUEST

### DIFF
--- a/Classes/Core/Functional/Framework/FrameworkState.php
+++ b/Classes/Core/Functional/Framework/FrameworkState.php
@@ -41,6 +41,9 @@ class FrameworkState
     {
         $state = [];
         $state['globals-server'] = $GLOBALS['_SERVER'];
+        $state['globals-get'] = $_GET;
+        $state['globals-post'] = $_POST;
+        $state['globals-request'] = $_REQUEST;
         $state['globals-beUser'] = $GLOBALS['BE_USER'] ?? null;
         // Might be possible to drop this ...
         $state['globals-typo3-conf-vars'] = $GLOBALS['TYPO3_CONF_VARS'] ?: null;
@@ -106,6 +109,10 @@ class FrameworkState
         $state = array_pop(self::$state);
 
         $GLOBALS['_SERVER'] = $state['globals-server'];
+        $_GET = $state['globals-get'];
+        $_POST = $state['globals-post'];
+        $_REQUEST = $state['globals-request'];
+
         if ($state['globals-beUser'] !== null) {
             $GLOBALS['BE_USER'] = $state['globals-beUser'];
         }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1141,6 +1141,18 @@ abstract class FunctionalTestCase extends BaseTestCase
         $requestUrlParts = parse_url($request->getUri());
         $_SERVER['HTTP_HOST'] = $_SERVER['SERVER_NAME'] = isset($requestUrlParts['host']) ? $requestUrlParts['host'] : 'localhost';
 
+        if (isset($requestUrlParts['query'])) {
+            parse_str($requestUrlParts['query'], $_GET);
+            parse_str($requestUrlParts['query'], $_REQUEST);
+        }
+
+        if ($request->hasHeader('Content-Type')
+            // no further limitation to HTTP method, due to https://www.php.net/manual/en/reserved.variables.post.php
+            && in_array('application/x-www-form-urlencoded', $request->getHeader('Content-Type'))
+        ) {
+            parse_str((string) $this->request->getBody(), $_POST);
+        }
+
         $container = Bootstrap::init(ClassLoadingInformation::getClassLoader());
 
         // The testing-framework registers extension 'json_response' that brings some middlewares which


### PR DESCRIPTION
With commit d62c872d048015a3faee0b7b909302b8d3e54930 the frontend sub request handling has been adjusted - basically only a PSR-7 request object is being used to transport request information.

However, the TYPO3 core (at that time, and currently) still relies on super globals like `$_GET`, `$_POST` and `$_REQUEST`.
```
Releases: 6
```