### PR TITLE
[TASK] Make it clear that processingfolder is not typo3temp

### DIFF
--- a/Resources/Core/Functional/Fixtures/sys_file_storage.xml
+++ b/Resources/Core/Functional/Fixtures/sys_file_storage.xml
@@ -4,7 +4,7 @@
 		<uid>1</uid>
 		<pid>0</pid>
 		<name>fileadmin/ (auto-created)</name>
-		<processingfolder>typo3temp/assets/_processed_/</processingfolder>
+		<processingfolder>temp/assets/_processed_/</processingfolder>
 		<driver>Local</driver>
 		<configuration><![CDATA[<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <T3FlexForms>


### PR DESCRIPTION
The previously set processingfolder starting with typo3temp could be confused with the actual typo3temp folder of TYPO3 which is not the same folder in reality as the folder in this case is a subdirectory of the file storage (fileadmin) in this case.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/73932 which brought up this confusion.