### PR TITLE
[FEATURE] Allow restore callback in functional test snapshot

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1119,8 +1119,11 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      *
      * An example to this are the "SiteHandling" core tests, which create
      * a starter scenario using DataHandler based on Yaml files.
+     *
+     * @param callable|null $createCallback Optional callback executed just before the snapshot is created
+     * @param callable|null $restoreCallback Optional callback executed after a snapshot has been restored
      */
-    protected function withDatabaseSnapshot(callable $callback): void
+    protected function withDatabaseSnapshot(?callable $createCallback = null, ?callable $restoreCallback = null): void
     {
         $connection = $this->getConnectionPool()->getConnectionByName(
             ConnectionPool::DEFAULT_CONNECTION_NAME
@@ -1128,10 +1131,15 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $accessor = new DatabaseAccessor($connection);
         $snapshot = DatabaseSnapshot::instance();
         if ($this->isFirstTest) {
-            $callback();
+            if ($createCallback) {
+                $createCallback();
+            }
             $snapshot->create($accessor, $connection);
         } else {
             $snapshot->restore($accessor, $connection);
+            if ($restoreCallback) {
+                $restoreCallback();
+            }
         }
     }
 


### PR DESCRIPTION
The "snapshotter" is handy when priming the database in
setUp() with data in functional tests is expensive. Examples
are the "yaml" scenario core tests that feed DataHandler
with stuff, which takes some time. With the snapshotter,
subsequest tests of the test case are significantly quicker
since they avoid the calculation and just feed DB with records.

Main method withDatabaseSnapshot() takes a callback that is
executed right before *creating* the snapshot. That's the place
where record creation is located.
The patch adds a second callback that is executed just after
snapshots are restored. This allows post-initialization after
restore to for instance set up additional objects.
Additionally, both callbacks are now optional.