### PR TITLE
[TASK] Allow phpunit ^10 next to ^9

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,2 +1,16 @@
 parameters:
 	ignoreErrors:
+		-
+			message: "#^Call to an undefined method PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\<T of object&TYPO3\\\\TestingFramework\\\\Core\\\\AccessibleObjectInterface\\>\\:\\:setMethods\\(\\)\\.$#"
+			count: 1
+			path: ../../Classes/Core/BaseTestCase.php
+
+		-
+			message: "#^Instantiated class PHPUnit\\\\Framework\\\\RiskyTestError not found\\.$#"
+			count: 3
+			path: ../../Classes/Core/BaseTestCase.php
+
+		-
+			message: "#^Throwing object of an unknown class PHPUnit\\\\Framework\\\\RiskyTestError\\.$#"
+			count: 3
+			path: ../../Classes/Core/BaseTestCase.php

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
   "require": {
     "php": "^8.1",
     "ext-pdo": "*",
-    "phpunit/phpunit": "^9.5.25",
+    "guzzlehttp/psr7": "^1.7 || ^2.0",
+    "phpunit/phpunit": "^9.5.25 || ^10.0.14",
     "psr/container": "^1.1.0 || ^2.0.0",
-    "typo3/cms-core": "12.*.*@dev",
     "typo3/cms-backend": "12.*.*@dev",
-    "typo3/cms-frontend": "12.*.*@dev",
+    "typo3/cms-core": "12.*.*@dev",
     "typo3/cms-extbase": "12.*.*@dev",
     "typo3/cms-fluid": "12.*.*@dev",
-    "typo3/cms-install": "12.*.*@dev",
-    "guzzlehttp/psr7": "^1.7 || ^2.0"
+    "typo3/cms-frontend": "12.*.*@dev",
+    "typo3/cms-install": "12.*.*@dev"
   },
   "config": {
     "vendor-dir": ".Build/vendor",


### PR DESCRIPTION
To prepare core and extension towards phpunit 10,
we need to allow it in TF as a first step:

$ composer req phpunit/phpunit:"^9.5.25 || ^10.0.14" $ Build/Scripts/runTests.sh -s phpstanGenerateBaseline

Issues will be sorted out with further patches.

Releases: main, 7
