### PR TITLE
[TASK] Replace deprecated doctrine/dbal Connection::getSchemaManager()

### DIFF
--- a/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallMysqlCoreEnvironment.php
@@ -105,7 +105,7 @@ class InstallMysqlCoreEnvironment extends Extension
         ];
         $this->output->debug("Connecting to MySQL: " . json_encode($connectionParameters));
         $databaseName = $this->config['typo3InstallMysqlDatabaseName'];
-        $schemaManager = DriverManager::getConnection($connectionParameters)->getSchemaManager();
+        $schemaManager = DriverManager::getConnection($connectionParameters)->createSchemaManager();
         $this->output->debug("Database: $databaseName");
         if (in_array($databaseName, $schemaManager->listDatabases(), true)) {
             $this->output->debug("Dropping database $databaseName");

--- a/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/InstallPostgresqlCoreEnvironment.php
@@ -109,7 +109,7 @@ class InstallPostgresqlCoreEnvironment extends Extension
             'user' => $this->config['typo3InstallPostgresqlDatabaseUsername'],
         ];
         $this->output->debug("Connecting to PgSQL: " . json_encode($connectionParameters));
-        $schemaManager = DriverManager::getConnection($connectionParameters)->getSchemaManager();
+        $schemaManager = DriverManager::getConnection($connectionParameters)->createSchemaManager();
         $databaseName = $this->config['typo3InstallPostgresqlDatabaseName'];
         $this->output->debug("Database: $databaseName");
         if (in_array($databaseName, $schemaManager->listDatabases(), true)) {

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -46,7 +46,7 @@ class DatabaseAccessor
      */
     public function export(): array
     {
-        $schemaManager = $this->connection->getSchemaManager();
+        $schemaManager = $this->connection->createSchemaManager();
 
         $export = [];
         foreach ($schemaManager->listTables() as $table) {

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -564,7 +564,7 @@ abstract class FunctionalTestCase extends BaseTestCase
                     // Some DBMS like mssql are picky about inserting blob types with correct cast, setting
                     // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL
                     $types = [];
-                    $tableDetails = $connection->getSchemaManager()->listTableDetails($tableName);
+                    $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
                     foreach ($element as $columnName => $columnValue) {
                         $types[] = $tableDetails->getColumn($columnName)->getType()->getBindingType();
                     }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -588,7 +588,7 @@ class Testbase
         // @todo: This should by now work with using "our" ConnectionPool again, it does now, though.
         $connectionParameters = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
         unset($connectionParameters['dbname']);
-        $schemaManager = DriverManager::getConnection($connectionParameters)->getSchemaManager();
+        $schemaManager = DriverManager::getConnection($connectionParameters)->createSchemaManager();
 
         if ($schemaManager->getDatabasePlatform()->getName() === 'sqlite') {
             // This is the "path" option in sqlite: one file = one db
@@ -695,7 +695,7 @@ class Testbase
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
         $databaseName = $connection->getDatabase();
-        $tableNames = $connection->getSchemaManager()->listTableNames();
+        $tableNames = $connection->createSchemaManager()->listTableNames();
 
         if (empty($tableNames)) {
             // No tables to process
@@ -747,7 +747,7 @@ class Testbase
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
 
-        $schemaManager = $connection->getSchemaManager();
+        $schemaManager = $connection->createSchemaManager();
         foreach ($schemaManager->listTables() as $table) {
             $connection->truncate($table->getName());
             self::resetTableSequences($connection, $table->getName());
@@ -857,7 +857,7 @@ class Testbase
             // Some DBMS like mssql are picky about inserting blob types with correct cast, setting
             // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL
             $types = [];
-            $tableDetails = $connection->getSchemaManager()->listTableDetails($tableName);
+            $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
             foreach ($insertArray as $columnName => $columnValue) {
                 $types[] = $tableDetails->getColumn($columnName)->getType()->getBindingType();
             }


### PR DESCRIPTION
Replace deprecated `Connection::getSchemaManager()` calls with
`Connection::createSchemaManager()` to mitigate deprecation as
early as possible. Deprecation introduced with `doctrine/dbal:^3.x`.

Releases: main

TYPO3 Core: https://review.typo3.org/c/Packages/TYPO3.CMS/+/73629
Styleguide: https://github.com/sbuerk/styleguide/runs/5272006489?check_suite_focus=true