### PR TITLE
[!!!][TASK] Avoid setMethods() on mocks

### DIFF
--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -56,9 +56,14 @@ abstract class BaseTestCase extends TestCase
         }
 
         $mockBuilder = $this->getMockBuilder($this->buildAccessibleProxy($originalClassName))
-            ->setMethods($methods)
             ->setConstructorArgs($arguments)
             ->setMockClassName($mockClassName);
+
+        if ($methods === null) {
+            $mockBuilder->onlyMethods([]);
+        } elseif (!empty($methods)) {
+            $mockBuilder->onlyMethods($methods);
+        }
 
         if (!$callOriginalConstructor) {
             $mockBuilder->disableOriginalConstructor();


### PR DESCRIPTION
setMethods() has been removed with phpunit 10.

$this->getAccessibleMock() used this to only
partially mock a test subject. The patch switches
to onlyMethods() now.

There is one difference: onlyMethods() fails if
a methods that should be mocked does not exist,
while setMethods() did not fail on this.

So this is more strict now. It was frequently used in core tests mocking ['dummy'] to say "mock no method". Those have to be switched to use 'null' as argument to $this->getAccessibleMock() now. Also, when a class is refactored, and a method that has been previously mocked is removed with the refactoring, the mock has to be adapted to remove the method-mock request from the test as well now, otherwise the test will fail.

Rules for the second argument of getAccessibleMock():

* "keep all methods, mock nothing": Hand over 'null'
* "mock all methods": Hand over empty array [] (default)
* "mock single methods": Hand over an array with method names

Releases: main, 7
Resolves: #444

### Changes proposed in this pull request

<!--
1. ..
2. ..
-->

### Steps to test the solution

<!--
1. ..
2. ..
-->

### Results

<!--
Look at the contributing guidelines of the testing framework, what results are
expected here.
-->

Fixes: #<!-- Issue ID -->
