### PR TITLE
[TASK] Use proper type hints for set_error_handler() dummy callback

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -66,11 +66,6 @@ parameters:
 			path: ../../Classes/Core/Functional/Framework/Frontend/ResponseContent.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, Closure\\(\\)\\: void given\\.$#"
-			count: 1
-			path: ../../Classes/Core/Functional/FunctionalTestCase.php
-
-		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, SimpleXMLElement given\\.$#"
 			count: 1
 			path: ../../Classes/Core/Testbase.php

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -398,7 +398,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         // fails to unset/restore it's custom error handler as "risky".
         // @todo: Consider moving this to BaseTestCase to have it for unit tests, too.
         // @see: https://github.com/sebastianbergmann/phpunit/issues/4801
-        $previousErrorHandler = set_error_handler(function () {});
+        $previousErrorHandler = set_error_handler(function (int $errorNumber, string $errorString, string $errorFile, int $errorLine): bool {return false;});
         restore_error_handler();
         if (!$previousErrorHandler instanceof ErrorHandler) {
             throw new RiskyTestError(


### PR DESCRIPTION
Solve phpstan baseline entry for set_error_handler() with adding
proper type hints to used dummy closure callback method and make
phpstan happier.
