### PR TITLE
[BUGFIX] Avoid removing site configuration if folder is symlinked

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -413,8 +413,17 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
     protected function tearDown(): void
     {
         // Remove any site configuration, and it's cache files, most likely created by SiteBasedTestTrait
-        GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
-        @unlink($this->instancePath . '/typo3temp/var/cache/code/core/sites-configuration.php');
+        if (!in_array('typo3conf/sites', $this->pathsToLinkInTestInstance)
+            && !in_array('typo3conf/sites/', $this->pathsToLinkInTestInstance)
+            && is_dir($this->instancePath . '/typo3conf/sites')
+        ) {
+            GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
+        }
+        if (file_exists($this->instancePath . '/typo3temp/var/cache/code/core/sites-configuration.php')
+            && is_file($this->instancePath . '/typo3temp/var/cache/code/core/sites-configuration.php')
+        ) {
+            @unlink($this->instancePath . '/typo3temp/var/cache/code/core/sites-configuration.php');
+        }
 
         // Unset especially the container after each test, it is a huge memory hog.
         // Test class instances in phpunit are kept until end of run, this sums up.


### PR DESCRIPTION
FunctionalTestCase tearDown() got recently the order to proper
cleanup written site configurations and the corresponding core
cache. Howver, some developers may use the provided property
`array $pathsToLinkInTestInstance[]` to define a folder which
should be symlinked as site-configuration instead of writing
them. The new order now removes these site-configuration files,
thus missing them on subsequence tests.

This change introduces some checks to only cleanup, if the folder
and files a dedicated to the instance and not symlinked (folder).
