### PR TITLE
[TASK] Enhance test setup for typo3/cms-composer-installers 5

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -36,7 +36,7 @@ parameters:
 			path: ../../Classes/Composer/ExtensionTestEnvironment.php
 
 		-
-			message: "#^Parameter \\#1 \\$prefix of function uniqid expects string, int given\\.$#"
+			message: "#^Parameter \\#1 \\$prefix of function uniqid expects string, int\\<0, max\\> given\\.$#"
 			count: 1
 			path: ../../Classes/Core/BaseTestCase.php
 

--- a/Classes/Core/InstalledPackages.php
+++ b/Classes/Core/InstalledPackages.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Core;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+
+/**
+ * Little helper service to gather information about the installed composer packages, which is a big befenit
+ * for managing extension symlinking later on into the dedicated legacy test installation paths. Using the
+ * available composer and cms-composer-installers runtime information makes this more robust and removes the
+ * need for assumptions and guesses of installation structures.
+ *
+ * @internal This is a testing-framework internal service class and is not part of public testing-framework API.
+ */
+final class InstalledPackages
+{
+    public const TYPE_MONOREPO = 'monorepo';
+    public const TYPE_EXTENSION = 'extension';
+    public const TYPE_PROJECT = 'project';
+
+    /**
+     * @var string
+     */
+    private $packagesPath;
+
+    /**
+     * @var bool
+     */
+    private $composerInstallerFourOrHigherInstalled;
+
+    /**
+     * @var string
+     */
+    private $projectType = self::TYPE_PROJECT;
+
+    /**
+     * @var array
+     */
+    protected static $installedPackages = [];
+
+    public function __construct()
+    {
+        // Let's calculate a proper path once to avoid wrong determination when symlinks has been invited to the party.
+        $this->packagesPath = realpath(dirname($this->getPackageInstallPath('typo3/testing-framework'), 2));
+        $this->composerInstallerFourOrHigherInstalled = InstalledVersions::satisfies(
+            new VersionParser(),
+            'typo3/cms-composer-installers',
+            '4.0.0-RC1 || ^5'
+        );
+        if (!is_file($this->packagesPath . '/composer/installed.json')) {
+            throw new \RuntimeException(
+                '"vendor/composer/installed.json" file missing. Please require "typo3/cms-composer-installers" in '
+                . 'proper version to the root composer.json.',
+                1674932561
+            );
+        }
+
+        $this->reload();
+    }
+
+    public function getPackagesPath(): string
+    {
+        return $this->packagesPath;
+    }
+
+    public function reload(): void
+    {
+        $typesMap = [
+            'typo3-cms-core' => self::TYPE_MONOREPO,
+            'typo3-cms-framework' => self::TYPE_EXTENSION,
+            'typo3-cms-extension' => self::TYPE_EXTENSION,
+            'project' => self::TYPE_PROJECT,
+        ];
+        $rootPackage = InstalledVersions::getRootPackage();
+        $rootPackageName = $rootPackage['name'];
+        $rootPackageType = $rootPackage['type'];
+        $projectType = $typesMap[$rootPackageType] ?? '';
+        if ($projectType === '') {
+            throw new \RuntimeException(
+                'Could not properly determine project type based on root composer.json package type.'
+                . ' No match for "' . $rootPackageType . '" possible.'
+            );
+        }
+        $this->projectType = $projectType;
+
+        /**
+         * @var array<string, array{pretty_version?: string, version?: string, reference?: string|null, extra?: array<string, mixed>, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}> $packages
+         */
+        $packages = [];
+        $decoded = \json_decode(file_get_contents($this->packagesPath . '/composer/installed.json'), true);
+        if (!is_array($decoded)) {
+            throw new \Exception(
+                'Could not decode "typo3/cms-composer-installers" installed.json file: '
+                . $this->packagesPath . '/composer/installed.json',
+                1674939842
+            );
+        }
+        foreach ($decoded['packages'] ?? [] as $decodedPackage) {
+            $packages[$decodedPackage['name']] = $decodedPackage;
+        }
+        // It seems that "typo3/cms-composer-installers" does not add the root package to the "installed.json"
+        // file with enriched data. So we add it here now to have better lookup data at handy when we need it.
+        if ($rootPackageType === 'typo3-cms-extension') {
+            $packages[$rootPackageName] = $rootPackage;
+            if (file_exists($this->getPackageInstallPath($rootPackageName) . '/composer.json')) {
+                $packages[$rootPackageName] = array_replace(
+                    json_decode(file_get_contents($this->getPackageInstallPath($rootPackageName) . '/composer.json'), true) ?? [],
+                    $rootPackage
+                );
+            }
+        }
+
+        $packagesPerType = [];
+        $packagesExtensionKeyToNameMap = [];
+        foreach (InstalledVersions::getAllRawData() as $loader) {
+            foreach ($loader['versions'] as $packageName => $packageInfo) {
+                /**
+                 * @var array{pretty_version?: string, version?: string, reference?: string|null, extra?: array<string, mixed>, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]} $package
+                 */
+                $package = array_replace(
+                    $packageInfo,
+                    $packages[$packageName] ?? []
+                );
+                $packageType = $package['type'] ?? '';
+                $packageExtensionKey = (string)($package['extra']['typo3/cms']['extension-key'] ?? '');
+                $packagesPerType[$packageType][] = $packageName;
+                if ($packageExtensionKey !== '') {
+                    $packagesExtensionKeyToNameMap[$packageExtensionKey] = $packageName;
+                }
+            }
+        }
+        $self = $this;
+        array_walk($packages, static function (array &$package, string $packageName) use ($self) {
+            // cleanup invalid install path key
+            unset($package['install-path']);
+            // normalize install path in package information
+            $package['install_path'] = realpath($self->getPackageInstallPath($packageName));
+        });
+        self::$installedPackages = [
+            'packages' => $packages,
+            'typeMap' => $packagesPerType,
+            'extensionKeyMap' => $packagesExtensionKeyToNameMap,
+        ];
+    }
+
+    public function isCmsComposerInstallersFourOrHigher(): bool
+    {
+        return $this->composerInstallerFourOrHigherInstalled;
+    }
+
+    public function getPackageInstallPath(string $name): string
+    {
+        return rtrim(strtr(InstalledVersions::getInstallPath($name), '\\', '/'), '/');
+    }
+
+    public function getPackage(string $name): ?array
+    {
+        if ($this->getPackages()[$name] ?? false) {
+            return $this->getPackages()[$name];
+        }
+        if (($this->getExtensionKeyMap()[$name] ?? false)
+            && ($this->getPackages()[$this->getExtensionKeyMap()[$name]] ?? false)
+        ) {
+            return $this->getPackages()[$this->getExtensionKeyMap()[$name]];
+        }
+        return null;
+    }
+
+    public function getRealPackageName(string $name): string
+    {
+        if (str_starts_with($name, 'typo3conf/ext/')) {
+            $name = basename($name);
+        }
+        if ($this->getExtensionKeyMap()[$name] ?? false) {
+            return $this->getRealPackageName($this->getExtensionKeyMap()[$name]);
+        }
+        if ($this->getPackage($name) !== null) {
+            return $name;
+        }
+        return '';
+    }
+
+    public function getPackagesPerType(string $type): array
+    {
+        $packages = [];
+        foreach (self::$installedPackages['typeMap'][$type] ?? [] as $packageName) {
+            $packages[$packageName] = $this->getPackage($packageName);
+        }
+        return $packages;
+    }
+
+    public function getPackages(): array
+    {
+        return self::$installedPackages['packages'] ?? [];
+    }
+
+    public function getProjectType(): string
+    {
+        return $this->projectType;
+    }
+
+    protected function getExtensionKeyMap(): array
+    {
+        return self::$installedPackages['extensionKeyMap'] ?? [];
+    }
+}

--- a/Classes/Core/SystemEnvironmentBuilder.php
+++ b/Classes/Core/SystemEnvironmentBuilder.php
@@ -40,13 +40,13 @@ use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder as CoreSystemEnvironmentBuilder
  */
 class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
 {
-    public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE)
+    public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE, bool $composerMode = false)
     {
         CoreSystemEnvironmentBuilder::run($entryPointLevel, $requestType);
         Environment::initialize(
             Environment::getContext(),
             Environment::isCli(),
-            false,
+            $composerMode,
             Environment::getProjectPath(),
             Environment::getPublicPath(),
             Environment::getVarPath(),

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -45,8 +45,15 @@
 
     $testbase->defineSitePath();
 
+    // Since testing-framework is normally installed in composer mode, the root installation installs a composer
+    // installation anyway. Thus, we could safely assume composer mode. However, we do a proper check here to stay
+    // on the light side. Additionally, we fall back to legacy mode install mode for older composer installers,
+    // which provides the same directory structure in composer mode as in legacy mode.
+    $composerMode = defined('TYPO3_COMPOSER_MODE')
+        && TYPO3_COMPOSER_MODE === true
+        && $testbase->getInstalledPackages()->isCmsComposerInstallersFourOrHigher();
     $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType);
+    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
 
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');


### PR DESCRIPTION
TYPO3 v12 hard required "typo3/cms-composer-installers" in version 5, which results in a different installation folder structure like in the past. This differes from a classic legacy installation even more then composer mode versus legacy mode in recent versions.

"typo3/testing-framework" builds legacy mode instances for each functional test-case, and have to provide core extensions and extensions in the test instance based on the test-case selection. That way, different installation scenarious have been possibile to test, also *all* extensions needed for all tests had to be available in the root installation. Root installation could be the TYPO3 core "monorepo", a TYPO3 extension which should be tested or a TYPO3 project to test on project level.

Until v5 of the composer installers, all different versions ensured a proper root setup, or installation in a subfolder, with a specified layout. This is not guaranteed anylonger, which let the testing-framework badly fail to keep testing working.

To mitigate this gap in support, a unofficial composer plugin has been quickly put in charge to provide the expected old structure with symlinks during installs, which was fine for automatic testings. However, that had some side-effects. First of all, eventually left-overs with hard coded links in templates, mostly in project-level based test sceneries, was silently shadowed in development installations.

Instead of explictly expecting hard coded paths and places, this change implements proper detection and symlinking based on the available package information provided by the composer runtime, and enriched by the typo3/cms-composer-installers. This is handled basicly by a TF internal service class, which is then used in the already known `Testbase` class. The named `Testbase` class is used in the whole bootstrap and instance setup process. This allows testing all currently needed variants.

The TYPO3 core monorepo however still is a special setup, not fitting in normal known and workable setup types. One thing to mention here is the fact, that the core extensions are not required in the monorepo root composer.json, and thus the corresponding package informations are not available in the runtime composer information. To mitigate this and keep core testing working a fallback to the "well" known structore of the monorepo is kept.

The phpunit template file `UnitTestsBootstrap.php` has been adjusted with the proper check to keep them running. The corresponding functional or ac tests needs no adjustmens.

However, a extension or project using the testing-framework and the `runTests.sh` adoption along with a corresponding docker-compose.yml file may have defined paths and a setup which is also hard-guessed on the structure until now. With the bridge plugin this kept working. The now implemented testing-framework changes has no need for the old-structure symlinks and only handle proper symlinking from the outer installation into the test instances. Thus assumption of old-structure won't work anylonger.

Regardless your installation setup, eg. for a extension setup, phpunit and the unit, functional or acceptance tests should be called directly from the root package, instead into the installed "instance" - as there will be no symlinking to the vendor folder nor the old typo3 or typo3conf/ext folders in the public folder.

Beside this change in the TF, this change will be tested against the core and at least some known public extensions. These tests will be promoted to real pull-requests to quickly adopt the needed changes.

Changes related to unit testing:

* add additional argument `$composerMode` to the provided `TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run()`
* add composer mode detection in `UnitTestBootstrap.php` template and pass it to `SystemEnvironmentBuilder::run()`

Changes related to functional testing:

* using composer installed version along with enhanced info created by typo3/cms-composer-installers package to properly calculate paths and symlink extension (system, extension) correctly depending on context (monorepo, extension or project setup) to functional legacy test instance.

Resolves #403
