### PR TITLE
[TASK] Ensure "typo3/cms-composer-installers" v5 compatibility

### DIFF
--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Composer;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Composer\InstalledVersions;
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * @internal This class is for testing-framework internal processing and not part of public testing API.
+ */
+final class ComposerPackageManager
+{
+    private static string $vendorPath = '';
+
+    private static ?PackageInfo $rootPackage = null;
+
+    /**
+     * @var array<string, PackageInfo>
+     */
+    private static array $packages = [];
+
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    private static array $extensionKeyToPackageNameMap = [];
+
+    public function __construct()
+    {
+        $this->build();
+    }
+
+    public function getPackageInfo(string $name): ?PackageInfo
+    {
+        $name = $this->resolvePackageName($name);
+        return self::$packages[$name] ?? null;
+    }
+
+    /**
+     * Get list of system extensions keys. We need this as fallback if no core extensions are selected to be symlinked.
+     *
+     * @return string[]
+     */
+    public function getSystemExtensionExtensionKeys(): array
+    {
+        $extensionKeys = [];
+        foreach (self::$packages as $packageInfo) {
+            if ($packageInfo->isSystemExtension()
+                && $packageInfo->getExtensionKey() !== ''
+            ) {
+                $extensionKeys[] = $packageInfo->getExtensionKey();
+            }
+        }
+        return $extensionKeys;
+    }
+
+    /**
+     * Get full vendor path
+     */
+    public function getVendorPath(): string
+    {
+        return self::$vendorPath;
+    }
+
+    /**
+     * Build package caches if not already done.
+     */
+    private function build(): void
+    {
+        if (self::$rootPackage instanceof PackageInfo) {
+            return;
+        }
+
+        $this->processRootPackage();
+        $this->processMonoRepository();
+        $this->processPackages();
+    }
+
+    /**
+     * Extract root package information. This must be done first, to have related information at hand for subsequent
+     * package information retrieval.
+     */
+    private function processRootPackage(): void
+    {
+        $package = InstalledVersions::getRootPackage();
+        $packageName = $package['name'];
+        $packagePath = $this->getPackageInstallPath($packageName);
+        $packageRealPath = $this->realPath($packagePath);
+        $info = $this->getPackageComposerJson($packagePath) ?? [];
+        $packageType = $info['type'] ?? '';
+
+        $packageInfo = new PackageInfo(
+            $packageName,
+            $packageType,
+            $packagePath,
+            $packageRealPath,
+            $package['pretty_version'],
+            $info
+        );
+        self::$rootPackage = $packageInfo;
+        $this->addPackageInfo($packageInfo);
+
+        self::$vendorPath = $this->realPath(
+            rtrim(
+                $packageInfo->getRealPath() . '/' . ($packageInfo->getVendorDir() ?: 'vendor'),
+                '/'
+            )
+        );
+    }
+
+    /**
+     * TYPO3 Core Development Mono Repository has a special setup, where the system extension are not required by the
+     * root composer.json. Therefore, we need to look them up manually to add corresponding package information. This
+     * allows us to handle system extensions in mono repository they same way as outside and make e.g. symlink system
+     * extensions to test instance simpler by eliminating the need for dedicated mono-repository handling there.
+     */
+    private function processMonoRepository(): void
+    {
+        if (!$this->rootPackage()->isMonoRepository()) {
+            return;
+        }
+
+        $systemExtensionComposerJsonFiles = glob($this->rootPackage()->getRealPath() . '/typo3/sysext/*/composer.json');
+        foreach ($systemExtensionComposerJsonFiles as $systemExtensionComposerJsonFile) {
+            $packagePath = dirname($systemExtensionComposerJsonFile);
+            $packageRealPath = $this->realPath($packagePath);
+            $info = $this->getPackageComposerJson($packageRealPath);
+            $packageName = $info['name'] ?? '';
+            $packageType = $info['type'] ?? '';
+            $packageInfo = new PackageInfo(
+                $packageName,
+                $packageType,
+                $packagePath,
+                $packageRealPath,
+                // System extensions in mono-repository are exactly the same version as the root package. Use it.
+                $this->rootPackage()->getVersion(),
+                $info
+            );
+            if (!$packageInfo->isSystemExtension()) {
+                continue;
+            }
+            $this->addPackageInfo($packageInfo);
+        }
+    }
+
+    /**
+     * Process all composer installed packages.
+     */
+    private function processPackages(): void
+    {
+        foreach (InstalledVersions::getAllRawData() as $loader) {
+            foreach ($loader['versions'] as $packageName => $version) {
+                $packagePath = $this->getPackageInstallPath($packageName);
+                $packageRealPath = $this->realPath($packagePath);
+                $info = $this->getPackageComposerJson($packagePath) ?? [];
+                $packageType = $info['type'] ?? '';
+                $this->addPackageInfo(new PackageInfo(
+                    $packageName,
+                    $packageType,
+                    $packagePath,
+                    $packageRealPath,
+                    (string)($version['pretty_version'] ?? ''),
+                    $info
+                ));
+            }
+        }
+    }
+
+    /**
+     * Adds the package information to the internal cache. Additionally, it sets the extensionKey to packageName
+     * map information, if a TYPO3 extension or system-extensions package information is handed over. This map
+     * is used to allow extensionKey or packageName for retrieving package information, which comes in handy to
+     * provide backward compatibility for test core- and test extension symlink configuration per test instance.
+     */
+    private function addPackageInfo(PackageInfo $packageInfo): void
+    {
+        if (self::$packages[$packageInfo->getName()] ?? null) {
+            return;
+        }
+        self::$packages[$packageInfo->getName()] = $packageInfo;
+        if ($packageInfo->getExtensionKey() !== '') {
+            self::$extensionKeyToPackageNameMap[$packageInfo->getExtensionKey()] = $packageInfo->getName();
+        }
+    }
+
+    private function rootPackage(): ?PackageInfo
+    {
+        return self::$rootPackage;
+    }
+
+    private function getPackageComposerJson(string $path): ?array
+    {
+        $composerFile = rtrim($path, '/') . '/composer.json';
+        if (!file_exists($composerFile) || !is_readable($composerFile)) {
+            return null;
+        }
+        try {
+            return json_decode((string)file_get_contents($composerFile), true, JSON_THROW_ON_ERROR);
+        } catch(\Throwable $t) {
+            // skipped
+        }
+        return null;
+    }
+
+    private function resolvePackageName(string $name): string
+    {
+        if (str_starts_with($name, 'typo3conf/ext/')
+            || str_starts_with($name, 'typo3/sysext/')
+        ) {
+            $name = basename($name);
+        }
+        return self::$extensionKeyToPackageNameMap[$name] ?? $name;
+    }
+
+    /**
+     * Get the sanitized package installation path.
+     *
+     * Note: Not using realpath() is done by intention. That gives us the ability, to eventually avoid duplicates and
+     *       act on both paths if needed.
+     */
+    private function getPackageInstallPath(string $name): string
+    {
+        return $this->sanitizePath((string)InstalledVersions::getInstallPath($name));
+    }
+
+    /**
+     * This method resolves relative path tokens directly ( e.g. '/../' ) and sanitizes the path from back-slash to
+     * slash for a cross os compatibility.
+     */
+    private function sanitizePath(string $path): string
+    {
+        return Path::canonicalize(rtrim(strtr($path, '\\', '/'), '/'));
+    }
+
+    /**
+     * Guarded realpath() wrapper, to ensure we do not lose an path information if realpath() would fail.
+     */
+    private function realPath(string $path): string
+    {
+        $path = $this->sanitizePath($path);
+        return realpath($path) ?: $path;
+    }
+}

--- a/Classes/Composer/PackageInfo.php
+++ b/Classes/Composer/PackageInfo.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Composer;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * @internal This class is for testing-framework internal processing and not part of public testing API.
+ */
+final class PackageInfo
+{
+    private string $name;
+    private string $type;
+    private string $path;
+    private string $realPath;
+    private string $version;
+    private array $info;
+
+    public function __construct(
+        string $name,
+        string $type,
+        string $path,
+        string $realPath,
+        string $version,
+        array $info
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->path = $path;
+        $this->realPath = $realPath;
+        $this->version = $version;
+        $this->info = $info;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getRealPath(): string
+    {
+        return $this->realPath;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function isSystemExtension(): bool
+    {
+        return $this->type === 'typo3-cms-framework';
+    }
+
+    public function isExtension(): bool
+    {
+        return $this->type === 'typo3-cms-extension';
+    }
+
+    public function isMonoRepository(): bool
+    {
+        return $this->type === 'typo3-cms-core';
+    }
+
+    public function getExtensionKey(): string
+    {
+        return (string)($this->info['extra']['typo3/cms']['extension-key'] ?? '');
+    }
+
+    public function getVendorDir(): string
+    {
+        return (string)($this->info['config']['vendor-dir'] ?? '');
+    }
+}

--- a/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFive.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFive.php
@@ -265,7 +265,8 @@ abstract class BackendEnvironmentCodeceptionFive extends Extension
         foreach ($this->config['additionalFoldersToCreate'] as $directory) {
             $testbase->createDirectory($instancePath . '/' . $directory);
         }
-        $testbase->setUpInstanceCoreLinks($instancePath);
+        $coreExtensionsToLoad = $this->config['coreExtensionsToLoad'];
+        $testbase->setUpInstanceCoreLinks($instancePath, [], $coreExtensionsToLoad);
         $testExtensionsToLoad = $this->config['testExtensionsToLoad'];
         $testbase->linkTestExtensionsToInstance($instancePath, $testExtensionsToLoad);
         $testbase->linkPathsInTestInstance($instancePath, $this->config['pathsToLinkInTestInstance']);
@@ -304,7 +305,6 @@ abstract class BackendEnvironmentCodeceptionFive extends Extension
         $localConfiguration['SYS']['caching']['cacheConfigurations']['extbase_object']['backend'] = NullBackend::class;
         $localConfiguration['GFX']['processor'] = 'GraphicsMagick';
         $testbase->setUpLocalConfiguration($instancePath, $localConfiguration, $this->config['configurationToUseInTestInstance']);
-        $coreExtensionsToLoad = $this->config['coreExtensionsToLoad'];
         $frameworkExtensionPaths = [];
         $testbase->setUpPackageStates($instancePath, [], $coreExtensionsToLoad, $testExtensionsToLoad, $frameworkExtensionPaths);
         $this->output->debug('Loaded Extensions: ' . json_encode(array_merge($coreExtensionsToLoad, $testExtensionsToLoad)));

--- a/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFour.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironmentCodeceptionFour.php
@@ -265,7 +265,8 @@ abstract class BackendEnvironmentCodeceptionFour extends Extension
         foreach ($this->config['additionalFoldersToCreate'] as $directory) {
             $testbase->createDirectory($instancePath . '/' . $directory);
         }
-        $testbase->setUpInstanceCoreLinks($instancePath);
+        $coreExtensionsToLoad = $this->config['coreExtensionsToLoad'];
+        $testbase->setUpInstanceCoreLinks($instancePath, [], $coreExtensionsToLoad);
         $testExtensionsToLoad = $this->config['testExtensionsToLoad'];
         $testbase->linkTestExtensionsToInstance($instancePath, $testExtensionsToLoad);
         $testbase->linkPathsInTestInstance($instancePath, $this->config['pathsToLinkInTestInstance']);
@@ -304,7 +305,6 @@ abstract class BackendEnvironmentCodeceptionFour extends Extension
         $localConfiguration['SYS']['caching']['cacheConfigurations']['extbase_object']['backend'] = NullBackend::class;
         $localConfiguration['GFX']['processor'] = 'GraphicsMagick';
         $testbase->setUpLocalConfiguration($instancePath, $localConfiguration, $this->config['configurationToUseInTestInstance']);
-        $coreExtensionsToLoad = $this->config['coreExtensionsToLoad'];
         $frameworkExtensionPaths = [];
         $testbase->setUpPackageStates($instancePath, [], $coreExtensionsToLoad, $testExtensionsToLoad, $frameworkExtensionPaths);
         $this->output->debug('Loaded Extensions: ' . json_encode(array_merge($coreExtensionsToLoad, $testExtensionsToLoad)));

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -321,9 +321,19 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             foreach ($this->additionalFoldersToCreate as $directory) {
                 $testbase->createDirectory($this->instancePath . '/' . $directory);
             }
-            $testbase->setUpInstanceCoreLinks($this->instancePath);
+            $defaultCoreExtensionsToLoad = [
+                'core',
+                'backend',
+                'frontend',
+                'extbase',
+                'install',
+                'fluid',
+            ];
+            if ((new Typo3Version())->getMajorVersion() < 12) {
+                $defaultCoreExtensionsToLoad[] = 'recordlist';
+            }
+            $testbase->setUpInstanceCoreLinks($this->instancePath, $defaultCoreExtensionsToLoad, $this->coreExtensionsToLoad);
             $testbase->linkTestExtensionsToInstance($this->instancePath, $this->testExtensionsToLoad);
-            $testbase->linkFrameworkExtensionsToInstance($this->instancePath, $this->frameworkExtensionsToLoad);
             $testbase->linkPathsInTestInstance($this->instancePath, $this->pathsToLinkInTestInstance);
             $testbase->providePathsInTestInstance($this->instancePath, $this->pathsToProvideInTestInstance);
             $localConfiguration['DB'] = $testbase->getOriginalDatabaseSettingsFromEnvironmentOrLocalConfiguration();
@@ -372,15 +382,6 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             $localConfiguration['SYS']['caching']['cacheConfigurations']['extbase_object']['backend'] = NullBackend::class;
             $localConfiguration['GFX']['processor'] = 'GraphicsMagick';
             $testbase->setUpLocalConfiguration($this->instancePath, $localConfiguration, $this->configurationToUseInTestInstance);
-            $defaultCoreExtensionsToLoad = [
-                'core',
-                'backend',
-                'frontend',
-                'extbase',
-                'install',
-                'recordlist',
-                'fluid',
-            ];
             $testbase->setUpPackageStates(
                 $this->instancePath,
                 $defaultCoreExtensionsToLoad,

--- a/Classes/Core/SystemEnvironmentBuilder.php
+++ b/Classes/Core/SystemEnvironmentBuilder.php
@@ -40,13 +40,13 @@ use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder as CoreSystemEnvironmentBuilder
  */
 class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
 {
-    public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE)
+    public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE, bool $composerMode = false)
     {
         CoreSystemEnvironmentBuilder::run($entryPointLevel, $requestType);
         Environment::initialize(
             Environment::getContext(),
             Environment::isCli(),
-            false,
+            $composerMode,
             Environment::getProjectPath(),
             Environment::getPublicPath(),
             Environment::getVarPath(),

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -45,8 +45,11 @@
 
     $testbase->defineSitePath();
 
+    // We can use the "typo3/cms-composer-installers" constant "TYPO3_COMPOSER_MODE" to determine composer mode.
+    // This should be always true except for TYPO3 mono repository.
+    $composerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE === true;
     $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType);
+    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
 
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');

--- a/composer.json
+++ b/composer.json
@@ -70,5 +70,8 @@
     "phpstan/phpstan": "^1.9.2",
     "phpstan/phpstan-phpunit": "^1.1.1",
     "typo3/cms-workspaces": "11.*.*@dev"
+  },
+  "replace": {
+    "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "*"
   }
 }


### PR DESCRIPTION
Since TYPO3 v12.0 the "typo3/cms-composer-installers" package
is a hard requirement in version 5. This comes along with some
changes:

* system-extensions are no longer installed in
  `<public-dir>/typo3/sysext/*`

* extensions are no longer installed in
  `<public-dir>/typo3conf/ext/*`

Extension and System Extensions are now installed into the
`vendor-dir` folder, which is the default behaviour of the
composer package-manager. Generally, this is really good
move.

"typo3/testing-framework" expected a specific setup structure,
to provide correct symlinks for system and extensions for
functional- and acceptance test instances. Which is not given
anymore.

As a intermediate solution, a composer plugin has been put
into the wild, providing the the expected structure with
symlinks. Which is a horrable solution, but worked for the
meanwhile.

This change now introduces a testing-framework internal
composer package manager to retrieve informations about
root packags and required packages and use the loaded
information for symlink handling.

Benefits of the implementation:

* core- and test extensions to load can now be specified by
  using the extension-key and/or the composer package name.
  `typo3conf/ext/extension-key` compatibilty is added and
  works without changes. May be deprecated at a later point.

* absolute paths to test-fixture extensions still works the
  same way

* testing-framework do not longer expects system-extensions
  or extensions in a specific place

* works with cms-composer-installers 3, 4RC1 and 5 the same
  way

* "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge"
  is obsolete now, therefore added a "replace" for it to
  `composer.json`

This restores working state. With further dedicated change, this
could be extended by adding a composer.json file scanner to find
and register `test-fixture extensions` directly. Which further
forces that extensions should have always a composer.json.

Releases: main, 7
Resolves: #403

--------------------------------------------------------------------------

tf-main (#434)

* [77624: [WIP][TASK] Test TF typo3/cms-composer-installers 5 changes](https://review.typo3.org/c/Packages/TYPO3.CMS/+/77624)
* [typo3/styleguide (PR)](https://github.com/TYPO3/styleguide/pull/373)

tf-7 (#435)

* [sbuerk/typo3-ensure-admin (PR)](https://github.com/sbuerk/typo3-ensure-admin/pull/6)
* [lolli42/dbdoctor (PR)](https://github.com/lolli42/dbdoctor/pull/26)

--------------------------------------------------------------------------

With this solution, unit-, functional and acceptance tests are working in
core, extension and project level without the need for further adjustments.

Minor adjustment in test invocation are needed, which are backwards compatible
for `typo3/cms-composer-installer 3.x / TYPO3 v11` without the need of the 
bridge plugin.