### PR TITLE
[TASK] Avoid prophecy related composer quirk

### DIFF
--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -49,12 +49,7 @@ services:
           set -x
         fi
         php -v | grep '^PHP';
-        if [ ${DOCKER_PHP_IMAGE} = "php82" ]; then
-            # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-            composer update --no-progress --no-interaction --ignore-platform-req=php+
-        else
-            composer update --no-progress --no-interaction;
-        fi
+        composer update --no-progress --no-interaction;
       "
   lint:
     image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^8.1",
     "ext-pdo": "*",
-    "phpunit/phpunit": "^9.5.10",
+    "phpunit/phpunit": "^9.5.25",
     "psr/container": "^1.1.0 || ^2.0.0",
     "typo3/cms-core": "12.*.*@dev",
     "typo3/cms-backend": "12.*.*@dev",


### PR DESCRIPTION
prophecy is no longer a dependency of phpunit.
We can remove a quirk in the test setup again.

We also raise minimum phpunit version to ensure
prophecy is gone, this raise will be left out in
v6 backport.

> composer req phpunit/phpunit:^9.5.25