### PR TITLE
[BUGFIX] Reactivate framework extensions in functional tests

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -334,6 +334,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             }
             $testbase->setUpInstanceCoreLinks($this->instancePath, $defaultCoreExtensionsToLoad, $this->coreExtensionsToLoad);
             $testbase->linkTestExtensionsToInstance($this->instancePath, $this->testExtensionsToLoad);
+            $testbase->linkFrameworkExtensionsToInstance($this->instancePath, $this->frameworkExtensionsToLoad);
             $testbase->linkPathsInTestInstance($this->instancePath, $this->pathsToLinkInTestInstance);
             $testbase->providePathsInTestInstance($this->instancePath, $this->pathsToProvideInTestInstance);
             $localConfiguration['DB'] = $testbase->getOriginalDatabaseSettingsFromEnvironmentOrLocalConfiguration();


### PR DESCRIPTION
With c34df68, symlinks of framework extensions such as `json_response` were removed (see https://github.com/TYPO3/testing-framework/commit/c34df68427475543e9a73d337824241a40b382cd#diff-8cfe230a7b65db0044a7b32148784e47da3e6521474a51d16ceaba06636b1363L326). Without the symlinks, all fixture extensions provided by TF are no longer available in the test application, making it impossible to perform e.g. internal requests.

This PR reactivates symlinks of configured framework extensions, restoring the original behavior and re-enabling usage of internal requests in functional tests.

Related: #435
Releases: 7