### PR TITLE
[TASK] Consecutive tests do not fail on left over instance

### DIFF
--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -190,6 +190,10 @@ abstract class UnitTestCase extends BaseTestCase
                 }
             }
         }
+        if (!empty($notCleanInstances)) {
+            // Reset instance list (including singletons & container) to not let all further tests fail
+            GeneralUtility::purgeInstances();
+        }
         // Let the test fail if there were instances left and give some message on why it fails
         self::assertEquals(
             [],


### PR DESCRIPTION
When a test uses GeneralUtility::addInstance() to add (non-singleton) instances, and if that test does not consume all those instances, it fails.

The patch adds a call to clean up left over instances. This way, tests executed afterwards start clean again and don't fail as side-effect as well anymore.

Releases: main
