### PR TITLE
[BUGFIX] Load frontend-user injection middleware before FE authenticator

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/Configuration/RequestMiddlewares.php
+++ b/Resources/Core/Functional/Extensions/json_response/Configuration/RequestMiddlewares.php
@@ -20,10 +20,14 @@ return [
         'typo3/json-response/frontend-user-authentication' => [
             'target' => \TYPO3\JsonResponse\Middleware\FrontendUserHandler::class,
             'after' => [
-                'typo3/cms-frontend/backend-user-authentication',
+                (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 12
+                    ? 'typo3/cms-frontend/backend-user-authentication'
+                    : 'typo3/cms-frontend/authentication',
             ],
             'before' => [
-                'typo3/cms-frontend/base-redirect-resolver',
+                (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() >= 12
+                    ? 'typo3/cms-frontend/authentication'
+                    : 'typo3/cms-frontend/base-redirect-resolver',
             ],
         ],
         'typo3/json-response/backend-user-authentication' => [


### PR DESCRIPTION
typo3/testing-framework frontend-user injection using the corresponding InternalContext setting for the user id *must* be proper set, before the core frontend-user authenticator middleware evaluates and loads the needed informations.

This change adjusts the middleware loading definition of testing-framework FrontendUserHandler middleware to ensure the correct loading order.

Resolves #424
Releases: 7
