### PR TITLE
[!!!][TASK] Tighten unit and functional tests with more checks

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -376,6 +376,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
                 }
             }
         }
+
+        parent::setUp();
     }
 
     /**
@@ -418,6 +420,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
                 1634490418
             );
         }
+
+        parent::tearDown();
     }
 
     protected function getConnectionPool(): ConnectionPool

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -19,8 +19,6 @@ namespace TYPO3\TestingFramework\Core\Functional;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use PHPUnit\Framework\RiskyTestError;
-use PHPUnit\Util\ErrorHandler;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -392,34 +390,6 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         unset($this->testExtensionsToLoad, $this->pathsToLinkInTestInstance);
         unset($this->pathsToProvideInTestInstance, $this->configurationToUseInTestInstance);
         unset($this->additionalFoldersToCreate);
-
-        // Verify no dangling error handler is registered. This might happen when
-        // tests register an own error handler which is not reset again. This error
-        // handler then may "eat" error of subsequent tests.
-        // Register a dummy error handler to retrieve *previous* one and unregister dummy again,
-        // then verify previous is the phpunit error handler. This will mark the one test that
-        // fails to unset/restore it's custom error handler as "risky".
-        // @todo: Consider moving this to BaseTestCase to have it for unit tests, too.
-        // @see: https://github.com/sebastianbergmann/phpunit/issues/4801
-        $previousErrorHandler = set_error_handler(function (int $errorNumber, string $errorString, string $errorFile, int $errorLine): bool {return false;});
-        restore_error_handler();
-        if (!$previousErrorHandler instanceof ErrorHandler) {
-            throw new RiskyTestError(
-                'tearDown() check: A dangling error handler has been found. Use restore_error_handler() to unset it.',
-                1634490417
-            );
-        }
-
-        // Verify no dangling exception handler is registered. Same scenario as with error handlers.
-        // @todo: Consider moving this to BaseTestCase to have it for unit tests, too.
-        $previousExceptionHandler = set_exception_handler(function () {});
-        restore_exception_handler();
-        if ($previousExceptionHandler !== null) {
-            throw new RiskyTestError(
-                'tearDown() check: A dangling exception handler has been found. Use restore_exception_handler() to unset it.',
-                1634490418
-            );
-        }
 
         parent::tearDown();
     }

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -76,10 +76,21 @@ abstract class UnitTestCase extends BaseTestCase
     private array $backedUpEnvironment = [];
 
     /**
+     * This property helps to determine if method chain of
+     * setUp() is valid down to this class, which is checked
+     * in tearDown() which is more unlikely to be overridden
+     * in tests.
+     *
+     * @var bool
+     */
+    private bool $setUpMethodCallChainValid = false;
+
+    /**
      * Generic setUp()
      */
     protected function setUp(): void
     {
+        $this->setUpMethodCallChainValid = true;
         if ($this->backupEnvironment === true) {
             $this->backupEnvironment();
         }
@@ -192,6 +203,10 @@ abstract class UnitTestCase extends BaseTestCase
         $property = $reflectionClass->getProperty('configurationManager');
         $property->setAccessible(true);
         self::assertNull($property->getValue());
+
+        self::assertTrue($this->setUpMethodCallChainValid, 'tearDown() integrity check detected that setUp has a '
+            . 'broken parent call chain. Please check that setUp() methods properly calls parent::setUp(), starting from "'
+            . get_class($this) . '"');
     }
 
     /**

--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -207,6 +207,8 @@ abstract class UnitTestCase extends BaseTestCase
         self::assertTrue($this->setUpMethodCallChainValid, 'tearDown() integrity check detected that setUp has a '
             . 'broken parent call chain. Please check that setUp() methods properly calls parent::setUp(), starting from "'
             . get_class($this) . '"');
+
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
This pull-request contains a small chain of commits with
the goal to harden unit and functional tests and has been
verified with:

* [76010: [WIP][TASK] Test testing-framework hardenings](https://review.typo3.org/c/Packages/TYPO3.CMS/+/76010)

#### [!!!][TASK] Introduce setUp() call chain check for unit tests

This change basicly adds a integrity check to verify
that the `setUp()` call chain of unit tests reaches the
UnitTestCase / BaseTestcase. Prepares also the following
changes.

Core has been checked and fixed with:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/76007

#### [!!!][TASK] Add error_reporting() check for unit/functional tests

This change introduces a integrity check in the BaseTestCase
to ensure that a test leaves and don't pullate following tests
with changed error_reporting() level state and thus changing
behaviour.

One occurance (and the reason for this check) has been already
fixed in core with:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/76006

#### [!!!][TASK] Move Error- and Exception Handler check to BaseTestCase

The testing-framework already contained a integration check for
pullated error and exception handlers for functional tests. Now
we provide it for unit-tests also, thus the corresponding check
is moved from FunctionalTestCase to BaseTestCase.

Core has been checked and prepared with:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/76009

