### PR TITLE
[BUGFIX] Bump the `psr/container` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^8.1",
     "phpunit/phpunit": "^9.5.10",
-    "psr/container": "^1.0",
+    "psr/container": "^1.1.0 || ^2.0.0",
     "mikey179/vfsstream": "~1.6.10",
     "typo3fluid/fluid": "^2.7.1",
     "typo3/cms-core": "12.*.*@dev",


### PR DESCRIPTION
- require at least version 1.1.0 to fix a signature mismatch
  for `get(string $id)` (which caused a crash with `psr/container`
  1.0)
- also allow version 2

This problem was found while running the CI of the Tea example extension with the latest version of the testing framework, but using the lowest possible other dependencies: https://github.com/TYPO3-Documentation/tea/actions/runs/1962922210