### PR TITLE
[FEATURE] Provide access to private services in functional tests

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -83,7 +83,7 @@ use TYPO3\TestingFramework\Core\Testbase;
  *     --bootstrap components/testing_framework/core/Build/FunctionalTestsBootstrap.php \
  *     typo3/sysext/core/Tests/Functional/DataHandling/DataHandlerTest.php
  */
-abstract class FunctionalTestCase extends BaseTestCase
+abstract class FunctionalTestCase extends BaseTestCase implements ContainerInterface
 {
     /**
      * An unique identifier for this test case. Location of the test
@@ -150,6 +150,7 @@ abstract class FunctionalTestCase extends BaseTestCase
      */
     protected $frameworkExtensionsToLoad = [
         'Resources/Core/Functional/Extensions/json_response',
+        'Resources/Core/Functional/Extensions/private_container',
     ];
 
     /**
@@ -456,7 +457,12 @@ abstract class FunctionalTestCase extends BaseTestCase
     }
 
     /**
+<<<<<<< HEAD
      * @return ContainerInterface
+=======
+     * @todo: Consider setting this private, too. So consumers have to
+     *        use get() / has().
+>>>>>>> d5d65dd... [FEATURE] Provide access to private services in functional tests
      */
     protected function getContainer(): ContainerInterface
     {
@@ -464,6 +470,32 @@ abstract class FunctionalTestCase extends BaseTestCase
             throw new \RuntimeException('Please invoke parent::setUp() before calling getContainer().', 1589221777);
         }
         return $this->container;
+    }
+
+    private function getPrivateContainer(): ContainerInterface
+    {
+        return $this->getContainer()->get('typo3.testing-framework.private-container');
+    }
+
+    /**
+     * Implements ContainerInterface. Can be used by tests to get both public
+     * and non-public services.
+     */
+    public function get(string $id): mixed
+    {
+        if ($this->getContainer()->has($id)) {
+            return $this->getContainer()->get($id);
+        }
+        return $this->getPrivateContainer()->get($id);
+    }
+
+    /**
+     * Implements ContainerInterface. Used to find out if there is such a service.
+     * This will return true if the container is public OR non-public.
+     */
+    public function has(string $id): bool
+    {
+        return $this->getContainer()->has($id) || $this->getPrivateContainer()->has($id);
     }
 
     /**

--- a/Resources/Core/Functional/Extensions/private_container/Classes/DependencyInjection/PrivateContainerRealRefPass.php
+++ b/Resources/Core/Functional/Extensions/private_container/Classes/DependencyInjection/PrivateContainerRealRefPass.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\PrivateContainer\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Unset unused private services. This is used in functional tests to
+ * only add private services that are actually used.
+ */
+class PrivateContainerRealRefPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('typo3.testing-framework.private-container')) {
+            return;
+        }
+
+        $privateContainer = $container->getDefinition('typo3.testing-framework.private-container');
+        $definitions = $container->getDefinitions();
+        $privateServices = $privateContainer->getArgument(0);
+
+        foreach ($privateServices as $id => $argument) {
+            if (isset($definitions[$target = (string) $argument->getValues()[0]])) {
+                $argument->setValues([new Reference($target)]);
+            } else {
+                unset($privateServices[$id]);
+            }
+        }
+
+        $privateContainer->replaceArgument(0, $privateServices);
+    }
+}

--- a/Resources/Core/Functional/Extensions/private_container/Classes/DependencyInjection/PrivateContainerWeakRefPass.php
+++ b/Resources/Core/Functional/Extensions/private_container/Classes/DependencyInjection/PrivateContainerWeakRefPass.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\PrivateContainer\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Register used private services. This is a special testing-framework
+ * functional service pass to allow $this->get() of private services in
+ * functional tests.
+ */
+class PrivateContainerWeakRefPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $privateServices = [];
+        $definitions = $container->getDefinitions();
+
+        foreach ($definitions as $id => $definition) {
+            if ($id &&
+                $id[0] !== '.' &&
+                (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag('container.private')) &&
+                !$definition->hasErrors() &&
+                !$definition->isAbstract()
+            ) {
+                $privateServices[$id] = new Reference($id, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
+            }
+        }
+
+        $aliases = $container->getAliases();
+
+        foreach ($aliases as $id => $alias) {
+            if ($id && $id[0] !== '.' && (!$alias->isPublic() || $alias->isPrivate())) {
+                while (isset($aliases[$target = (string) $alias])) {
+                    $alias = $aliases[$target];
+                }
+                if (isset($definitions[$target]) && !$definitions[$target]->hasErrors() && !$definitions[$target]->isAbstract()) {
+                    $privateServices[$id] = new Reference($target, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
+                }
+            }
+        }
+
+        if ($privateServices) {
+            $id = (string) ServiceLocatorTagPass::register($container, $privateServices);
+            $container->setDefinition('typo3.testing-framework.private-container', $container->getDefinition($id))->setPublic(true);
+            $container->removeDefinition($id);
+        }
+    }
+}

--- a/Resources/Core/Functional/Extensions/private_container/Configuration/Services.php
+++ b/Resources/Core/Functional/Extensions/private_container/Configuration/Services.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\PrivateContainer;
+
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container, ContainerBuilder $containerBuilder) {
+    // Register services similar to symfony testing: Allow private services if they are used
+    // by other services. This is a special testing-framework quirk to allow get'ting private
+    // (as-in public:false) services.
+    $containerBuilder->addCompilerPass(new DependencyInjection\PrivateContainerWeakRefPass(), PassConfig::TYPE_BEFORE_REMOVING, -32);
+    $containerBuilder->addCompilerPass(new DependencyInjection\PrivateContainerRealRefPass(), PassConfig::TYPE_AFTER_REMOVING);
+};

--- a/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
@@ -1,0 +1,18 @@
+<?php
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Private Container',
+    'description' => 'Private Container',
+    'version' => '1.0.0',
+    'state' => 'stable',
+    'createDirs' => '',
+    'author' => 'Benjamin Franzke',
+    'author_email' => 'bfr@qbus.de',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-12.99.99'
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
   },
   "autoload": {
     "psr-4": {
-      "TYPO3\\TestingFramework\\": "Classes/"
+      "TYPO3\\TestingFramework\\": "Classes/",
+      "TYPO3\\PrivateContainer\\": "Resources/Core/Functional/Extensions/private_container/Classes/"
     }
   }
 }


### PR DESCRIPTION
Functional tests frequently need to instantiate $subject
or a dependency. This can be cumbersome if the service
in question is not public, since $this->getContainer()->get()
can currently only instantiate services marked as public.

The patch adds compiler passes as always-registered core
extension to DI in functional tests that allows to get()
private containers, too.

Also, FunctionalTestCase implements ContainerInterface,
this might be handy for some nifty cases where $this
can be hand over as container to a service to allow
custom callbacks if needed - Not a frequent option,
but useful in edge cases, use with care.

Based on:
https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerRealRefPass.php
https://github.com/symfony/symfony/blob/6.1/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php

Related change for TYPO3 core:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/73646

Releases: main, v7, v6

### Changes proposed in this pull request

<!--
1. ..
2. ..
-->

### Steps to test the solution

<!--
1. ..
2. ..
-->

### Results

<!--
Look at the contributing guidelines of the testing framework, what results are
expected here.
-->

Fixes: #<!-- Issue ID -->
