### PR TITLE
[BUGFIX] Use correct class for method_exists check in event listener

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/Classes/EventListener/AddTypoScriptFromInternalRequest.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/EventListener/AddTypoScriptFromInternalRequest.php
@@ -31,7 +31,7 @@ final class AddTypoScriptFromInternalRequest
 {
     public function __invoke(AfterTemplatesHaveBeenDeterminedEvent $event): void
     {
-        if (method_exists($request, 'getRequest')) {
+        if (method_exists($event, 'getRequest')) {
             $request = $event->getRequest();
         } else {
             // This is a compat layer for 12.0 exclusively, 12.1 will have getRequest() in the event.


### PR DESCRIPTION
Check for method getRequest() against the event in the event listener instead of undefined variable.
