### PR TITLE
[TASK] Guard "executeFrontendSubRequests()" against old core version

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: ../../Classes/Composer/ExtensionTestEnvironment.php
 
 		-
-			message: "#^Parameter \\#1 \\$prefix of function uniqid expects string, int given\\.$#"
-			count: 1
-			path: ../../Classes/Core/BaseTestCase.php
-
-		-
 			message: "#^Cannot access offset string on int\\.$#"
 			count: 2
 			path: ../../Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php

--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -148,7 +148,7 @@ abstract class BaseTestCase extends TestCase
      */
     protected function getUniqueId($prefix = '')
     {
-        $uniqueId = uniqid(mt_rand(), true);
+        $uniqueId = uniqid((string)mt_rand(), true);
         return $prefix . str_replace('.', '', $uniqueId);
     }
 }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1117,6 +1117,16 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         InternalRequestContext $context = null,
         bool $followRedirects = false
     ): InternalResponse {
+        if ((new Typo3Version())->getMajorVersion() < 11) {
+            throw new \RuntimeException(
+                'executeFrontendSubRequests() only possible with TYPO3 v11 or higher.'
+                . ' Please use executeFrontendRequest() for TYPO3 up to v10. If you need to'
+                . ' to multi-core testing with the same testcase, implement a proper version check'
+                . ' or use executeFrontendRequest() for tests against both core versions.',
+                1675871234
+            );
+        }
+
         if ($context === null) {
             $context = new InternalRequestContext();
         }


### PR DESCRIPTION
This change adds a exception with a proper exception message, if 
`executeFrontendSubRequests()` is used with invalid core version.

As a side fix a string cast is added to avoid phpstand error
reporting because of type missmatch.

Used command(s):

```shell
Build/Scripts/runTests.sh -s phpstanGenerateBaseline
```

Resolves #437
