### PR TITLE
[BUGFIX][v7] Explicitly require symfony/filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "guzzlehttp/psr7": "^2.4.3",
     "phpunit/phpunit": "^9.5.25 || ^10.1",
     "psr/container": "^1.1.0 || ^2.0.0",
+    "symfony/filesystem": "^5.4 || ^6.0",
     "typo3/cms-backend": "11.*.*@dev || 12.*.*@dev",
     "typo3/cms-core": "11.*.*@dev || 12.*.*@dev",
     "typo3/cms-extbase": "11.*.*@dev || 12.*.*@dev",


### PR DESCRIPTION
With c34df68, usage of the Symfony Filesystem's `Path` class was introduced. As this class is available since symfony/filesystem 5.4.0 only (see https://github.com/symfony/filesystem/commit/d5ca5f7080a759dcb65300a55d5ee42f1ee7ef59), it is essential to explicitly define this dependency with an appropriate version constraint. Otherwise, extensions running tests with TF and lowest dependencies may fail with TYPO3 < 11.5.5 because prior to this version, symfony/filesystem ^5.3 was required and therefore v5.3.x of the library may be installed (see https://github.com/TYPO3/typo3/commit/445f60667dc4db2da0d42c8b2faab8c67d5bd396).

See https://github.com/CPS-IT/handlebars/actions/runs/4802256934/jobs/8545498227 for an example of a failed test run.