### PR TITLE
[TASK] Let phpstan properly detect that called method exists

### DIFF
--- a/Classes/Core/Functional/Framework/FrameworkState.php
+++ b/Classes/Core/Functional/Framework/FrameworkState.php
@@ -62,7 +62,7 @@ class FrameworkState
 
         // @todo Remove this block with next major version of the testing-framework,
         //       or if TYPO3 v13 is the min supported version.
-        if (static::handleRootlineUtilityStaticProperties()) {
+        if (method_exists(RootlineUtility::class, 'purgeCaches')) {
             // Infamous RootlineUtility carries various static state ...
             $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
             $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
@@ -101,7 +101,7 @@ class FrameworkState
 
         // @todo Remove this block with next major version of the testing-framework,
         //       or if TYPO3 v13 is the min supported version.
-        if (static::handleRootlineUtilityStaticProperties()) {
+        if (method_exists(RootlineUtility::class, 'purgeCaches')) {
             RootlineUtility::purgeCaches();
             $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
             $rootlineFieldsDefault = $rootlineUtilityReflection->getDefaultProperties();
@@ -143,7 +143,7 @@ class FrameworkState
 
         // @todo Remove this block with next major version of the testing-framework,
         //       or if TYPO3 v13 is the min supported version.
-        if (static::handleRootlineUtilityStaticProperties()) {
+        if (method_exists(RootlineUtility::class, 'purgeCaches')) {
             $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
             $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
             $rootlineUtilityLocalCache->setAccessible(true);
@@ -161,13 +161,5 @@ class FrameworkState
             $rootlineUtilityPageRecordCache->setAccessible(true);
             $rootlineUtilityPageRecordCache->setValue($state['rootlineUtilityPageRecordCache']);
         }
-    }
-
-    /**
-     * @todo Remove this with next major version of the testing-framework, or if TYPO3 v13 is the min supported version.
-     */
-    protected static function handleRootlineUtilityStaticProperties(): bool
-    {
-        return method_exists(RootlineUtility::class, 'purgeCaches');
     }
 }


### PR DESCRIPTION
FrameworkState::* methods are used to save the state before
executing frontend sub requests in functional tests. This
contained handling static caches of the the `RootlineUtility`.
These static property caches has been recently removed in TYPO3,
along with the then obsolete static method `purgeCaches()`.

Thus FrameworkState has been changed to only handle the static
cache handling of `RootlineUtility` if method `purgeCaches()`
exists. That check has been wrapped in a dedicated static method.

PHPStan now have issues to properly recognise that the call to
`RootlineUtility::purgeCaches()` is only called, if existing.

To mitigate this, this change removes the static wrap-method and
doing the `method_exists()` check in the three methods directly.

Releases: main, 7