### PR TITLE
[TASK] Update to typo3/coding-standards:^0.5.3

### DIFF
--- a/Classes/Core/Acceptance/Helper/Acceptance.php
+++ b/Classes/Core/Acceptance/Helper/Acceptance.php
@@ -80,8 +80,8 @@ class Acceptance extends Module
         $messages = [];
         foreach ($browserLogEntries as $logEntry) {
             // We fail only on errors. Warnings and info messages are OK.
-            if (true === isset($logEntry['level'])
-                && true === isset($logEntry['message'])
+            if (isset($logEntry['level']) === true
+                && isset($logEntry['message']) === true
                 && $this->isJSError($logEntry['level'], $logEntry['message'])
             ) {
                 // Timestamp is in milliseconds, but date() requires seconds.

--- a/Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
+++ b/Classes/Core/Functional/Framework/Frontend/Internal/AbstractInstruction.php
@@ -54,7 +54,7 @@ abstract class AbstractInstruction implements \JsonSerializable
             );
         }
 
-        if (self::class === static::class) {
+        if (static::class === self::class) {
             return $data['__type']::fromArray($data);
         }
         /** @phpstan-ignore-next-line Avoid 'Unsafe usage of new static' error. This is needed by design and considerable safe with the above checks*/

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -137,11 +137,11 @@ class Testbase
         }
 
         $commonPath = $to;
-        while (strpos($from . '/', $commonPath . '/') !== 0 && '/' !== $commonPath && preg_match('{^[a-z]:/?$}i', $commonPath) !== false && '.' !== $commonPath) {
+        while (strpos($from . '/', $commonPath . '/') !== 0 && $commonPath !== '/' && preg_match('{^[a-z]:/?$}i', $commonPath) !== false && $commonPath !== '.') {
             $commonPath = str_replace('\\', '/', \dirname($commonPath));
         }
 
-        if ('/' === $commonPath || '.' === $commonPath || 0 !== strpos($from, $commonPath)) {
+        if ($commonPath === '/' || $commonPath === '.' || strpos($from, $commonPath) !== 0) {
             return var_export($to, true);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     }
   },
   "require-dev": {
-    "typo3/coding-standards": "^0.5.0",
+    "typo3/coding-standards": "^0.5.3",
     "phpstan/phpstan": "^1.8.0",
     "phpstan/phpstan-phpunit": "^1.1.1",
     "typo3/cms-workspaces": "10.*.*@dev || 11.*.*@dev"


### PR DESCRIPTION
Apply new non-yoda rule.

> composer req --dev typo3/coding-standards:^0.5.3
> Build/Scripts/runTests.sh -p 8.1 -s cgl

The main purpose of this change is to get the build green again.