### PR TITLE
[!!!][TASK] Use session identifier JWT when initializing sessions

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -474,9 +474,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $userRow = $this->getBackendUserRecordFromDatabase($userUid);
         $backendUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
         $session = $backendUser->createUserSession($userRow);
-        $sessionId = $session->getIdentifier();
         $request = $this->createServerRequest('https://typo3-testing.local/typo3/');
-        $request = $request->withCookieParams(['be_typo_user' => $sessionId]);
+        $request = $request->withCookieParams(['be_typo_user' => $session->getJwt()]);
         $backendUser = $this->authenticateBackendUser($backendUser, $request);
         // @todo: remove this with the next major version
         $GLOBALS['BE_USER'] = $backendUser;

--- a/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/FrontendUserHandler.php
@@ -58,7 +58,7 @@ class FrontendUserHandler implements MiddlewareInterface
                 array_replace(
                     $request->getCookieParams(),
                     [
-                        'fe_typo_user' => $userSession->getIdentifier(),
+                        'fe_typo_user' => $userSession->getJwt(),
                     ]
                 )
             );


### PR DESCRIPTION
see https://review.typo3.org/c/Packages/TYPO3.CMS/+/69337

Frontend and Backend Cookies are not just the plain session identifier anymore, but the cookie values a hash-signed JWT containing the corresponding session identifier.