### PR TITLE
Adjust variables, use composer info, allow `EXT:` in paths

### DIFF
--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -188,6 +188,6 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
 
     public static function getAutoload()
     {
-        return !empty($_composer_autoload_path) ? $_composer_autoload_path : realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
+        return realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
     }
 }

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -188,6 +188,6 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
 
     public static function getAutoload()
     {
-        return @isset($_composer_autoload_path) ? $_composer_autoload_path : realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
+        return !empty($_composer_autoload_path) ? $_composer_autoload_path : realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
     }
 }

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -16,7 +16,7 @@ namespace TYPO3\TestingFramework\Composer;
  * The TYPO3 project - inspiring people to share!
  */
 
-use \Composer\InstalledVersions;
+use Composer\InstalledVersions;
 
 /**
  * PROPERTIES of \Composer\InstalledVersions:

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -184,6 +184,6 @@ class ComposerPackageInfo
 
     public static function getAutoload()
     {
-        return realpath(self::getInstallPath('typo3/cms-core') . '/../../autoload.php');
+        return realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
     }
 }

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\TestingFramework\Composer;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * PARENT PROPERTIES:
+ * private static $installed;
+ * private static $canGetVendors;
+ * private static $installedByVendor = array();
+ *
+ * PARENT METHODS:
+ * public static function getInstalledPackages()
+ * public static function getInstalledPackagesByType($type)
+ * public static function isInstalled($packageName, $includeDevRequirements = true)
+ * public static function satisfies(VersionParser $parser, $packageName, $constraint)
+ * public static function getVersionRanges($packageName)
+ * public static function getVersion($packageName)
+ * public static function getPrettyVersion($packageName)
+ * public static function getReference($packageName)
+ * public static function getInstallPath($packageName)
+ * public static function getRootPackage()
+ * public static function getRawData() @deprecated
+ * public static function getAllRawData()
+ * public static function reload($data)
+ * private static function getInstalled()
+ */
+
+/**
+ * TYPO3 related extending class of \Composer\InstalledVersions.
+ * @see https://github.com/composer/composer/blob/main/src/Composer/InstalledVersions.php
+ */
+class ComposerPackageInfo extends \Composer\InstalledVersions
+{
+    /**
+     * Get's all TYPO3 local extensions that are installed.
+     * This is ignoring system extensions.
+     */
+    public static function getLocalExtensions()
+    {
+        return self::getInstalledPackagesByType('typo3-cms-extension');
+    }
+
+    /**
+     * Get's all TYPO3 system extensions that are installed.
+     * This is ignoring local extensions.
+     */
+    public static function getSystemExtensions()
+    {
+        return self::getInstalledPackagesByType('typo3-cms-framework');
+    }
+
+    /**
+     * Get's all TYPO3 extensions that are installed.
+     * This is ignoring i.e. packages that serve as composer plugin or are independent libraries
+     */
+    public static function getAllExtensions()
+    {
+        $localExtensions = self::getLocalExtensions();
+        $systemExtensions = self::getSystemExtensions();
+        return array_merge($systemExtensions, $localExtensions);
+    }
+
+    /**
+     * Get's all TYPO3 local extensions that are installed.
+     * This is ignoring system extensions.
+     */
+    public static function getLocalExtensionsEnriched()
+    {
+        $localExtensions = self::getLocalExtensions();
+        $localExtensionsEnriched = self::getExtensionsEnriched($localExtensions);
+        return $localExtensionsEnriched;
+    }
+
+    /**
+     * Get's all TYPO3 system extensions that are installed.
+     * This is ignoring local extensions.
+     */
+    public static function getSystemExtensionsEnriched()
+    {
+        $systemExtensions = self::getSystemExtensions();
+        $systemExtensionsEnriched = self::getExtensionsEnriched($systemExtensions);
+        return $systemExtensionsEnriched;
+    }
+
+    public static function getExtensionsEnriched($composerNameArray)
+    {
+        if (!is_array($composerNameArray)) {
+            return false;
+        }
+        $extensionsEnriched = [];
+        foreach ($composerNameArray as $count => $composerName) {
+            $extensionDetails = self::getExtensionDetails($composerName);
+            $extensionsEnriched[$composerName] = $extensionDetails;
+            $extensionsEnriched[$composerName]['composerName'] = $composerName;
+            if (!empty($extensionDetails['install_path'])) {
+                $extensionsEnriched[$composerName]['extensionKey'] = self::getExtensionKey($composerName, $extensionDetails['install_path']);
+            }
+        }
+        return $extensionsEnriched;
+    }
+
+    /**
+     * Get's all TYPO3 extensions that are installed.
+     * This is ignoring i.e. packages that serve as composer plugin or are independent libraries
+     */
+    public static function getAllExtensionsEnriched()
+    {
+        $localExtensionsEnriched = self::getLocalExtensionsEnriched();
+        $systemExtensionsEnriched = self::getSystemExtensionsEnriched();
+        return array_merge_recursive($localExtensionsEnriched, $systemExtensionsEnriched);
+    }
+
+    public static function getExtensionDetails($composerName)
+    {
+        $extensionDetails = [];
+        $allRawData = self::getAllRawData($composerName);
+        if (array_key_exists($composerName, $allRawData[0]['versions'])) {
+            $extensionDetails = $allRawData[0]['versions'][$composerName];
+        }
+        elseif ($composerName == $allRawData[0]['root']['name']) {
+            $extensionDetails = null;
+        }
+        else {
+            $extensionDetails = false;
+        }
+        return $extensionDetails;
+    }
+
+    public static function getExtensionKey($composerName, $installPath)
+    {
+        $data = self::getJsonConfiguration($composerName, $installPath);
+        $extensionKey = $data['extra']['typo3/cms']['extension-key'] ?? '';
+        return $extensionKey;
+    }
+
+    /**
+     * Gets the full configuration of an extension's composer.json.
+     * Can be used to get any details which are not provided by composer API by default.
+     * Used for getExtensionKey()
+     *
+     * @param string
+     * @param string
+     *
+     * @return mixed [array | false]
+     */
+    public static function getJsonConfiguration($composerName, $installPath)
+    {
+        $filePath = $installPath . '/composer.json';
+        if (!is_file($filePath)) {
+            return false;
+        }
+        $content = file_get_contents($filePath);
+        $data = json_decode($content, true);
+        return $data;
+    }
+
+    public static function resolveExtensionPath($extensionPath)
+    {
+        if (strpos($extensionPath, 'EXT:') === 0) {
+            $extKey = substr($extensionPath, 4);
+            $allConfig = self::getAllExtensionsEnriched();
+            foreach ($allConfig as $count => $extConf) {
+                if ($extConf['extensionKey'] == $extKey) {
+                    return $extConf['install_path'];
+                }
+            }
+            return false;
+        }
+        return $extensionPath;
+    }
+
+    public static function getVendorPath()
+    {
+        // return realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../');
+        return dirname($_composer_autoload_path);
+    }
+}

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -16,13 +16,15 @@ namespace TYPO3\TestingFramework\Composer;
  * The TYPO3 project - inspiring people to share!
  */
 
+use \Composer\InstalledVersions;
+
 /**
- * PARENT PROPERTIES:
+ * PROPERTIES of \Composer\InstalledVersions:
  * private static $installed;
  * private static $canGetVendors;
  * private static $installedByVendor = array();
  *
- * PARENT METHODS:
+ * METHODS of \Composer\InstalledVersions:
  * public static function getInstalledPackages()
  * public static function getInstalledPackagesByType($type)
  * public static function isInstalled($packageName, $includeDevRequirements = true)
@@ -43,7 +45,7 @@ namespace TYPO3\TestingFramework\Composer;
  * TYPO3 related extending class of \Composer\InstalledVersions.
  * @see https://github.com/composer/composer/blob/main/src/Composer/InstalledVersions.php
  */
-class ComposerPackageInfo extends \Composer\InstalledVersions
+class ComposerPackageInfo
 {
     /**
      * Get's all TYPO3 local extensions that are installed.
@@ -51,7 +53,7 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
      */
     public static function getLocalExtensions()
     {
-        return self::getInstalledPackagesByType('typo3-cms-extension');
+        return InstalledVersions::getInstalledPackagesByType('typo3-cms-extension');
     }
 
     /**
@@ -60,7 +62,7 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
      */
     public static function getSystemExtensions()
     {
-        return self::getInstalledPackagesByType('typo3-cms-framework');
+        return InstalledVersions::getInstalledPackagesByType('typo3-cms-framework');
     }
 
     /**
@@ -96,11 +98,8 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
         return $systemExtensionsEnriched;
     }
 
-    public static function getExtensionsEnriched($composerNameArray)
+    public static function getExtensionsEnriched(array $composerNameArray)
     {
-        if (!is_array($composerNameArray)) {
-            return false;
-        }
         $extensionsEnriched = [];
         foreach ($composerNameArray as $count => $composerName) {
             $extensionDetails = self::getExtensionDetails($composerName);
@@ -124,10 +123,10 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
         return array_merge_recursive($localExtensionsEnriched, $systemExtensionsEnriched);
     }
 
-    public static function getExtensionDetails($composerName)
+    public static function getExtensionDetails(string $composerName)
     {
         $extensionDetails = [];
-        $allRawData = self::getAllRawData($composerName);
+        $allRawData = InstalledVersions::getAllRawData();
         if (array_key_exists($composerName, $allRawData[0]['versions'])) {
             $extensionDetails = $allRawData[0]['versions'][$composerName];
         } elseif ($composerName == $allRawData[0]['root']['name']) {
@@ -138,7 +137,7 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
         return $extensionDetails;
     }
 
-    public static function getExtensionKey($composerName, $installPath)
+    public static function getExtensionKey(string $composerName, string $installPath)
     {
         $data = self::getJsonConfiguration($composerName, $installPath);
         $extensionKey = $data['extra']['typo3/cms']['extension-key'] ?? '';
@@ -150,12 +149,9 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
      * Can be used to get any details which are not provided by composer API by default.
      * Used for getExtensionKey()
      *
-     * @param string
-     * @param string
-     *
      * @return mixed [array | false]
      */
-    public static function getJsonConfiguration($composerName, $installPath)
+    public static function getJsonConfiguration(string $composerName, string $installPath)
     {
         $filePath = $installPath . '/composer.json';
         if (!is_file($filePath)) {
@@ -166,7 +162,7 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
         return $data;
     }
 
-    public static function resolveExtensionPath($extensionPath)
+    public static function resolveExtensionPath(string $extensionPath)
     {
         if (strpos($extensionPath, 'EXT:') === 0) {
             $extKey = substr($extensionPath, 4);

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -183,7 +183,11 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
 
     public static function getVendorPath()
     {
-        // return realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../');
-        return dirname($_composer_autoload_path);
+        return dirname(self::getAutoload());
+    }
+
+    public static function getAutoload()
+    {
+        return isset($_composer_autoload_path) ? $_composer_autoload_path : realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
     }
 }

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -188,6 +188,6 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
 
     public static function getAutoload()
     {
-        return realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
+        return realpath(self::getInstallPath('typo3/cms-core') . '/../../autoload.php');
     }
 }

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -130,11 +130,9 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
         $allRawData = self::getAllRawData($composerName);
         if (array_key_exists($composerName, $allRawData[0]['versions'])) {
             $extensionDetails = $allRawData[0]['versions'][$composerName];
-        }
-        elseif ($composerName == $allRawData[0]['root']['name']) {
+        } elseif ($composerName == $allRawData[0]['root']['name']) {
             $extensionDetails = null;
-        }
-        else {
+        } else {
             $extensionDetails = false;
         }
         return $extensionDetails;

--- a/Classes/Composer/ComposerPackageInfo.php
+++ b/Classes/Composer/ComposerPackageInfo.php
@@ -188,6 +188,6 @@ class ComposerPackageInfo extends \Composer\InstalledVersions
 
     public static function getAutoload()
     {
-        return isset($_composer_autoload_path) ? $_composer_autoload_path : realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
+        return @isset($_composer_autoload_path) ? $_composer_autoload_path : realpath(InstalledVersions::getInstallPath('typo3/cms-core') . '/../../autoload.php');
     }
 }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -227,8 +227,7 @@ class Testbase
             $instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php' => $instancePath . '/typo3/install.php',
         ];
 
-        // var $_composer_autoload_path is global and set by composer
-        $autoloadFile = $_composer_autoload_path ?? $this->getPackagesPath() . '/autoload.php';
+        $autoloadFile = ComposerPackageInfo::getAutoload();
         foreach ($entryPointsToSet as $source => $target) {
             if (($entryPointContent = @file_get_contents($source)) === false) {
                 throw new \UnexpectedValueException(sprintf('Source file (%s) was not found.', $source), 1636244753);
@@ -281,8 +280,7 @@ class Testbase
             $instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php' => $instancePath . '/typo3/install.php',
         ];
 
-        // var $_composer_autoload_path is global and set by composer
-        $autoloadFile = $_composer_autoload_path ?? $this->getPackagesPath() . '/autoload.php';
+        $autoloadFile = ComposerPackageInfo::getAutoload();
         foreach ($entryPointsToSet as $source => $target) {
             if (($entryPointContent = @file_get_contents($source)) === false) {
                 throw new \UnexpectedValueException(sprintf('Source file (%s) was not found.', $source), 1636244753);
@@ -713,8 +711,7 @@ class Testbase
         // Reset state from a possible previous run
         GeneralUtility::purgeInstances();
 
-        // var $_composer_autoload_path is global and set by composer
-        $autoloadFile = require $_composer_autoload_path ?? $this->getPackagesPath() . '/autoload.php';
+        $autoloadFile = require ComposerPackageInfo::getAutoload();
         SystemEnvironmentBuilder::run(1, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);
         $container = Bootstrap::init($autoloadFile);
         // Make sure output is not buffered, so command-line output can take place and

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -198,8 +198,7 @@ class Testbase
                     );
                 }
             }
-        }
-        else {
+        } else {
             chdir($instancePath);
             $this->createDirectory($instancePath . '/typo3');
             $this->createDirectory($instancePath . '/typo3/sysext');
@@ -562,8 +561,7 @@ class Testbase
         $legacyFilePath = ORIGINAL_ROOT . 'typo3/sysext/core/Configuration/FactoryConfiguration.php';
         if (is_file($legacyFilePath)) {
             $filePath = $legacyFilePath;
-        }
-        else {
+        } else {
             $filePath = ComposerPackageInfo::resolveExtensionPath('EXT:core') . '/Configuration/FactoryConfiguration.php';
         }
         $finalConfigurationArray = require $filePath;


### PR DESCRIPTION
Introduce Composer/ComposerPackageInfo to provide package info and selection based on composer and related to TYPO3. Furthermore extensions can be linked with prefix `EXT` and the path is resolved.

adjust Testbase for TYPO3 v12 and the new class ComposerPackageInfo

This PR is partially in competition to #435 (and perhaps other PRs), but I see it as exchange of code to find the best way. So some of my ideas could be taken for #435 or some other kind of merge could be considered.

### Changes proposed in this pull request

- resolve paths fore independent on file structure
- filter composer packages for TYPO3 system or 'local' extensions
- allow incoming configuration to use the prefix `EXT:` for extensions
- change how symlinks to core extensions are created:
    before the whole sysext folder was linked as one symlink, now the sysext folder is created and each extension symlinked individually.

### Steps to test the solution

- install https://github.com/DavidBruchmann/t3docs-screenshots/ when it's updated
- execute the basic test like described in the README (without need to load external documentation).

### Results

All suite installations are working properly.
Main installation and acceptance tests never work yet, due to other reasons).

