### PR TITLE
[FEATURE] Allow loading csv files in acceptance setup

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -21,6 +21,7 @@ use Codeception\Events;
 use Codeception\Extension;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
 use TYPO3\TestingFramework\Core\Testbase;
 
 /**
@@ -145,6 +146,17 @@ abstract class BackendEnvironment extends Extension
          * @var array
          */
         'xmlDatabaseFixtures' => [],
+
+        /**
+         * Array of absolute paths to .csv files to be loaded into database.
+         * This can be used to prime the database with fixture records.
+         *
+         * The core for example uses this to have a default page tree and
+         * to create valid sessions so users are logged-in automatically.
+         *
+         * Example: [ __DIR__ . '/../../Fixtures/BackendEnvironment.csv' ]
+         */
+        'csvDatabaseFixtures' => [],
     ];
 
     /**
@@ -306,6 +318,10 @@ abstract class BackendEnvironment extends Extension
         foreach ($this->config['xmlDatabaseFixtures'] as $fixture) {
             $testbase->importXmlDatabaseFixture($fixture);
         }
+
+        foreach ($this->config['csvDatabaseFixtures'] as $fixture) {
+            $this->importCSVDataSet($fixture);
+        }
     }
 
     /**
@@ -321,5 +337,32 @@ abstract class BackendEnvironment extends Extension
         GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('be_users')
             ->update('be_users', ['uc' => null], ['uid' => 1]);
+    }
+
+    /**
+     * Import data from a CSV file to database.
+     * Single file can contain data from multiple tables.
+     *
+     * @param string $path Absolute path to the CSV file containing the data set to load
+     * @todo: Very similar to FunctionolTestCase->importCSVDataSet() ... we may want to abstract in a better way
+     */
+    private function importCSVDataSet(string $path): void
+    {
+        $dataSet = DataSet::read($path, true);
+        foreach ($dataSet->getTableNames() as $tableName) {
+            $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
+            foreach ($dataSet->getElements($tableName) as $element) {
+                // Some DBMS like postgresql are picky about inserting blob types with correct cast, setting
+                // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL
+                $types = [];
+                $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
+                foreach ($element as $columnName => $columnValue) {
+                    $types[] = $tableDetails->getColumn($columnName)->getType()->getBindingType();
+                }
+                // Insert the row
+                $connection->insert($tableName, $element, $types);
+            }
+            Testbase::resetTableSequences($connection, $tableName);
+        }
     }
 }


### PR DESCRIPTION
In addition to .xml imports, the acceptance test related
BackendEnvironment now allows .csv files to prime the
acceptance test database.

The .csv files are much more slim and easier to read and
maintain. They do not support the EXT: or PACKAGE: prefix
and thus force consumers to provide an own local setup
file: The default fixtures delivered by testing-framework
for current xml imports turned out to be hard to maintain
when core changes db schema, and it's better when extensions
have full control over these files to adapt them to their
needs.

The .xml imports will be deprecated in v6 and v7 with
further patches, and removed in main.

Releases: main, 7, 6
Related: #247