### PR TITLE
[BUGFIX] Add the PDO PHP extension as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   },
   "require": {
     "php": "^8.1",
+    "ext-pdo": "*",
     "phpunit/phpunit": "^9.5.10",
     "psr/container": "^1.1.0 || ^2.0.0",
     "mikey179/vfsstream": "~1.6.10",


### PR DESCRIPTION
As we are using the `PDO` class, we need to have it as an explicit
requirement in order to get a proper warning when the extension
is missing (instead of random breakage).

Releases: main, 7, 6