### PR TITLE
Feature: caching of DependencyInjectionContainer to speedup execution

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -50,7 +50,6 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3\TestingFramework\Core\Testbase;
 
-
 /**
  * Base test case class for functional tests, all TYPO3 CMS
  * functional tests should extend from this class!

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -367,7 +367,49 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
                     'Resources/Core/Functional/Extensions/private_container',
                 ]
             );
+
+            // Cache the Dependency Injection Container, which is dependent on the PackageStates file
+            $pstate_file = $this->instancePath. '/typo3conf/PackageStates.php';
+
+            // make sure, to only cache the same combination of Packages
+            $package_md5 = md5(file_get_contents($pstate_file));
+
+            // set cache Path next to function Testing Folder
+            $cache_dir = dirname($this->instancePath).'/cache';
+            $cached_di = $cache_dir.'/di_'.$package_md5.'.php';
+
+            // load modification Time (which is different, since it was just created)
+            $mTime = @filemtime($pstate_file);
+
+            // generate cache identifer, the same way typo3 does
+            $cacheIdentifier = md5((string)(new Typo3Version()) . $pstate_file . $mTime);
+            $baseIdentifier = sha1((new Typo3Version())->getVersion() . $this->instancePath . $cacheIdentifier);
+            $current_cache_identifier = 'DependencyInjectionContainer_'.$baseIdentifier;
+
+            // if there is a cache file, copy it over
+            if (is_file($cached_di)) {
+                // create DI container cache folder
+                mkdir($this->instancePath.'/typo3temp/var/cache/code/di/', 0755, true);
+
+                // load cache and replace IDENTIFIER with current Identifier
+                $cache = file_get_contents($cached_di);
+                file_put_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $current_cache_identifier.'.php', str_replace('######CACHE_IDENTIFIER######', $current_cache_identifier, $cache));
+                unset($cache);
+            }
+
             $this->container = $testbase->setUpBasicTypo3Bootstrap($this->instancePath);
+
+            // if there was no cache file, copy the generated over
+            if (!is_file($cached_di)) {
+                // create cache directory if not present
+                if (!is_dir($cache_dir)) mkdir($cache_dir, 0755, true);
+
+                // replace current identifier with Placeholder
+                $cache = file_get_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $current_cache_identifier.'.php');
+                file_put_contents($cached_di, str_replace($current_cache_identifier, '######CACHE_IDENTIFIER######', $cache));
+                unset($cache);
+            }
+
             if ($this->initializeDatabase) {
                 if ($dbDriver !== 'pdo_sqlite') {
                     $testbase->setUpTestDatabase($dbName, $originalDatabaseName);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -369,44 +369,44 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             );
 
             // Cache the Dependency Injection Container, which is dependent on the PackageStates file
-            $pstate_file = $this->instancePath. '/typo3conf/PackageStates.php';
+            $pstateFile = $this->instancePath. '/typo3conf/PackageStates.php';
 
             // make sure, to only cache the same combination of Packages
-            $package_md5 = md5(file_get_contents($pstate_file));
+            $packageMd5 = md5(file_get_contents($pstateFile));
 
             // set cache Path next to function Testing Folder
-            $cache_dir = dirname($this->instancePath).'/cache';
-            $cached_di = $cache_dir.'/di_'.$package_md5.'.php';
+            $cacheDir = dirname($this->instancePath).'/cache';
+            $cachedDi = $cacheDir.'/di_'.$packageMd5.'.php';
 
             // load modification Time (which is different, since it was just created)
-            $mTime = @filemtime($pstate_file);
+            $mTime = @filemtime($pstateFile);
 
             // generate cache identifer, the same way typo3 does
-            $cacheIdentifier = md5((string)(new Typo3Version()) . $pstate_file . $mTime);
+            $cacheIdentifier = md5((string)(new Typo3Version()) . $pstateFile . $mTime);
             $baseIdentifier = sha1((new Typo3Version())->getVersion() . $this->instancePath . $cacheIdentifier);
-            $current_cache_identifier = 'DependencyInjectionContainer_'.$baseIdentifier;
+            $currentCacheIdentifier = 'DependencyInjectionContainer_'.$baseIdentifier;
 
             // if there is a cache file, copy it over
-            if (is_file($cached_di)) {
+            if (is_file($cachedDi)) {
                 // create DI container cache folder
                 mkdir($this->instancePath.'/typo3temp/var/cache/code/di/', 0755, true);
 
                 // load cache and replace IDENTIFIER with current Identifier
-                $cache = file_get_contents($cached_di);
-                file_put_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $current_cache_identifier.'.php', str_replace('######CACHE_IDENTIFIER######', $current_cache_identifier, $cache));
+                $cache = file_get_contents($cachedDi);
+                file_put_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $currentCacheIdentifier.'.php', str_replace('######CACHE_IDENTIFIER######', $currentCacheIdentifier, $cache));
                 unset($cache);
             }
 
             $this->container = $testbase->setUpBasicTypo3Bootstrap($this->instancePath);
 
             // if there was no cache file, copy the generated over
-            if (!is_file($cached_di)) {
+            if (!is_file($cachedDi)) {
                 // create cache directory if not present
-                if (!is_dir($cache_dir)) mkdir($cache_dir, 0755, true);
+                if (!is_dir($cacheDir)) mkdir($cacheDir, 0755, true);
 
                 // replace current identifier with Placeholder
-                $cache = file_get_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $current_cache_identifier.'.php');
-                file_put_contents($cached_di, str_replace($current_cache_identifier, '######CACHE_IDENTIFIER######', $cache));
+                $cache = file_get_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $currentCacheIdentifier.'.php');
+                file_put_contents($cachedDi, str_replace($currentCacheIdentifier, '######CACHE_IDENTIFIER######', $cache));
                 unset($cache);
             }
 

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -369,14 +369,14 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             );
 
             // Cache the Dependency Injection Container, which is dependent on the PackageStates file
-            $pstateFile = $this->instancePath. '/typo3conf/PackageStates.php';
+            $pstateFile = $this->instancePath . '/typo3conf/PackageStates.php';
 
             // make sure, to only cache the same combination of Packages
             $packageMd5 = md5(file_get_contents($pstateFile));
 
             // set cache Path next to function Testing Folder
-            $cacheDir = dirname($this->instancePath).'/cache';
-            $cachedDi = $cacheDir.'/di_'.$packageMd5.'.php';
+            $cacheDir = dirname($this->instancePath) . '/cache';
+            $cachedDi = $cacheDir . '/di_' . $packageMd5 . '.php';
 
             // load modification Time (which is different, since it was just created)
             $mTime = @filemtime($pstateFile);
@@ -384,16 +384,16 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             // generate cache identifer, the same way typo3 does
             $cacheIdentifier = md5((string)(new Typo3Version()) . $pstateFile . $mTime);
             $baseIdentifier = sha1((new Typo3Version())->getVersion() . $this->instancePath . $cacheIdentifier);
-            $currentCacheIdentifier = 'DependencyInjectionContainer_'.$baseIdentifier;
+            $currentCacheIdentifier = 'DependencyInjectionContainer_' . $baseIdentifier;
 
             // if there is a cache file, copy it over
             if (is_file($cachedDi)) {
                 // create DI container cache folder
-                mkdir($this->instancePath.'/typo3temp/var/cache/code/di/', 0755, true);
+                mkdir($this->instancePath . '/typo3temp/var/cache/code/di/', 0755, true);
 
                 // load cache and replace IDENTIFIER with current Identifier
                 $cache = file_get_contents($cachedDi);
-                file_put_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $currentCacheIdentifier.'.php', str_replace('######CACHE_IDENTIFIER######', $currentCacheIdentifier, $cache));
+                file_put_contents($this->instancePath . '/typo3temp/var/cache/code/di/' . $currentCacheIdentifier . '.php', str_replace('######CACHE_IDENTIFIER######', $currentCacheIdentifier, $cache));
                 unset($cache);
             }
 
@@ -402,10 +402,12 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             // if there was no cache file, copy the generated over
             if (!is_file($cachedDi)) {
                 // create cache directory if not present
-                if (!is_dir($cacheDir)) mkdir($cacheDir, 0755, true);
+                if (!is_dir($cacheDir)) {
+                    mkdir($cacheDir, 0755, true);
+                }
 
                 // replace current identifier with Placeholder
-                $cache = file_get_contents($this->instancePath.'/typo3temp/var/cache/code/di/'. $currentCacheIdentifier.'.php');
+                $cache = file_get_contents($this->instancePath . '/typo3temp/var/cache/code/di/' . $currentCacheIdentifier . '.php');
                 file_put_contents($cachedDi, str_replace($currentCacheIdentifier, '######CACHE_IDENTIFIER######', $cache));
                 unset($cache);
             }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -48,6 +49,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\FrameworkState;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 use TYPO3\TestingFramework\Core\Testbase;
+
 
 /**
  * Base test case class for functional tests, all TYPO3 CMS


### PR DESCRIPTION
### Changes proposed in this pull request

When executing Function TestCases Typo3 is generated with every TestCases executed. This will lead to the regeneration (or first generation) of the DependencyInjectionContainer every run. Which takes a big amount of time. This will cache the correct DependencyInjectionContainer for the used Extensions in this test/any other test. Since the Classes will not change while execution of the TestSuite the generated Data will always be the same.


### Steps to test the solution

Run TestSuite with this changes, and see faster execution of TestCases. (on my maschine it was ~10sec per Testcase which were saved.)

### Results


Fixes: #371 