### PR TITLE
[TASK] Avoid deprecated dbal/doctrine methods

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -61,12 +61,12 @@ parameters:
 			path: ../../Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
 
 		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\|string\\.$#"
+			message: "#^Instanceof between Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder and TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder will always evaluate to false\\.$#"
 			count: 1
 			path: ../../Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
 
 		-
-			message: "#^Instanceof between Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder and TYPO3\\\\CMS\\\\Core\\\\Database\\\\Query\\\\QueryBuilder will always evaluate to false\\.$#"
+			message: "#^Method Doctrine\\\\DBAL\\\\Driver\\\\Result\\:\\:fetchAllAssociative\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: ../../Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
 
@@ -152,7 +152,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\DBAL\\\\Result\\:\\:fetch\\(\\)\\.$#"
-			count: 2
+			count: 4
 			path: ../../Classes/Core/Functional/FunctionalTestCase.php
 
 		-
@@ -162,16 +162,6 @@ parameters:
 
 		-
 			message: "#^Call to method setVar\\(\\) on an unknown class Text_Template\\.$#"
-			count: 1
-			path: ../../Classes/Core/Functional/FunctionalTestCase.php
-
-		-
-			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
-			count: 3
-			path: ../../Classes/Core/Functional/FunctionalTestCase.php
-
-		-
-			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
 			count: 1
 			path: ../../Classes/Core/Functional/FunctionalTestCase.php
 
@@ -191,11 +181,6 @@ parameters:
 			path: ../../Classes/Core/Functional/FunctionalTestCase.php
 
 		-
-			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
-			count: 1
-			path: ../../Classes/Core/Testbase.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: ../../Classes/Core/Testbase.php
@@ -206,7 +191,17 @@ parameters:
 			path: ../../Classes/Core/Testbase.php
 
 		-
+			message: "#^Call to method reveal\\(\\) on an unknown class Prophecy\\\\Prophecy\\\\ObjectProphecy\\.$#"
+			count: 2
+			path: ../../Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+
+		-
 			message: "#^Property TYPO3\\\\TestingFramework\\\\Fluid\\\\Unit\\\\ViewHelpers\\\\ViewHelperBaseTestcase\\:\\:\\$request \\(TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Request\\) does not accept Prophecy\\\\Prophecy\\\\ObjectProphecy\\.$#"
+			count: 1
+			path: ../../Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+
+		-
+			message: "#^Property TYPO3\\\\TestingFramework\\\\Fluid\\\\Unit\\\\ViewHelpers\\\\ViewHelperBaseTestcase\\:\\:\\$viewHelperVariableContainer has unknown class Prophecy\\\\Prophecy\\\\ObjectProphecy as its type\\.$#"
 			count: 1
 			path: ../../Classes/Fluid/Unit/ViewHelpers/ViewHelperBaseTestcase.php
 

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -20,7 +20,6 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Workspaces\Service\WorkspaceService;
 use TYPO3\TestingFramework\Core\Exception;
@@ -547,13 +546,8 @@ class ActionService
                     $queryBuilder->createNamedParameter($workspaceId, \PDO::PARAM_INT)
                 )
             )
-            ->execute();
-        if ((new Typo3Version())->getMajorVersion() >= 11) {
-            $row = $statement->fetchAssociative();
-        } else {
-            // @deprecated: Will be removed with next major version - core v10 compat.
-            $row = $statement->fetch();
-        }
+            ->executeQuery();
+        $row = $statement->fetchAssociative();
         if (!empty($row['uid'])) {
             return (int)$row['uid'];
         }
@@ -584,13 +578,8 @@ class ActionService
                     $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
                 )
             )
-            ->execute();
-        if ((new Typo3Version())->getMajorVersion() >= 11) {
-            $row = $statement->fetchAssociative();
-        } else {
-            // @deprecated: Will be removed with next major version - core v10 compat.
-            $row = $statement->fetch();
-        }
+            ->executeQuery();
+        $row = $statement->fetchAssociative();
         if (!empty($row)) {
             // This is effectively the same record as $liveUid, but only if the constraints from above match
             return (int)$row['uid'];

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseAccessor.php
@@ -97,7 +97,7 @@ class DatabaseAccessor
     {
         return $this->createQueryBuilder()
             ->select('*')->from($tableName)
-            ->execute()->fetchAll(FetchMode::ASSOCIATIVE);
+            ->executeQuery()->fetchAllAssociative(FetchMode::ASSOCIATIVE);
     }
 
     /**

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -567,12 +567,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $result = $queryBuilder->select('*')
             ->from('be_users')
             ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($userId, \PDO::PARAM_INT)))
-            ->execute();
-        if ((new Typo3Version())->getMajorVersion() >= 11) {
-            return $result->fetchAssociative() ?: null;
-        }
-        // @deprecated: Will be removed with next major version - core v10 compat.
-        return $result->fetch() ?: null;
+            ->executeQuery();
+        return $result->fetchAssociative() ?: null;
     }
 
     private function createServerRequest(string $url, string $method = 'GET'): ServerRequestInterface
@@ -812,10 +808,10 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $statement = $queryBuilder
             ->select('*')
             ->from($tableName)
-            ->execute();
+            ->executeQuery();
 
         if (!$hasUidField && !$hasHashField) {
-            return $statement->fetchAll();
+            return $statement->fetchAllAssociative();
         }
 
         if ($hasUidField) {

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Schema\SchemaMigrator;
 use TYPO3\CMS\Core\Database\Schema\SqlReader;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -912,14 +911,8 @@ class Testbase
                     $queryBuilder->expr()->eq('PGT.tablename', $queryBuilder->quote($tableName))
                 )
                 ->setMaxResults(1)
-                ->execute();
-            if ((new Typo3Version())->getMajorVersion() >= 11) {
-                $row = $statement->fetchAssociative();
-            } else {
-                // @deprecated: Will be removed with next major version - core v10 compat.
-                $row = $statement->fetch();
-            }
-
+                ->executeQuery();
+            $row = $statement->fetchAssociative();
             if ($row !== false) {
                 $connection->exec(
                     sprintf(


### PR DESCRIPTION
Replaces deprecated dbal/doctrine methods with proper
replacements:

* `QueryBuilder->execute()` with `executeQuery()` for
  SELECT or COUNT queries (retrieving result set)
* `fetchAll()` with `fetchAllAssociative()`

> Build/Scripts/runTests.sh -p 8.1 -s phpstanGenerateBaseline

Releases: main, 7