### PR TITLE
[TASK] Do not allow core v10 in TF 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
     "psr/container": "^1.0",
     "mikey179/vfsstream": "~1.6.10",
     "typo3fluid/fluid": "^2.7.1",
-    "typo3/cms-core": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-backend": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-frontend": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-extbase": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-fluid": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-install": "10.*.*@dev || 11.*.*@dev",
-    "typo3/cms-recordlist": "10.*.*@dev || 11.*.*@dev",
+    "typo3/cms-core": "11.*.*@dev",
+    "typo3/cms-backend": "11.*.*@dev",
+    "typo3/cms-frontend": "11.*.*@dev",
+    "typo3/cms-extbase": "11.*.*@dev",
+    "typo3/cms-fluid": "11.*.*@dev",
+    "typo3/cms-install": "11.*.*@dev",
+    "typo3/cms-recordlist": "11.*.*@dev",
     "guzzlehttp/psr7": "^1.7 || ^2.0"
   },
   "conflict": {
@@ -60,6 +60,6 @@
   "require-dev": {
     "typo3/coding-standards": "^0.5.0",
     "phpstan/phpstan": "^1.4.6",
-    "typo3/cms-workspaces": "10.*.*@dev || 11.*.*@dev"
+    "typo3/cms-workspaces": "11.*.*@dev"
   }
 }


### PR DESCRIPTION
testing-framework:7 is a transition version for
extensions that drop v10, keep v11 and add v12.
It should not allow core v10.

> composer req --no-update "typo3/cms-core":"11.*.*@dev"
> composer req --no-update "typo3/cms-backend":"11.*.*@dev"
> composer req --no-update "typo3/cms-frontend":"11.*.*@dev"
> composer req --no-update "typo3/cms-extbase":"11.*.*@dev"
> composer req --no-update "typo3/cms-fluid":"11.*.*@dev"
> composer req --no-update "typo3/cms-install":"11.*.*@dev"
> composer req --no-update "typo3/cms-recordlist":"11.*.*@dev"
> composer req --no-update --dev "typo3/cms-workspaces":"11.*.*@dev"

