### PR TITLE
[TASK] Directly use InternalRequest instead of new ServerRequest

### DIFF
--- a/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
+++ b/Classes/Core/Functional/Framework/Frontend/InternalRequest.php
@@ -16,7 +16,8 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\Frontend;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Core\Http\Request;
+use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\TestingFramework\Core\Functional\Framework\AssignablePropertyTrait;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\AbstractInstruction;
@@ -28,7 +29,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\AbstractI
  * It provides some convenient helper methods like ->withPageId() to easily set up a frontend request.
  * It is later turned into a request implementing PSR-7 ServerRequestInterface.
  */
-class InternalRequest extends Request
+class InternalRequest extends ServerRequest
 {
     use AssignablePropertyTrait;
 
@@ -36,8 +37,6 @@ class InternalRequest extends Request
      * @var AbstractInstruction[]
      */
     protected $instructions = [];
-
-    protected ?array $parsedBody = null;
 
     /**
      * @param array $data
@@ -163,16 +162,11 @@ class InternalRequest extends Request
         return $this->instructions[$identifier] ?? null;
     }
 
-    public function withParsedBody(?array $parsedBody=null): InternalRequest
+    public function withServerParams(array $serverParams): InternalRequest
     {
         $target = clone $this;
-        $target->parsedBody = $parsedBody;
+        $target->serverParams = $serverParams;
         return $target;
-    }
-
-    public function getParsedBody(): ?array
-    {
-        return $this->parsedBody;
     }
 
     /**
@@ -193,5 +187,19 @@ class InternalRequest extends Request
         $parameters = \GuzzleHttp\Psr7\Query::parse($query);
         $parameters[$parameterName] = $value;
         return \GuzzleHttp\Psr7\Query::build($parameters);
+    }
+
+    /**
+     * Retrieves the URI instance.
+     *
+     * This method MUST return a UriInterface instance.
+     *
+     * @link https://tools.ietf.org/html/rfc3986#section-4.3
+     * @return \Psr\Http\Message\UriInterface Returns a UriInterface instance
+     *     representing the URI of the request.
+     */
+    public function getUri(): UriInterface
+    {
+        return parent::getUri();
     }
 }


### PR DESCRIPTION
This pullrequest extends InternalRequest from ServerRequest
instead of psr request. Additional the provided prepared
InternalRequest is directly used to handle the frontend
request stack.

Fallback code to prepare some data has been kept.

**Releases:** main, 7

**Gerrit:** https://review.typo3.org/c/Packages/TYPO3.CMS/+/73990

**Note:** Core (Gerrit) patch must be merged after this PR is merged,
to avoid failing core nightly afterwards. Core patch adjusts two tests.