### PR TITLE
[BUGFIX] Use codeception change for codeception compat class switch

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -17,19 +17,17 @@ declare(strict_types=1);
 
 namespace TYPO3\TestingFramework\Core\Acceptance\Extension;
 
-use TYPO3\CMS\Core\Information\Typo3Version;
-
 /**
  * This is an ugly hack exclusively for testing-framework v7 to allow
- * both codeception 4 (core v11) and 5 (core v12) at the same time.
+ * both codeception 4 and 5 to be used for core v11 and v12 at the same time.
  *
  * Problem is the codeception API is hard breaking between codeception 4 and 5,
  * especially due to new type hints on properties that we have to use.
  */
-if (((new Typo3Version())->getMajorVersion() >= 12)) {
-    class_alias(BackendEnvironmentCoreTwelve::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Extension\\BackendEnvironmentCoreConditionalParent');
+if (method_exists(\Codeception\Suite::class, 'backupGlobals')) {
+    class_alias(BackendEnvironmentCodeceptionFive::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Extension\\BackendEnvironmentCoreConditionalParent');
 } else {
-    class_alias(BackendEnvironmentCoreEleven::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Extension\\BackendEnvironmentCoreConditionalParent');
+    class_alias(BackendEnvironmentCodeceptionFour::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Extension\\BackendEnvironmentCoreConditionalParent');
 }
 
 abstract class BackendEnvironment extends BackendEnvironmentCoreConditionalParent

--- a/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFive.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFive.php
@@ -32,14 +32,14 @@ use TYPO3\TestingFramework\Core\Testbase;
  * and change the properties. This can be used to not copy the whole
  * bootstrapTypo3Environment() method but reuse it instead.
  *
- * Core v11 / codeception 4 compatible version.
+ * codeception 5 compatible version.
  */
-abstract class BackendEnvironmentCoreEleven extends Extension
+abstract class BackendEnvironmentCodeceptionFive extends Extension
 {
     /**
      * Some settings can be overridden by the same name environment variables, see _initialize()
      */
-    protected $config = [
+    protected array $config = [
         // config / environment variables
         'typo3Setup' => true,
         'typo3Cleanup' => true,
@@ -326,7 +326,7 @@ abstract class BackendEnvironmentCoreEleven extends Extension
         // Alternative solution:
         // unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys']['extbase']);
         $suite = $suiteEvent->getSuite();
-        $suite->setBackupGlobals(false);
+        $suite->backupGlobals(false);
 
         // @deprecated Will be removed with core v12 compatible testing-framework. See property comment.
         foreach ($this->config['xmlDatabaseFixtures'] as $fixture) {

--- a/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFour.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFour.php
@@ -32,14 +32,14 @@ use TYPO3\TestingFramework\Core\Testbase;
  * and change the properties. This can be used to not copy the whole
  * bootstrapTypo3Environment() method but reuse it instead.
  *
- * Core v12 / codeception 5 compatible version.
+ * codeception 4 compatible version.
  */
-abstract class BackendEnvironmentCoreTwelve extends Extension
+abstract class BackendEnvironmentCodeceptionFour extends Extension
 {
     /**
      * Some settings can be overridden by the same name environment variables, see _initialize()
      */
-    protected array $config = [
+    protected $config = [
         // config / environment variables
         'typo3Setup' => true,
         'typo3Cleanup' => true,
@@ -326,7 +326,7 @@ abstract class BackendEnvironmentCoreTwelve extends Extension
         // Alternative solution:
         // unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys']['extbase']);
         $suite = $suiteEvent->getSuite();
-        $suite->backupGlobals(false);
+        $suite->setBackupGlobals(false);
 
         // @deprecated Will be removed with core v12 compatible testing-framework. See property comment.
         foreach ($this->config['xmlDatabaseFixtures'] as $fixture) {

--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -17,19 +17,17 @@ declare(strict_types=1);
 
 namespace TYPO3\TestingFramework\Core\Acceptance\Helper;
 
-use TYPO3\CMS\Core\Information\Typo3Version;
-
 /**
  * This is an ugly hack exclusively for testing-framework v7 to allow
- * both codeception 4 (core v11) and 5 (core v12) at the same time.
+ * both codeception 4 and 5 to be used for core v11 and v12 at the same time.
  *
  * Problem is the codeception API is hard breaking between codeception 4 and 5,
  * especially due to new type hints on properties that we have to use.
  */
-if (((new Typo3Version())->getMajorVersion() >= 12)) {
-    class_alias(LoginTwelve::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Helper\\LoginConditionalParent');
+if (method_exists(\Codeception\Suite::class, 'backupGlobals')) {
+    class_alias(LoginCodeceptionFive::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Helper\\LoginConditionalParent');
 } else {
-    class_alias(LoginEleven::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Helper\\LoginConditionalParent');
+    class_alias(LoginCodeceptionFour::class, 'TYPO3\\TestingFramework\\Core\\Acceptance\\Helper\\LoginConditionalParent');
 }
 
 class Login extends LoginConditionalParent

--- a/Classes/Core/Acceptance/Helper/LoginCodeceptionFive.php
+++ b/Classes/Core/Acceptance/Helper/LoginCodeceptionFive.php
@@ -25,14 +25,14 @@ use Codeception\Util\Locator;
 /**
  * Helper class to log in backend users and load backend.
  *
- * Core v11 / codeception 4 compatible version.
+ * Core v12 / codeception 5 compatible version.
  */
-class LoginEleven extends Module
+class LoginCodeceptionFive extends Module
 {
     /**
      * @var array Filled by .yml config with valid sessions per role
      */
-    protected $config = [
+    protected array $config = [
         'sessions' => [],
     ];
 

--- a/Classes/Core/Acceptance/Helper/LoginCodeceptionFour.php
+++ b/Classes/Core/Acceptance/Helper/LoginCodeceptionFour.php
@@ -25,14 +25,14 @@ use Codeception\Util\Locator;
 /**
  * Helper class to log in backend users and load backend.
  *
- * Core v12 / codeception 5 compatible version.
+ * codeception 4 compatible version.
  */
-class LoginTwelve extends Module
+class LoginCodeceptionFour extends Module
 {
     /**
      * @var array Filled by .yml config with valid sessions per role
      */
-    protected array $config = [
+    protected $config = [
         'sessions' => [],
     ];
 


### PR DESCRIPTION
To support codeception version 4 and version 5 compatibility in
testing against core v11 and core v12 compatibility switches has
been added based on core version. However, neighter core nor the
testing-framework enforces a specific codeception version to be
used for extension or project testing against a specific core
version. The extension or project choose which codeception version
is used for acceptance testing.

To ensure compatibility with codeception version 4 and 5 against
both supported core verion with testing-framework 7 this switch
is changed to detecht the used codeception version instead.

This is still a ugly workaround, but the only way to go.

Releases: 7
