### PR TITLE
[TASK] Remove composer.json conflict with old doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,6 @@
     "typo3/cms-install": "12.*.*@dev",
     "guzzlehttp/psr7": "^1.7 || ^2.0"
   },
-  "conflict": {
-    "doctrine/dbal": "2.13.0 || 2.13.1"
-  },
   "config": {
     "vendor-dir": ".Build/vendor",
     "bin-dir": ".Build/bin",


### PR DESCRIPTION
doctrine/dbal 2.3.x is not allowed by the core
dependencies anymore, the explicit conflict is
obsolete.

Releases: main