### PR TITLE
[TASK] Merge importCSVDataSet() as DataSet::import()

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -307,7 +307,7 @@ abstract class BackendEnvironment extends Extension
         $suite->setBackupGlobals(false);
 
         foreach ($this->config['csvDatabaseFixtures'] as $fixture) {
-            $this->importCSVDataSet($fixture);
+            DataSet::import($fixture);
         }
     }
 
@@ -324,32 +324,5 @@ abstract class BackendEnvironment extends Extension
         GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('be_users')
             ->update('be_users', ['uc' => null], ['uid' => 1]);
-    }
-
-    /**
-     * Import data from a CSV file to database.
-     * Single file can contain data from multiple tables.
-     *
-     * @param string $path Absolute path to the CSV file containing the data set to load
-     * @todo: Very similar to FunctionolTestCase->importCSVDataSet() ... we may want to abstract in a better way
-     */
-    private function importCSVDataSet(string $path): void
-    {
-        $dataSet = DataSet::read($path, true);
-        foreach ($dataSet->getTableNames() as $tableName) {
-            $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
-            foreach ($dataSet->getElements($tableName) as $element) {
-                // Some DBMS like postgresql are picky about inserting blob types with correct cast, setting
-                // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL
-                $types = [];
-                $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
-                foreach ($element as $columnName => $columnValue) {
-                    $types[] = $tableDetails->getColumn($columnName)->getType()->getBindingType();
-                }
-                // Insert the row
-                $connection->insert($tableName, $element, $types);
-            }
-            Testbase::resetTableSequences($connection, $tableName);
-        }
     }
 }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -559,28 +559,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      */
     public function importCSVDataSet(string $path): void
     {
-        $dataSet = DataSet::read($path, true);
-
-        foreach ($dataSet->getTableNames() as $tableName) {
-            $connection = $this->getConnectionPool()->getConnectionForTable($tableName);
-            foreach ($dataSet->getElements($tableName) as $element) {
-                try {
-                    // Some DBMS like postgresql are picky about inserting blob types with correct cast, setting
-                    // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL
-                    $types = [];
-                    $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
-                    foreach ($element as $columnName => $columnValue) {
-                        $types[] = $tableDetails->getColumn($columnName)->getType()->getBindingType();
-                    }
-
-                    // Insert the row
-                    $connection->insert($tableName, $element, $types);
-                } catch (DBALException $e) {
-                    self::fail('SQL Error for table "' . $tableName . '": ' . LF . $e->getMessage());
-                }
-            }
-            Testbase::resetTableSequences($connection, $tableName);
-        }
+        DataSet::import($path);
     }
 
     /**


### PR DESCRIPTION
To avoid code duplication in FunctionalTestCase
with ac test related BackendEnvironment, the body
of importCSVDataSet() is merged as DataSet::import().