### PR TITLE
[BUGFIX] Add ability to pass data for POST/PUT/PATCH/DELETE requests

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -37,6 +37,11 @@ class InternalRequest extends Request implements \JsonSerializable
     protected $instructions = [];
 
     /**
+     * @var array|null
+     */
+    protected $parsedBody;
+
+    /**
      * @param array $data
      * @return InternalRequest
      * @internal
@@ -211,6 +216,18 @@ class InternalRequest extends Request implements \JsonSerializable
     public function getInstruction(string $identifier): ?AbstractInstruction
     {
         return $this->instructions[$identifier] ?? null;
+    }
+
+    public function withParsedBody(?array $parsedBody=null): InternalRequest
+    {
+        $target = clone $this;
+        $target->parsedBody = $parsedBody;
+        return $target;
+    }
+
+    public function getParsedBody(): ?array
+    {
+        return $this->parsedBody;
     }
 
     /**

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1217,13 +1217,18 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $serverRequest = new ServerRequest(
             $uri,
             $request->getMethod(),
-            'php://input',
+            $request->getBody(),
             $request->getHeaders(),
             $serverParams
         );
         $requestUrlParts = [];
         parse_str($uri->getQuery(), $requestUrlParts);
         $serverRequest = $serverRequest->withQueryParams($requestUrlParts);
+        $parsedBody = $request->getParsedBody();
+        if (empty($parsedBody) && $request->getBody() !== null && in_array($request->getMethod(), ['PUT', 'PATCH', 'DELETE'])) {
+            parse_str((string)$request->getBody(), $parsedBody);
+        }
+        $serverRequest = $serverRequest->withParsedBody($parsedBody);
         try {
             $frontendApplication = $container->get(Application::class);
             $jsonResponse = $frontendApplication->handle($serverRequest);


### PR DESCRIPTION
testing-framework provided methods to call requests using the core
subRequest feature, which was a great overhaul. However, the early
implementation lacked some features, which now bubbles up to the
surface. Extension developers and core could not use the frontend
request to test data submissions with DELETE, PATCH, POST and PUT
http request.

This patch adds the ability to provide 'parsedBody' (_POST) data
set as array with new method 'InternalRequest::withParsedBody()'.
Additional the frontend request emulation has adjusted to properly
build the 'ServerRequest' with the provided 'parsedBody' data.

For 'DELETE', 'POST' and 'PUT' method, body contend will be parsed
to 'parsedBody', if 'parsedBody' data set is set in InternalRequest.

This extends and open new worlds for testing purpose, in core and
for extension developers. Only suported by v11+ subRequest requests.

