### PR TITLE
[TASK] Deprecate auto-import of ext_tables_static+adt.sql files

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -767,12 +767,16 @@ class Testbase
     {
         $schemaMigrationService = GeneralUtility::makeInstance(SchemaMigrator::class);
         $sqlReader = GeneralUtility::makeInstance(SqlReader::class);
+        // @todo: Remove argument when the deprecation below is removed.
         $sqlCode = $sqlReader->getTablesDefinitionString(true);
-
         $createTableStatements = $sqlReader->getCreateTableStatementArray($sqlCode);
-
         $schemaMigrationService->install($createTableStatements);
-
+        // @deprecated: Will be removed with core v12 compatible testing-framework.
+        //              We will no longer read and auto-apply rows from ext_tables_static+adt.sql files.
+        //              Test cases that rely on this should either (recommended) supply according rows
+        //              as .csv fixture files and import them using importCSVDataSet(), or (not recommended)
+        //              call SqlReader and SchemaMigrator to manually import ext_tables_static+adt.sql
+        //              files in setUp().
         $insertStatements = $sqlReader->getInsertStatementArray($sqlCode);
         $schemaMigrationService->importStaticData($insertStatements);
     }


### PR DESCRIPTION
The auto-import of ext_tables_static+adt.sql files in
functional tests is unfortunate in testing-framework
since it creates a non-reliable dependency to potentially
third-party extensions and adds headaches with the snapshot
functionality.

Test cases should instead import needed data using
importCSVDataset(), or call the SchemaManager to apply
static rows from these files on their own.

The patch deprecates this functionality in 6, 7 and main,
another patch will then remove it in main altogether.

Releases: main, 7, 6
Related: #377
Related: #359