### PR TITLE
[TASK] Have a proper phpstan setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,11 @@ jobs:
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
+      - name: Lint PHP
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+
+      - name: Phpstan
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
+
       - name: Unit Tests
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
-      - name: Lint PHP
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
-
       - name: Phpstan
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -44,6 +44,8 @@ Options:
             - clean: clean up build and testing related files
             - composerUpdate: "composer update"
             - lint: PHP linting
+            - phpstan: phpstan analyze
+            - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
             - unit (default): PHP unit tests
 
     -p <8.1>
@@ -174,6 +176,18 @@ case ${TEST_SUITE} in
     lint)
         setUpDockerComposeDotEnv
         docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstan)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstanGenerateBaseline)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan_generate_baseline
         SUITE_EXIT_CODE=$?
         docker-compose down
         ;;

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,0 +1,87 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to static method cssSelector\\(\\) on an unknown class Facebook\\\\WebDriver\\\\WebDriverBy\\.$#"
+			count: 3
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Call to static method xpath\\(\\) on an unknown class Facebook\\\\WebDriver\\\\WebDriverBy\\.$#"
+			count: 1
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Caught class Facebook\\\\WebDriver\\\\Exception\\\\ElementNotInteractableException not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Caught class Facebook\\\\WebDriver\\\\Exception\\\\ElementNotVisibleException not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Caught class Facebook\\\\WebDriver\\\\Exception\\\\NoSuchElementException not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Parameter \\$context of method TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Helper\\\\AbstractPageTree\\:\\:ensureTreeNodeIsOpen\\(\\) has invalid type Facebook\\\\WebDriver\\\\Remote\\\\RemoteWebElement\\.$#"
+			count: 1
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Parameter \\$webdriver of anonymous function has invalid type Facebook\\\\WebDriver\\\\Remote\\\\RemoteWebDriver\\.$#"
+			count: 1
+			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Workspaces\\\\Service\\\\WorkspaceService not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/ActionService.php
+
+		-
+			message: "#^Method TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\DataHandling\\\\ActionService\\:\\:getWorkspaceService\\(\\) has invalid return type TYPO3\\\\CMS\\\\Workspaces\\\\Service\\\\WorkspaceService\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/ActionService.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerWriter.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/ResponseContent.php
+
+		-
+			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\PostgreSqlPlatform not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/FunctionalTestCase.php
+
+		-
+			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\MySqlPlatform not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Testbase.php
+
+		-
+			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\PostgreSqlPlatform not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Testbase.php
+

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Class TYPO3\\\\CMS\\\\Workspaces\\\\Service\\\\WorkspaceService not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Functional/Framework/DataHandling/ActionService.php
-
-		-
-			message: "#^Method TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\DataHandling\\\\ActionService\\:\\:getWorkspaceService\\(\\) has invalid return type TYPO3\\\\CMS\\\\Workspaces\\\\Service\\\\WorkspaceService\\.$#"
-			count: 1
-			path: ../../Classes/Core/Functional/Framework/DataHandling/ActionService.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,41 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to static method cssSelector\\(\\) on an unknown class Facebook\\\\WebDriver\\\\WebDriverBy\\.$#"
-			count: 3
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
-			message: "#^Call to static method xpath\\(\\) on an unknown class Facebook\\\\WebDriver\\\\WebDriverBy\\.$#"
-			count: 1
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
-			message: "#^Caught class Facebook\\\\WebDriver\\\\Exception\\\\ElementNotInteractableException not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
-			message: "#^Caught class Facebook\\\\WebDriver\\\\Exception\\\\ElementNotVisibleException not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
-			message: "#^Caught class Facebook\\\\WebDriver\\\\Exception\\\\NoSuchElementException not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
-			message: "#^Parameter \\$context of method TYPO3\\\\TestingFramework\\\\Core\\\\Acceptance\\\\Helper\\\\AbstractPageTree\\:\\:ensureTreeNodeIsOpen\\(\\) has invalid type Facebook\\\\WebDriver\\\\Remote\\\\RemoteWebElement\\.$#"
-			count: 1
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
-			message: "#^Parameter \\$webdriver of anonymous function has invalid type Facebook\\\\WebDriver\\\\Remote\\\\RemoteWebDriver\\.$#"
-			count: 1
-			path: ../../Classes/Core/Acceptance/Helper/AbstractPageTree.php
-
-		-
 			message: "#^Class TYPO3\\\\CMS\\\\Workspaces\\\\Service\\\\WorkspaceService not found\\.$#"
 			count: 1
 			path: ../../Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -69,19 +34,4 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: ../../Classes/Core/Functional/Framework/Frontend/ResponseContent.php
-
-		-
-			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\PostgreSqlPlatform not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Functional/FunctionalTestCase.php
-
-		-
-			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\MySqlPlatform not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Testbase.php
-
-		-
-			message: "#^Class Doctrine\\\\DBAL\\\\Platforms\\\\PostgreSqlPlatform not found\\.$#"
-			count: 1
-			path: ../../Classes/Core/Testbase.php
 

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -1,0 +1,12 @@
+includes:
+  - phpstan-baseline.neon
+
+parameters:
+  level: 0
+
+  # Use local cache dir instead of /tmp
+  tmpDir: ../../.Build/.cache/phpstan
+
+  paths:
+    - ../../Classes
+    - ../../Tests

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -10,3 +10,7 @@ parameters:
   paths:
     - ../../Classes
     - ../../Tests
+
+  excludePaths:
+    # Checking acceptance support files is cumbersome due to codeception dynamic mixin generation
+    - ../../Classes/Core/Acceptance/*

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -68,6 +68,38 @@ services:
         find . -name \\*.php ! -path "./.Build/\\*" ! -path "./public/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
       "
 
+  phpstan:
+      image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+      user: "${HOST_UID}"
+      volumes:
+          - ${ROOT_DIR}:${ROOT_DIR}
+      working_dir: ${ROOT_DIR}
+      command: >
+          /bin/sh -c "
+            if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+              set -x
+            fi
+            mkdir -p .Build/.cache
+            php -v | grep '^PHP';
+            php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --no-progress --no-interaction
+          "
+
+  phpstan_generate_baseline:
+      image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+      user: "${HOST_UID}"
+      volumes:
+          - ${ROOT_DIR}:${ROOT_DIR}
+      working_dir: ${ROOT_DIR}
+      command: >
+          /bin/sh -c "
+            if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+              set -x
+            fi
+            mkdir -p .Build/.cache
+            php -v | grep '^PHP';
+            php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --no-progress --no-interaction --generate-baseline=Build/phpstan/phpstan-baseline.neon
+          "
+
   unit:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -17,7 +17,7 @@ namespace TYPO3\TestingFramework\Core\Functional;
  */
 
 use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use PHPUnit\Framework\RiskyTestError;
 use PHPUnit\Util\ErrorHandler;
@@ -903,7 +903,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         }
 
         $databasePlatform = 'mysql';
-        if ($connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
             $databasePlatform = 'postgresql';
         }
 

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -17,8 +17,8 @@ namespace TYPO3\TestingFramework\Core;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Psr\Container\ContainerInterface;
@@ -671,7 +671,7 @@ class Testbase
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
         $platform = $connection->getDatabasePlatform();
-        if ($platform instanceof MySqlPlatform) {
+        if ($platform instanceof MySQLPlatform) {
             $this->truncateAllTablesForMysql();
         } else {
             $this->truncateAllTablesForOtherDatabases();

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,8 @@
     }
   },
   "require-dev": {
-    "typo3/coding-standards": "^0.5.0"
+    "typo3/coding-standards": "^0.5.0",
+    "phpstan/phpstan": "^1.4.5",
+    "codeception/codeception": "^4.1.22"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,6 @@
   },
   "require-dev": {
     "typo3/coding-standards": "^0.5.0",
-    "phpstan/phpstan": "^1.4.5",
-    "codeception/codeception": "^4.1.22"
+    "phpstan/phpstan": "^1.4.5"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
   },
   "require-dev": {
     "typo3/coding-standards": "^0.5.0",
-    "phpstan/phpstan": "^1.4.5"
+    "phpstan/phpstan": "^1.4.6",
+    "typo3/cms-workspaces": "12.*.*@dev"
   }
 }


### PR DESCRIPTION
This change adopts phpstan configuration and workflow like it
has been implemented into the core and also typo/cms-styleguide.

* added phpstan/phpstan dev dependency
* added basic phpstan configuration and baseline to 'Build/phpstan'
* added `phpstan` and `phpstan_generate_baseline` container
* added commands to `Build/Scripts/runTests.sh`
  - `-s phpstan`
  - `-s phpstanGenerateBaseline`

used commands:

```bash
> composer req --dev --no-update \
    "phpstan/phpstan":"^1.4.5" \
    "codeception/codeception":"^4.1.22"
```