### PR TITLE
[TASK] Prepare removal of core RootlineUtility::$rootlineFields

### DIFF
--- a/Classes/Core/Functional/Framework/FrameworkState.php
+++ b/Classes/Core/Functional/Framework/FrameworkState.php
@@ -66,9 +66,15 @@ class FrameworkState
         $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
         $rootlineUtilityLocalCache->setAccessible(true);
         $state['rootlineUtilityLocalCache'] = $rootlineUtilityLocalCache->getValue();
-        $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
-        $rootlineUtilityRootlineFields->setAccessible(true);
-        $state['rootlineUtilityRootlineFields'] = $rootlineUtilityRootlineFields->getValue();
+
+        try {
+            $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
+            $rootlineUtilityRootlineFields->setAccessible(true);
+            $state['rootlineUtilityRootlineFields'] = $rootlineUtilityRootlineFields->getValue();
+        } catch (\ReflectionException $e) {
+            // @todo: Remove full block when rootlineFields has been removed from core RootlineUtility
+        }
+
         $rootlineUtilityPageRecordCache = $rootlineUtilityReflection->getProperty('pageRecordCache');
         $rootlineUtilityPageRecordCache->setAccessible(true);
         $state['rootlineUtilityPageRecordCache'] = $rootlineUtilityPageRecordCache->getValue();
@@ -93,10 +99,15 @@ class FrameworkState
         RootlineUtility::purgeCaches();
         $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
         $rootlineFieldsDefault = $rootlineUtilityReflection->getDefaultProperties();
-        $rootlineFieldsDefault = $rootlineFieldsDefault['rootlineFields'];
-        $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
-        $rootlineUtilityRootlineFields->setAccessible(true);
-        $state['rootlineUtilityRootlineFields'] = $rootlineFieldsDefault;
+
+        try {
+            $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
+            $rootlineFieldsDefault = $rootlineFieldsDefault['rootlineFields'];
+            $rootlineUtilityRootlineFields->setAccessible(true);
+            $state['rootlineUtilityRootlineFields'] = $rootlineFieldsDefault;
+        } catch (\ReflectionException $e) {
+            // @todo: Remove full block when rootlineFields has been removed from core RootlineUtility
+        }
     }
 
     /**
@@ -127,9 +138,15 @@ class FrameworkState
         $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
         $rootlineUtilityLocalCache->setAccessible(true);
         $rootlineUtilityLocalCache->setValue($state['rootlineUtilityLocalCache']);
-        $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
-        $rootlineUtilityRootlineFields->setAccessible(true);
-        $rootlineUtilityRootlineFields->setValue($state['rootlineUtilityRootlineFields']);
+
+        try {
+            $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
+            $rootlineUtilityRootlineFields->setAccessible(true);
+            $rootlineUtilityRootlineFields->setValue($state['rootlineUtilityRootlineFields']);
+        } catch (\ReflectionException $e) {
+            // @todo: Remove full block when rootlineFields has been removed from core RootlineUtility
+        }
+
         $rootlineUtilityPageRecordCache = $rootlineUtilityReflection->getProperty('pageRecordCache');
         $rootlineUtilityPageRecordCache->setAccessible(true);
         $rootlineUtilityPageRecordCache->setValue($state['rootlineUtilityPageRecordCache']);


### PR DESCRIPTION
Core v12 will probably drop this property. It is handled
in the FrameworkState class for state reset in functional
tests.

Prepare that class for removal of the property by
catching a ReflectionException that will be thrown
when the property in core is gone.

Releases: main, 7