### PR TITLE
[TASK] Make the type annotations of the base test classes more specific

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -84,12 +84,16 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
     /**
      * An unique identifier for this test case. Location of the test
      * instance and database name depend on this. Calculated early in setUp()
+     *
+     * @var non-empty-string
      */
     protected string $identifier;
 
     /**
      * Absolute path to test instance document root. Depends on $identifier.
      * Calculated early in setUp()
+     *
+     * @var non-empty-string
      */
     protected string $instancePath;
 
@@ -108,7 +112,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * A default list of core extensions is always loaded.
      *
      * @see FunctionalTestCaseUtility $defaultActivatedCoreExtensions
-     * @var array<int, string>
+     *
+     * @var non-empty-string[]
      */
     protected array $coreExtensionsToLoad = [];
 
@@ -130,7 +135,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * Extensions in this array are linked to the test instance, loaded
      * and their ext_tables.sql will be applied.
      *
-     * @var string[]
+     * @var non-empty-string[]
      */
     protected array $testExtensionsToLoad = [];
 
@@ -158,7 +163,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * To be able to link from my_own_ext the extension path needs also to be registered in
      * property $testExtensionsToLoad
      *
-     * @var string[]
+     * @var array<string, non-empty-string>
      */
     protected array $pathsToLinkInTestInstance = [];
 
@@ -174,13 +179,15 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      *   'typo3/sysext/lowlevel/Tests/Functional/Fixtures/testImage/someImage.jpg' => 'fileadmin/_processed_/0/a/someImage.jpg',
      * ]
      *
-     * @var string[]
+     * @var array<string, non-empty-string>
      */
     protected array $pathsToProvideInTestInstance = [];
 
     /**
      * This configuration array is merged with TYPO3_CONF_VARS
      * that are set in default configuration and factory configuration
+     *
+     * @var array<string, mixed>
      */
     protected array $configurationToUseInTestInstance = [];
 
@@ -204,11 +211,15 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * [
      *   'fileadmin/user_upload'
      * ]
+     *
+     * @var non-empty-string[]
      */
     protected array $additionalFoldersToCreate = [];
 
     /**
      * The fixture which is used when initializing a backend user
+     *
+     * @var non-empty-string
      */
     protected string $backendUserFixture = 'PACKAGE:typo3/testing-framework/Resources/Core/Functional/Fixtures/be_users.xml';
 
@@ -561,7 +572,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
     /**
      * Imports a data set represented as XML into the test database,
      *
-     * @param string $path Absolute path to the XML file containing the data set to load
+     * @param non-empty-string $path Absolute path to the XML file containing the data set to load
      * @throws Exception
      */
     protected function importDataSet(string $path): void
@@ -1126,12 +1137,17 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
 
     /**
      * Uses a 7 char long hash of class name as identifier.
+     *
+     * @return non-empty-string
      */
     protected static function getInstanceIdentifier(): string
     {
         return substr(sha1(static::class), 0, 7);
     }
 
+    /**
+     * @return non-empty-string
+     */
     protected static function getInstancePath(): string
     {
         $identifier = self::getInstanceIdentifier();

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -147,7 +147,7 @@ class Testbase
      * Remove test instance folder structure if it exists.
      * This may happen if a functional test before threw a fatal or is too old
      *
-     * @param string $instancePath Absolute path to test instance
+     * @param non-empty-string $instancePath Absolute path to test instance
      * @throws Exception
      */
     public function removeOldInstanceIfExists($instancePath): void
@@ -174,7 +174,7 @@ class Testbase
      * Link TYPO3 CMS core from "parent" instance.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
+     * @param non-empty-string $instancePath Absolute path to test instance
      * @throws Exception
      */
     public function setUpInstanceCoreLinks($instancePath): void
@@ -233,8 +233,8 @@ class Testbase
      * Link test extensions to the typo3conf/ext folder of the instance.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
-     * @param array $extensionPaths Contains paths to extensions relative to document root
+     * @param non-empty-string $instancePath Absolute path to test instance
+     * @param non-empty-string[] $extensionPaths Contains paths to extensions relative to document root
      * @throws Exception
      */
     public function linkTestExtensionsToInstance($instancePath, array $extensionPaths): void
@@ -262,8 +262,8 @@ class Testbase
      * Link framework extensions to the typo3conf/ext folder of the instance.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
-     * @param array $extensionPaths Contains paths to extensions relative to document root
+     * @param non-empty-string $instancePath Absolute path to test instance
+     * @param non-empty-string[] $extensionPaths Contains paths to extensions relative to document root
      * @throws Exception
      */
     public function linkFrameworkExtensionsToInstance($instancePath, array $extensionPaths): void
@@ -292,8 +292,8 @@ class Testbase
      * test instance fileadmin folder.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
-     * @param array $pathsToLinkInTestInstance Contains paths as array of source => destination in key => value pairs of folders relative to test instance root
+     * @param non-empty-string $instancePath Absolute path to test instance
+     * @param array<string, non-empty-string> $pathsToLinkInTestInstance Contains paths as array of source => destination in key => value pairs of folders relative to test instance root
      * @throws Exception if a source path could not be found and on failing creating the symlink
      */
     public function linkPathsInTestInstance($instancePath, array $pathsToLinkInTestInstance): void
@@ -325,8 +325,8 @@ class Testbase
      *
      * For functional and acceptance tests.
      *
-     * @param string $instancePath
-     * @param array $pathsToProvideInTestInstance
+     * @param non-empty-string $instancePath
+     * @param array<string, non-empty-string> $pathsToProvideInTestInstance
      * @throws Exception
      */
     public function providePathsInTestInstance(string $instancePath, array $pathsToProvideInTestInstance): void
@@ -468,7 +468,7 @@ class Testbase
      * Create LocalConfiguration.php file of the test instance.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
+     * @param non-empty-string $instancePath Absolute path to test instance
      * @param array $configuration Base configuration array
      * @param array $overruleConfiguration Overrule factory and base configuration
      * @throws Exception
@@ -499,11 +499,11 @@ class Testbase
      * and a list of test extensions.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
-     * @param array $defaultCoreExtensionsToLoad Default list of core extensions to load
-     * @param array $additionalCoreExtensionsToLoad Additional core extensions to load
-     * @param array $testExtensionPaths Paths to test extensions relative to document root
-     * @param array $frameworkExtensionPaths Paths to framework extensions relative to testing framework package
+     * @param non-empty-string $instancePath Absolute path to test instance
+     * @param non-empty-string[] $defaultCoreExtensionsToLoad Default list of core extensions to load
+     * @param non-empty-string[] $additionalCoreExtensionsToLoad Additional core extensions to load
+     * @param non-empty-string[] $testExtensionPaths Paths to test extensions relative to document root
+     * @param non-empty-string[] $frameworkExtensionPaths Paths to framework extensions relative to testing framework package
      * @throws Exception
      */
     public function setUpPackageStates(
@@ -614,7 +614,7 @@ class Testbase
      * Bootstrap basic TYPO3. This bootstraps TYPO3 far enough to initialize database afterwards.
      * For functional and acceptance tests.
      *
-     * @param string $instancePath Absolute path to test instance
+     * @param non-empty-string $instancePath Absolute path to test instance
      * @return ContainerInterface
      */
     public function setUpBasicTypo3Bootstrap($instancePath): ContainerInterface
@@ -780,7 +780,7 @@ class Testbase
     /**
      * Imports a data set represented as XML into the test database,
      *
-     * @param string $path Absolute path to the XML file containing the data set to load
+     * @param non-empty-string $path Absolute path to the XML file containing the data set to load
      * @throws DBALException
      * @throws \InvalidArgumentException
      * @throws \RuntimeException

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -62,12 +62,16 @@ abstract class UnitTestCase extends BaseTestCase
      * Absolute path to files that should be removed after a test.
      * Handled in tearDown. Tests can register here to get any files
      * within typo3temp/ or typo3conf/ext cleaned up again.
+     *
+     * @var non-empty-string[]
      */
     protected array $testFilesToDelete = [];
 
     /**
      * Holds state of TYPO3\CMS\Core\Core\Environment if
      * $this->backupEnvironment has been set to true in a test case
+     *
+     * @var array<string, mixed>
      */
     private array $backedUpEnvironment = [];
 


### PR DESCRIPTION
This helps developers provide the correct data in their tests, and spot
problems using static analysis more easily.

Also make some type annotations more loose in order to lift
unnecessary restrictions.

Releases: main, 7, 6