### PR TITLE
[TASK] Ensure fixture field data for json fields can be inserted

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFour.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFour.php
@@ -20,6 +20,7 @@ namespace TYPO3\TestingFramework\Core\Acceptance\Extension;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Extension;
+use Doctrine\DBAL\Types\JsonType;
 use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -365,13 +366,22 @@ abstract class BackendEnvironmentCodeceptionFour extends Extension
         $dataSet = DataSet::read($path, true);
         foreach ($dataSet->getTableNames() as $tableName) {
             $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
+            $platform = $connection->getDatabasePlatform();
+            $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
             foreach ($dataSet->getElements($tableName) as $element) {
                 // Some DBMS like postgresql are picky about inserting blob types with correct cast, setting
                 // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL
                 $types = [];
-                $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
                 foreach ($element as $columnName => $columnValue) {
-                    $types[] = $tableDetails->getColumn($columnName)->getType()->getBindingType();
+                    $columnType = $tableDetails->getColumn($columnName)->getType();
+                    // JSON-Field data is converted (json-encode'd) within $connection->insert(), and since json field
+                    // data can only be provided json encoded in the csv dataset files, we need to decode them here.
+                    if ($element[$columnName] !== null
+                        && $columnType instanceof JsonType
+                    ) {
+                        $element[$columnName] = $columnType->convertToPHPValue($columnValue, $platform);
+                    }
+                    $types[] = $columnType->getBindingType();
                 }
                 // Insert the row
                 $connection->insert($tableName, $element, $types);


### PR DESCRIPTION
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/76553
support for native json database field has been introduced 
into TYPO3. This came along with automatic transformation 
from PHP-Value to database compatible values, which basicly 
means that the values get json-encode'd.

Providing fixture database values for JSON fields are now 
impossible to set, as string values get encoded as string
which does not write the expected values to the database.

This change uses the already used database schema information
and proper decode the values after reading from the csv files.
That ensures that the data written to the database has the
expected format. Othewise testing would be inpossible for
JSON-Fields.

Releases: main, 7