### PR TITLE
[BUGFIX] Sanitize FunctionalTestCase renderRecords()

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -760,16 +760,16 @@ abstract class FunctionalTestCase extends BaseTestCase
         foreach ($columns as $columnIndex => $column) {
             $columnLength = null;
             foreach ($column as $value) {
-                if (strpos($value, '<?xml') === 0) {
+                if (strpos((string)$value, '<?xml') === 0) {
                     $value = '[see diff]';
                 }
-                $valueLength = strlen($value);
+                $valueLength = strlen((string)$value);
                 if (empty($columnLength) || $valueLength > $columnLength) {
                     $columnLength = $valueLength;
                 }
             }
             foreach ($column as $valueIndex => $value) {
-                if (strpos($value, '<?xml') === 0) {
+                if (strpos((string)$value, '<?xml') === 0) {
                     if ($columnIndex === 'assertion') {
                         try {
                             $this->assertXmlStringEqualsXmlString((string)$value, (string)$record[$columns['fields'][$valueIndex]]);
@@ -780,7 +780,7 @@ abstract class FunctionalTestCase extends BaseTestCase
                     }
                     $value = '[see diff]';
                 }
-                $lines[$valueIndex][$columnIndex] = str_pad($value, $columnLength, ' ');
+                $lines[$valueIndex][$columnIndex] = str_pad((string)$value, $columnLength, ' ');
             }
         }
 


### PR DESCRIPTION
With FunctionalTestCase being strict_types=1,
renderRecords() needs more type sanitations.

Releases: main, 7, 6

### Changes proposed in this pull request

<!--
1. ..
2. ..
-->

### Steps to test the solution

<!--
1. ..
2. ..
-->

### Results

<!--
Look at the contributing guidelines of the testing framework, what results are
expected here.
-->

Fixes: #<!-- Issue ID -->
