### PR TITLE
[TASK] Use php-cs-fixer directly

### DIFF
--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -1,0 +1,70 @@
+<?php
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+return (new \PhpCsFixer\Config())
+    ->setFinder(
+        (new PhpCsFixer\Finder())
+            ->ignoreVCSIgnored(true)
+            ->in([
+                __DIR__ . '/../../Build/',
+                __DIR__ . '/../../Classes/',
+                __DIR__ . '/../../Resources/',
+                __DIR__ . '/../../Tests/',
+            ])
+    )
+    ->setUsingCache(false)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_after_opening_tag' => true,
+        'braces' => ['allow_single_line_closure' => true],
+        'cast_spaces' => ['space' => 'none'],
+        'compact_nullable_typehint' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'dir_constant' => true,
+        'function_typehint_space' => true,
+        'lowercase_cast' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'new_with_braces' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => true,
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        'single_trait_insert_per_statement' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'whitespace_after_comma_in_array' => true,
+    ]);

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -19,8 +19,7 @@ services:
             .Build/bin/php-cs-fixer fix \
               -v \
               ${CGLCHECK_DRY_RUN} \
-              --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php  \
-              --using-cache=no Classes/ Resources/ Tests/
+              --config=Build/php-cs-fixer/config.php
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
@@ -29,8 +28,7 @@ services:
           .Build/bin/php-cs-fixer fix \
             -v \
             ${CGLCHECK_DRY_RUN} \
-            --config=.Build/vendor/typo3/coding-standards/templates/extension_php-cs-fixer.dist.php  \
-            --using-cache=no Classes/ Resources/ Tests/
+            --config=Build/php-cs-fixer/config.php
         fi
       "
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
   "config": {
     "vendor-dir": ".Build/vendor",
     "bin-dir": ".Build/bin",
+    "sort-packages": true,
     "allow-plugins": {
       "composer/package-versions-deprecated": true,
       "typo3/class-alias-loader": true,
@@ -62,7 +63,7 @@
     }
   },
   "require-dev": {
-    "typo3/coding-standards": "0.5.2",
+    "friendsofphp/php-cs-fixer": "^3.11.0",
     "phpstan/phpstan": "^1.8.0",
     "phpstan/phpstan-phpunit": "^1.1.1",
     "typo3/cms-workspaces": "12.*.*@dev"


### PR DESCRIPTION
typo3/coding-standards is a too big hammer for this tiny repository.

The patch picks the default typo3/coding-standards config and adds it directly.

> composer rem --dev typo3/coding-standards
> composer req --dev friendsofphp/php-cs-fixer:^3.11.0

Releases: main, 7, 6