### PR TITLE
[TASK] Have a proper phpstan setup (#338)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Lint PHP
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
+      - name: Phpstan
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
+
       - name: Unit Tests
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -44,6 +44,8 @@ Options:
             - clean: clean up build and testing related files
             - composerUpdate: "composer update"
             - lint: PHP linting
+            - phpstan: phpstan analyze
+            - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
             - unit (default): PHP unit tests
 
     -p <7.4|8.0|8.1>
@@ -176,6 +178,18 @@ case ${TEST_SUITE} in
     lint)
         setUpDockerComposeDotEnv
         docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstan)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstanGenerateBaseline)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan_generate_baseline
         SUITE_EXIT_CODE=$?
         docker-compose down
         ;;

--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,0 +1,67 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Instantiated class Composer\\\\Util\\\\Filesystem not found\\.$#"
+			count: 1
+			path: ../../Classes/Composer/ExtensionTestEnvironment.php
+
+		-
+			message: "#^Parameter \\$event of method TYPO3\\\\TestingFramework\\\\Composer\\\\ExtensionTestEnvironment\\:\\:prepare\\(\\) has invalid type Composer\\\\Script\\\\Event\\.$#"
+			count: 1
+			path: ../../Classes/Composer/ExtensionTestEnvironment.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerWriter.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/InternalRequestContext.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/InternalResponse.php
+
+		-
+			message: "#^Access to an undefined property TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Response\\:\\:\\$responseContent\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/Response.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/Framework/Frontend/ResponseContent.php
+
+		-
+			message: "#^Class Text_Template not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/FunctionalTestCase.php
+
+		-
+			message: "#^Instantiated class Text_Template not found\\.$#"
+			count: 1
+			path: ../../Classes/Core/Functional/FunctionalTestCase.php
+

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -1,0 +1,16 @@
+includes:
+  - phpstan-baseline.neon
+
+parameters:
+  level: 0
+
+  # Use local cache dir instead of /tmp
+  tmpDir: ../../.Build/.cache/phpstan
+
+  paths:
+    - ../../Classes
+    - ../../Tests
+
+  excludePaths:
+    # Checking acceptance support files is cumbersome due to codeception dynamic mixin generation
+    - ../../Classes/Core/Acceptance/*

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -68,6 +68,38 @@ services:
         find . -name \\*.php ! -path "./.Build/\\*" ! -path "./public/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
       "
 
+  phpstan:
+      image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+      user: "${HOST_UID}"
+      volumes:
+          - ${ROOT_DIR}:${ROOT_DIR}
+      working_dir: ${ROOT_DIR}
+      command: >
+          /bin/sh -c "
+            if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+              set -x
+            fi
+            mkdir -p .Build/.cache
+            php -v | grep '^PHP';
+            php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --no-progress --no-interaction
+          "
+
+  phpstan_generate_baseline:
+      image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+      user: "${HOST_UID}"
+      volumes:
+          - ${ROOT_DIR}:${ROOT_DIR}
+      working_dir: ${ROOT_DIR}
+      command: >
+          /bin/sh -c "
+            if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+              set -x
+            fi
+            mkdir -p .Build/.cache
+            php -v | grep '^PHP';
+            php -dxdebug.mode=off .Build/bin/phpstan analyze -c Build/phpstan/phpstan.neon --no-progress --no-interaction --generate-baseline=Build/phpstan/phpstan-baseline.neon
+          "
+
   unit:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,8 @@
     }
   },
   "require-dev": {
-    "typo3/coding-standards": "^0.5.0"
+    "typo3/coding-standards": "^0.5.0",
+    "phpstan/phpstan": "^1.4.6",
+    "typo3/cms-workspaces": "10.*.*@dev || 11.*.*@dev"
   }
 }


### PR DESCRIPTION
This change adopts phpstan configuration and workflow like it
has been implemented into the core and also typo3/cms-styleguide.

* added phpstan/phpstan dev dependency
* added basic phpstan configuration and baseline to 'Build/phpstan'
* added `phpstan` and `phpstan_generate_baseline` container
* added commands to `Build/Scripts/runTests.sh`
  - `-s phpstan`
  - `-s phpstanGenerateBaseline`
* activate in CI

> composer req --dev --no-update "phpstan/phpstan":"^1.4.6"
> composer req --dev --no-update "typo3/cms-workspaces":"10.*.*@dev || 11.*.*@dev"