### PR TITLE
[BUGFIX] Silence `symlink()` errors using `@` operator 

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -186,7 +186,7 @@ class Testbase
         chdir($instancePath);
         $this->createDirectory($instancePath . '/typo3');
         foreach ($linksToSet as $from => $to) {
-            $success = symlink(realpath($from), $to);
+            $success = @symlink(realpath($from), $to);
             if (!$success) {
                 throw new Exception(
                     'Creating link failed: from ' . $from . ' to: ' . $to,
@@ -248,7 +248,7 @@ class Testbase
                 );
             }
             $destinationPath = $instancePath . '/typo3conf/ext/' . basename($absoluteExtensionPath);
-            $success = symlink($absoluteExtensionPath, $destinationPath);
+            $success = @symlink($absoluteExtensionPath, $destinationPath);
             if (!$success) {
                 throw new Exception(
                     'Can not link extension folder: ' . $absoluteExtensionPath . ' to ' . $destinationPath,
@@ -277,7 +277,7 @@ class Testbase
                 );
             }
             $destinationPath = $instancePath . '/typo3conf/ext/' . basename($absoluteExtensionPath);
-            $success = symlink($absoluteExtensionPath, $destinationPath);
+            $success = @symlink($absoluteExtensionPath, $destinationPath);
             if (!$success) {
                 throw new Exception(
                     'Can not link extension folder: ' . $absoluteExtensionPath . ' to ' . $destinationPath,
@@ -307,7 +307,7 @@ class Testbase
                 );
             }
             $destinationPath = $instancePath . '/' . ltrim($destinationPathToLinkInTestInstance, '/');
-            $success = symlink($sourcePath, $destinationPath);
+            $success = @symlink($sourcePath, $destinationPath);
             if (!$success) {
                 throw new Exception(
                     'Can not link the path ' . $sourcePath . ' to ' . $destinationPath,


### PR DESCRIPTION
Creating symlinks in `Testbase` may fail due several
reasons, triggering a mostly use-less message without
much context.

This change now uses the `@` silence operator for the
`symlink()` method calls in `Testbase` in favour of
the more use-full custom error message provided by the
thrown exceptions.

Resolves: https://github.com/TYPO3/testing-framework/issues/456
Releases: main, 7