### PR TITLE
[!!!][TASK] Use session identifier JWT when initializing sessions (backport)

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -18,3 +18,5 @@ parameters:
   excludePaths:
     # Checking acceptance support files is cumbersome due to codeception dynamic mixin generation
     - ../../Classes/Core/Acceptance/*
+    # phpstan does not work well with multi core testing and existing/non existing classes and traits, exclude it
+    - ../../Classes/Core/Jwt/SessionHelperTwelve.php

--- a/Classes/Core/Acceptance/Helper/LoginCodeceptionFive.php
+++ b/Classes/Core/Acceptance/Helper/LoginCodeceptionFive.php
@@ -21,11 +21,14 @@ use Codeception\Exception\ConfigurationException;
 use Codeception\Module;
 use Codeception\Module\WebDriver;
 use Codeception\Util\Locator;
+use TYPO3\TestingFramework\Core\Jwt\SessionHelper;
 
 /**
  * Helper class to log in backend users and load backend.
  *
  * Core v12 / codeception 5 compatible version.
+ *
+ * @internal Compat layer for testing-framework v7 only.
  */
 class LoginCodeceptionFive extends Module
 {
@@ -118,7 +121,7 @@ class LoginCodeceptionFive extends Module
     public function _createSession($userSessionId)
     {
         $webDriver = $this->getWebDriver();
-        $webDriver->setCookie('be_typo_user', $userSessionId);
+        $webDriver->setCookie('be_typo_user', (new SessionHelper())->createSessionCookieValue($userSessionId));
         $webDriver->setCookie('be_lastLoginProvider', '1433416747');
         $webDriver->saveSessionSnapshot('login');
     }

--- a/Classes/Core/Acceptance/Helper/LoginCodeceptionFour.php
+++ b/Classes/Core/Acceptance/Helper/LoginCodeceptionFour.php
@@ -21,11 +21,14 @@ use Codeception\Exception\ConfigurationException;
 use Codeception\Module;
 use Codeception\Module\WebDriver;
 use Codeception\Util\Locator;
+use TYPO3\TestingFramework\Core\Jwt\SessionHelper;
 
 /**
  * Helper class to log in backend users and load backend.
  *
  * codeception 4 compatible version.
+ *
+ * @internal Compat layer for testing-framework v7 only.
  */
 class LoginCodeceptionFour extends Module
 {
@@ -118,7 +121,7 @@ class LoginCodeceptionFour extends Module
     public function _createSession($userSessionId)
     {
         $webDriver = $this->getWebDriver();
-        $webDriver->setCookie('be_typo_user', $userSessionId);
+        $webDriver->setCookie('be_typo_user', (new SessionHelper())->createSessionCookieValue($userSessionId));
         $webDriver->setCookie('be_lastLoginProvider', '1433416747');
         $webDriver->saveSessionSnapshot('login');
     }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -53,6 +53,7 @@ use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestCon
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalResponse;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalResponseException;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Response;
+use TYPO3\TestingFramework\Core\Jwt\SessionHelper;
 use TYPO3\TestingFramework\Core\Testbase;
 
 /**
@@ -548,9 +549,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         } else {
             $backendUser = GeneralUtility::makeInstance(BackendUserAuthentication::class);
             $session = $backendUser->createUserSession($userRow);
-            $sessionId = $session->getIdentifier();
             $request = $this->createServerRequest('https://typo3-testing.local/typo3/');
-            $request = $request->withCookieParams(['be_typo_user' => $sessionId]);
+            $request = $request->withCookieParams(['be_typo_user' => (new SessionHelper())->resolveSessionCookieValue($session)]);
             $backendUser = $this->authenticateBackendUser($backendUser, $request);
             // @todo: remove this with the next major version
             $GLOBALS['BE_USER'] = $backendUser;

--- a/Classes/Core/Jwt/SessionHelper.php
+++ b/Classes/Core/Jwt/SessionHelper.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Core\Jwt;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Session\UserSession;
+
+/**
+ * @internal This class is only for cross core compat. This will not be available in the next major version.
+ */
+class SessionHelper
+{
+    public function createSessionCookieValue(string $userSessionId): string
+    {
+        return $this->getParentSessionHelper()->createSessionCookieValue($userSessionId);
+    }
+
+    public function resolveSessionCookieValue(UserSession $session): string
+    {
+        return $this->getParentSessionHelper()->resolveSessionCookieValue($session);
+    }
+
+    /**
+     * @return SessionHelperEleven|SessionHelperTwelve
+     */
+    protected function getParentSessionHelper()
+    {
+        return ((new Typo3Version())->getMajorVersion() >= 12)
+            ? new SessionHelperTwelve()
+            : new SessionHelperEleven();
+    }
+}

--- a/Classes/Core/Jwt/SessionHelperEleven.php
+++ b/Classes/Core/Jwt/SessionHelperEleven.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Core\Jwt;
+
+use TYPO3\CMS\Core\Session\UserSession;
+
+/**
+ * @internal This class is only for cross core compat. This will not be available in the next major version.
+ */
+class SessionHelperEleven
+{
+    public function createSessionCookieValue(string $userSessionId): string
+    {
+        return $userSessionId;
+    }
+
+    public function resolveSessionCookieValue(UserSession $session): string
+    {
+        return $session->getIdentifier();
+    }
+}

--- a/Classes/Core/Jwt/SessionHelperTwelve.php
+++ b/Classes/Core/Jwt/SessionHelperTwelve.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Core\Jwt;
+
+use TYPO3\CMS\Core\Security\JwtTrait;
+use TYPO3\CMS\Core\Session\UserSession;
+
+/**
+ * @internal This class is only for cross core compat. This will not be available in the next major version.
+ */
+class SessionHelperTwelve
+{
+    use JwtTrait;
+
+    public function createSessionCookieValue(string $userSessionId): string
+    {
+        return self::encodeHashSignedJwt(
+            [
+                'identifier' => $userSessionId,
+                'time' => (new \DateTimeImmutable())->format(\DateTimeImmutable::RFC3339),
+            ],
+            // relies on $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
+            self::createSigningKeyFromEncryptionKey(UserSession::class)
+        );
+    }
+
+    public function resolveSessionCookieValue(UserSession $session): string
+    {
+        return $session->getJwt();
+    }
+}


### PR DESCRIPTION
see https://review.typo3.org/c/Packages/TYPO3.CMS/+/69337

This backport contains switches to support TYPO3 v11 and V12 testing in parallel.

FrontendUserHandler middleware is adjusted with v11/v12 switch, dropping v10 switch to align for shifted version testing.
