### PR TITLE
[TASK] Avoid setAccessible()

### DIFF
--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -205,7 +205,6 @@ abstract class UnitTestCase extends BaseTestCase
         // Verify LocalizationUtility class internal state has been reset properly if a test fiddled with it
         $reflectionClass = new \ReflectionClass(LocalizationUtility::class);
         $property = $reflectionClass->getProperty('configurationManager');
-        $property->setAccessible(true);
         self::assertNull($property->getValue());
 
         self::assertTrue($this->setUpMethodCallChainValid, 'tearDown() integrity check detected that setUp has a '


### PR DESCRIPTION
setAccessible() is a no-op since PHP 8.1.
We can clean up the FrameworkState class
quite a bit: core RootlineUtility
switched to runtime caches meanwhile.

Releases: main