### PR TITLE
[TASK] Do not clean up properties in UnitTestCase tearDown()

### DIFF
--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -136,23 +136,6 @@ abstract class UnitTestCase extends BaseTestCase
             );
         }
 
-        // Unset properties of test classes to safe memory
-        $reflection = new \ReflectionObject($this);
-        foreach ($reflection->getProperties() as $property) {
-            $declaringClass = $property->getDeclaringClass()->getName();
-            if (
-                !$property->isPrivate()
-                && !$property->isStatic()
-                && $declaringClass !== UnitTestCase::class
-                && $declaringClass !== BaseTestCase::class
-                && strpos($property->getDeclaringClass()->getName(), 'PHPUnit') !== 0
-            ) {
-                $propertyName = $property->getName();
-                unset($this->$propertyName);
-            }
-        }
-        unset($reflection);
-
         // Delete registered test files and directories
         foreach ($this->testFilesToDelete as $absoluteFileName) {
             $absoluteFileName = GeneralUtility::fixWindowsFilePath(PathUtility::getCanonicalPath($absoluteFileName));


### PR DESCRIPTION
With core unit tests, avoiding the property clean
up code in UnitTestCase tearDown() actually
reduces memory usage by now. This might be a
side effect of more clean unit tests, and it
seems the PHP reflection can be a bit of a
memory hog.

We'll remove that code for now.

Releases: main