### PR TITLE
[TASK] Avoid setMethods() on mocks

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\<T of object&TYPO3\\\\TestingFramework\\\\Core\\\\AccessibleObjectInterface\\>\\:\\:setMethods\\(\\)\\.$#"
-			count: 1
-			path: ../../Classes/Core/BaseTestCase.php
-
-		-
 			message: "#^Instantiated class PHPUnit\\\\Framework\\\\RiskyTestError not found\\.$#"
 			count: 3
 			path: ../../Classes/Core/BaseTestCase.php

--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -124,9 +124,14 @@ abstract class BaseTestCase extends TestCase
         }
 
         $mockBuilder = $this->getMockBuilder($this->buildAccessibleProxy($originalClassName))
-            ->setMethods($methods)
             ->setConstructorArgs($arguments)
             ->setMockClassName($mockClassName);
+
+        if ($methods === null) {
+            $mockBuilder->onlyMethods([]);
+        } elseif (!empty($methods)) {
+            $mockBuilder->onlyMethods($methods);
+        }
 
         if (!$callOriginalConstructor) {
             $mockBuilder->disableOriginalConstructor();


### PR DESCRIPTION
setMethods() has been removed with phpunit 10.

$this->getAccessibleMock() used this to only
partially mock a test subject. The patch switches
to onlyMethods() now.

There is one difference: onlyMethods() fails if
a methods that should be mocked does not exist,
while setMethods() did not fail on this.

So this is more strict now. It was frequently used in core tests mocking ['dummy'] to say "mock no method". Those have to be switched to use 'null' as argument to $this->getAccessibleMock() now. Also, when a class is refactored, and a method that has been previously mocked is removed with the refactoring, the mock has to be adapted to remove the method-mock request from the test as well now, otherwise the test will fail.

Releases: main, 7
Resolves: #444
