### PR TITLE
[TASK] Use core-testing-* images from ghcr.io

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -26,6 +26,7 @@ setUpDockerComposeDotEnv() {
     echo "DOCKER_PHP_IMAGE=${DOCKER_PHP_IMAGE}" >> .env
     echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}" >> .env
     echo "CGLCHECK_DRY_RUN=${CGLCHECK_DRY_RUN}" >> .env
+    echo "IMAGE_PREFIX=${IMAGE_PREFIX}" >> .env
 }
 
 # Load help text into $HELP
@@ -102,6 +103,7 @@ PHP_VERSION="7.2"
 PHP_XDEBUG_ON=0
 SCRIPT_VERBOSE=0
 CGLCHECK_DRY_RUN=""
+IMAGE_PREFIX="ghcr.io/typo3/"
 
 # Option parsing
 # Reset in case getopts has been used previously in the shell

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cgl:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -33,7 +33,7 @@ services:
       "
 
   composer_update:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -50,7 +50,7 @@ services:
         composer update --no-progress --no-interaction;
       "
   lint:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}
@@ -67,7 +67,7 @@ services:
       "
 
   phpstan:
-      image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+      image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
       user: "${HOST_UID}"
       volumes:
           - ${ROOT_DIR}:${ROOT_DIR}
@@ -83,7 +83,7 @@ services:
           "
 
   phpstan_generate_baseline:
-      image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+      image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
       user: "${HOST_UID}"
       volumes:
           - ${ROOT_DIR}:${ROOT_DIR}
@@ -99,7 +99,7 @@ services:
           "
 
   unit:
-    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: ${HOST_UID}
     volumes:
       - ${ROOT_DIR}:${ROOT_DIR}


### PR DESCRIPTION
This change adjusts Build/Scripts/runTests.sh and
Build/testing-docker/docker-compose.yml to add a
docker image prefix. This prefix is hardcoded to use
the TYPO3 core-testing images from the TYPO3 GitHub
Container Registry by setting the prefix to ghcr.io.

Releases: main, 7, 6
