### PR TITLE
[BUGFIX] Use Bootstrap 5 modal class

### DIFF
--- a/Classes/Core/Acceptance/Helper/AbstractModalDialog.php
+++ b/Classes/Core/Acceptance/Helper/AbstractModalDialog.php
@@ -33,14 +33,14 @@ abstract class AbstractModalDialog
      *
      * @var string
      */
-    public static $openedModalSelector = '.modal.in';
+    public static $openedModalSelector = '.modal.show';
 
     /**
      * Selector for the container in the modal where the buttons are located
      *
      * @var string
      */
-    public static $openedModalButtonContainerSelector = '.modal.in .modal-footer';
+    public static $openedModalButtonContainerSelector = '.modal.show .modal-footer';
 
     /**
      * @var AcceptanceTester


### PR DESCRIPTION
### Changes proposed in this pull request

Since Bootstrap 4 active modals have the "show" class, instead of the "in" class.
This fix restores compatibility with Bootstrap 5 which is used since TYPO3 CMS 11.

### Steps to test the solution

Running a test that uses ModalDialog (see example in #375) with TYPO3 CMS 11.

### Results

The test should succeed.

Fixes: #375