### PR TITLE
[TASK] Add DataSet to ensure json value string can be decoded

### DIFF
--- a/Tests/Unit/Core/Fixtures/Json/WithJsonValueQuotedWithDoubleQuotes.csv
+++ b/Tests/Unit/Core/Fixtures/Json/WithJsonValueQuotedWithDoubleQuotes.csv
@@ -1,0 +1,3 @@
+be_users,,,,,,,,,,,,,,,,,,,,
+,uid,pid,mfa,
+,1,0,"{""name"":""value"",""name2"":{""name3"":""subvalue"", ""empty-array"":[]}}",

--- a/Tests/Unit/Core/Functional/Framework/DataHandling/DataSetTest.php
+++ b/Tests/Unit/Core/Functional/Framework/DataHandling/DataSetTest.php
@@ -43,4 +43,18 @@ class DataSetTest extends UnitTestCase
         $tableName = $dataSet->getTableNames()[0];
         self::assertEquals(strlen('pages'), strlen($tableName));
     }
+
+    /**
+     * @test
+     */
+    public function notNullJsonFieldDataWithDoubleQuotationCanBeDecoded(): void
+    {
+        $csvFile = __DIR__ . '/../../../Fixtures/Json/WithJsonValueQuotedWithDoubleQuotes.csv';
+        $dataSet = DataSet::read($csvFile);
+        $tableName = $dataSet->getTableNames()[0];
+        self::assertSame('be_users', $tableName);
+        $jsonValue = $dataSet->getElements($tableName)[1]['mfa'];
+        $decoded = json_decode($jsonValue, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['name' => 'value', 'name2' => ['name3' => 'subvalue', 'empty-array' => []]], $decoded);
+    }
 }


### PR DESCRIPTION
Add a test to ensure that fixture csv json string is
read in a way that it can be properly decoded.