### PR TITLE
[TASK] Allow phpunit ^10 next to ^9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,18 @@
   "require": {
     "php": ">= 7.4",
     "ext-pdo": "*",
-    "phpunit/phpunit": "^9.5.25",
-    "psr/container": "^1.1.0 || ^2.0.0",
+    "guzzlehttp/psr7": "^1.7 || ^2.0",
     "mikey179/vfsstream": "~1.6.11",
-    "typo3fluid/fluid": "^2.7.1",
-    "typo3/cms-core": "11.*.*@dev || 12.*.*@dev",
+    "phpunit/phpunit": "^9.5.25 || ^10.0.14",
+    "psr/container": "^1.1.0 || ^2.0.0",
     "typo3/cms-backend": "11.*.*@dev || 12.*.*@dev",
-    "typo3/cms-frontend": "11.*.*@dev || 12.*.*@dev",
+    "typo3/cms-core": "11.*.*@dev || 12.*.*@dev",
     "typo3/cms-extbase": "11.*.*@dev || 12.*.*@dev",
     "typo3/cms-fluid": "11.*.*@dev || 12.*.*@dev",
+    "typo3/cms-frontend": "11.*.*@dev || 12.*.*@dev",
     "typo3/cms-install": "11.*.*@dev || 12.*.*@dev",
     "typo3/cms-recordlist": "11.*.*@dev || 12.*.*@dev",
-    "guzzlehttp/psr7": "^1.7 || ^2.0"
+    "typo3fluid/fluid": "^2.7.1"
   },
   "conflict": {
     "doctrine/dbal": "2.13.0 || 2.13.1"


### PR DESCRIPTION
To prepare core and extension towards phpunit 10,
we need to allow it in TF as a first step:

$ composer req phpunit/phpunit:"^9.5.25 || ^10.0.14"

Issues will be sorted out with further patches.

Releases: main, 7
