### PR TITLE
[TASK] Deprecated acceptance test xmlDatabaseFixtures config

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -144,6 +144,12 @@ abstract class BackendEnvironment extends Extension
          * Given paths are expected to be relative to your document root.
          *
          * @var array
+         * @deprecated Will be removed with core v12 compatible testing-framework.
+         *             Switch to 'csvDatabaseFixtures' below instead, and deliver
+         *             the default database imports as local file.
+         *             See v12 core/Test/Acceptance/Support/Extension/ApplicationEnvironment.php
+         *             or v12 styleguide Tests/Acceptance/Support/Extension/BackendStyleguideEnvironment.php
+         *             for example transitions.
          */
         'xmlDatabaseFixtures' => [],
 
@@ -315,6 +321,7 @@ abstract class BackendEnvironment extends Extension
         $suite = $suiteEvent->getSuite();
         $suite->setBackupGlobals(false);
 
+        // @deprecated Will be removed with core v12 compatible testing-framework. See property comment.
         foreach ($this->config['xmlDatabaseFixtures'] as $fixture) {
             $testbase->importXmlDatabaseFixture($fixture);
         }

--- a/Resources/Core/Acceptance/Fixtures/be_groups.xml
+++ b/Resources/Core/Acceptance/Fixtures/be_groups.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- @deprecated Will be removed with core v12 compatible testing-framework.
+                 See comment on 'xmlDatabaseFixtures' in BackendEnvironment.php -->
 <dataset>
 	<be_groups>
 		<uid>1</uid>

--- a/Resources/Core/Acceptance/Fixtures/be_sessions.xml
+++ b/Resources/Core/Acceptance/Fixtures/be_sessions.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- @deprecated Will be removed with core v12 compatible testing-framework.
+                 See comment on 'xmlDatabaseFixtures' in BackendEnvironment.php -->
 <dataset>
     <be_sessions>
         <!-- hash_hmac('sha256', '886526ce72b86870739cc41991144ec1', sha1('iAmInvalid' . 'core-session-backend')) -->

--- a/Resources/Core/Acceptance/Fixtures/be_users.xml
+++ b/Resources/Core/Acceptance/Fixtures/be_users.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- @deprecated Will be removed with core v12 compatible testing-framework.
+                 See comment on 'xmlDatabaseFixtures' in BackendEnvironment.php -->
 <dataset>
 	<be_users>
 		<uid>1</uid>

--- a/Resources/Core/Acceptance/Fixtures/sys_category.xml
+++ b/Resources/Core/Acceptance/Fixtures/sys_category.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- @deprecated Will be removed with core v12 compatible testing-framework.
+                 See comment on 'xmlDatabaseFixtures' in BackendEnvironment.php -->
 <dataset>
     <sys_category>
         <uid>1</uid>

--- a/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml
+++ b/Resources/Core/Acceptance/Fixtures/tx_extensionmanager_domain_model_extension.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- @deprecated Will be removed with core v12 compatible testing-framework.
+                 See comment on 'xmlDatabaseFixtures' in BackendEnvironment.php -->
 <dataset>
     <tx_extensionmanager_domain_model_extension>
         <uid>1</uid>


### PR DESCRIPTION
Encourage consumers to switch to csvDatabaseFixtures instead.
The xml import and the fixture files will be dropped in v12
compatible main branch with an additional patch.

Releases: main, 7, 6
Related: #247