### PR TITLE
reimport static content after truncate

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -671,6 +671,14 @@ class Testbase
         } else {
             $this->truncateAllTablesForOtherDatabases();
         }
+
+        // reimport static content
+        $schemaMigrationService = GeneralUtility::makeInstance(SchemaMigrator::class);
+        $sqlReader = GeneralUtility::makeInstance(SqlReader::class);
+        $sqlCode = $sqlReader->getTablesDefinitionString(true);
+
+        $insertStatements = $sqlReader->getInsertStatementArray($sqlCode);
+        $schemaMigrationService->importStaticData($insertStatements);
     }
 
     /**


### PR DESCRIPTION
### Changes proposed in this pull request

Reimport Static data into database after truncating All Tables

### Steps to test the solution

Run two TestCases in one class which use Static Data

### Results

Static Data is not missing for Second Test and therefore can be Tested

Fixes: #377
