### PR TITLE
[BUGFIX] Avoid 'class should return static(class)' for AbstractInstruction

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -136,11 +136,6 @@ parameters:
 			path: ../../Classes/Core/Functional/Framework/Frontend/Collector.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: ../../Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
-
-		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 2
 			path: ../../Classes/Core/Functional/Framework/Frontend/InternalRequest.php

--- a/Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
+++ b/Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
@@ -29,10 +29,6 @@ abstract class AbstractInstruction implements \JsonSerializable
      */
     protected $identifier;
 
-    /**
-     * @param array $data
-     * @return static
-     */
     public static function fromArray(array $data): self
     {
         if (empty($data['__type'])) {
@@ -61,6 +57,7 @@ abstract class AbstractInstruction implements \JsonSerializable
         if (self::class === static::class) {
             return $data['__type']::fromArray($data);
         }
+        /** @phpstan-ignore-next-line Avoid 'Unsafe usage of new static' error. This is needed by design and considerable safe with the above checks*/
         $target = new static($data['identifier']);
         unset($data['__type'], $data['identifier']);
         return $target->with($data);


### PR DESCRIPTION
doc-block return type is contrary to native php return type.
This leads to (new) reporting by phpstan which is confused
and interpets this that static(class) should be returned
instead of an instance of class, which is return by using
'new static()' - which is already reported as unsafe.

The implementation of AbstractInstruction and corresponding
child classes can considered safe. This patch removes the
doc-block and add 'phpstan-ignore-next-line' notation to
suppress unsafe warning, which is removed from baseline file.

used command:

> Build/Scripts/runTests.sh -s phpstanGenerateBaseline

Releases: main, 7, 6

