### PR TITLE
[TASK] Backport of #467 ( cms-composer-installers enhancement)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 public/
 Build/testing-docker/.env
+var/

--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -20,3 +20,5 @@ parameters:
     - ../../Classes/Core/Acceptance/*
     # phpstan does not work well with multi core testing and existing/non existing classes and traits, exclude it
     - ../../Classes/Core/Jwt/SessionHelperTwelve.php
+    # Text fixtures extensions uses $_EXTKEY phpstan would be report as "might not defined"
+    - ../../Tests/Unit/*/Fixtures/Extensions/*/ext_emconf.php

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -117,11 +117,11 @@ services:
         php -v | grep '^PHP';
         if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
           XDEBUG_MODE=\"off\" \
-          .Build/bin/phpunit Tests/Unit/;
+          .Build/bin/phpunit -c Resources/Core/Build/UnitTests.xml Tests/Unit/;
         else
           XDEBUG_MODE=\"debug,develop\" \
           XDEBUG_TRIGGER=\"foo\" \
           XDEBUG_CONFIG=\"client_host=host.docker.internal\" \
-          .Build/bin/phpunit Tests/Unit/;
+          .Build/bin/phpunit -c Resources/Core/Build/UnitTests.xml Tests/Unit/;
         fi
       "

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -18,13 +18,31 @@ namespace TYPO3\TestingFramework\Composer;
  */
 
 use Composer\InstalledVersions;
-use Symfony\Component\Filesystem\Path;
 
 /**
  * @internal This class is for testing-framework internal processing and not part of public testing API.
  */
 final class ComposerPackageManager
 {
+    /**
+     * The number of buffer entries that triggers a cleanup operation.
+     */
+    private const CLEANUP_THRESHOLD = 1250;
+
+    /**
+     * The buffer size after the cleanup operation.
+     */
+    private const CLEANUP_SIZE = 1000;
+
+    /**
+     * Buffers input/output of {@link canonicalize()}.
+     *
+     * @var array<string, string>
+     */
+    private static $buffer = [];
+
+    private static $bufferSize = 0;
+
     private static string $vendorPath = '';
 
     private static ?PackageInfo $rootPackage = null;
@@ -241,9 +259,9 @@ final class ComposerPackageManager
      * This method resolves relative path tokens directly ( e.g. '/../' ) and sanitizes the path from back-slash to
      * slash for a cross os compatibility.
      */
-    private function sanitizePath(string $path): string
+    public function sanitizePath(string $path): string
     {
-        return Path::canonicalize(rtrim(strtr($path, '\\', '/'), '/'));
+        return $this->canonicalize(rtrim(strtr($path, '\\', '/'), '/'));
     }
 
     /**
@@ -253,5 +271,108 @@ final class ComposerPackageManager
     {
         $path = $this->sanitizePath($path);
         return realpath($path) ?: $path;
+    }
+
+    private function canonicalize(string $path): string
+    {
+        if ($path === '') {
+            return '';
+        }
+
+        // This method is called by many other methods in this class. Buffer
+        // the canonicalized paths to make up for the severe performance
+        // decrease.
+        if (isset(self::$buffer[$path])) {
+            return self::$buffer[$path];
+        }
+
+        $path = str_replace('\\', '/', $path);
+
+        [$root, $pathWithoutRoot] = $this->split($path);
+
+        $canonicalParts = $this->findCanonicalParts($root, $pathWithoutRoot);
+
+        // Add the root directory again
+        self::$buffer[$path] = $canonicalPath = $root . implode('/', $canonicalParts);
+        ++self::$bufferSize;
+
+        // Clean up regularly to prevent memory leaks
+        if (self::$bufferSize > self::CLEANUP_THRESHOLD) {
+            self::$buffer = \array_slice(self::$buffer, -self::CLEANUP_SIZE, null, true);
+            self::$bufferSize = self::CLEANUP_SIZE;
+        }
+
+        return $canonicalPath;
+    }
+
+    private function split(string $path): array
+    {
+        if ($path === '') {
+            return ['', ''];
+        }
+
+        // Remember scheme as part of the root, if any
+        $schemeSeparatorPosition = strpos($path, '://');
+        if ($schemeSeparatorPosition !== false) {
+            $root = substr($path, 0, $schemeSeparatorPosition + 3);
+            $path = substr($path, $schemeSeparatorPosition + 3);
+        } else {
+            $root = '';
+        }
+
+        $length = \strlen($path);
+
+        // Remove and remember root directory
+        if (str_starts_with($path, '/')) {
+            $root .= '/';
+            $path = $length > 1 ? substr($path, 1) : '';
+        } elseif ($length > 1 && ctype_alpha($path[0]) && ':' === $path[1]) {
+            if ($length === 2) {
+                // Windows special case: "C:"
+                $root .= $path . '/';
+                $path = '';
+            } elseif ($path[2] === '/') {
+                // Windows normal case: "C:/"..
+                $root .= substr($path, 0, 3);
+                $path = $length > 3 ? substr($path, 3) : '';
+            }
+        }
+
+        return [$root, $path];
+    }
+
+    private function findCanonicalParts(string $root, string $pathWithoutRoot): array
+    {
+        $parts = explode('/', $pathWithoutRoot);
+
+        $canonicalParts = [];
+
+        // Collapse "." and "..", if possible
+        foreach ($parts as $part) {
+            if ($part === '.'
+                || $part === ''
+            ) {
+                continue;
+            }
+
+            // Collapse ".." with the previous part, if one exists
+            // Don't collapse ".." if the previous part is also ".."
+            if ($part === '..'
+                && \count($canonicalParts) > 0
+                && $canonicalParts[\count($canonicalParts) - 1] !== '..'
+            ) {
+                array_pop($canonicalParts);
+                continue;
+            }
+
+            // Only add ".." prefixes for relative paths
+            if ($part !== '..'
+                || $root === ''
+            ) {
+                $canonicalParts[] = $part;
+            }
+        }
+
+        return $canonicalParts;
     }
 }

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -273,7 +273,7 @@ final class ComposerPackageManager
 
     private function resolvePackageName(string $name): string
     {
-        return self::$extensionKeyToPackageNameMap[basename($name)] ?? $name;
+        return self::$extensionKeyToPackageNameMap[$this->normalizeExtensionKey(basename($name))] ?? $name;
     }
 
     /**
@@ -419,7 +419,27 @@ final class ComposerPackageManager
             return '';
         }
         $baseName = basename($packagePath);
+        if (($info['type'] ?? '') === 'typo3-csm-framework'
+            && str_starts_with($baseName, 'cms-')
+        ) {
+            // remove `cms-` prefix
+            $baseName = substr($baseName, 4);
+        }
+        $baseName = $this->normalizeExtensionKey($baseName);
+
         return $info['extra']['typo3/cms']['extension-key'] ?? $baseName;
+    }
+
+    private function normalizeExtensionKey(string $extensionKey): string
+    {
+        $replaces = [
+            '-' => '_',
+        ];
+        return str_replace(
+            array_keys($replaces),
+            array_values($replaces),
+            $extensionKey
+        );
     }
 
     private function prettifyVersion(string $version): string

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -273,12 +273,7 @@ final class ComposerPackageManager
 
     private function resolvePackageName(string $name): string
     {
-        if (str_starts_with($name, 'typo3conf/ext/')
-            || str_starts_with($name, 'typo3/sysext/')
-        ) {
-            $name = basename($name);
-        }
-        return self::$extensionKeyToPackageNameMap[$name] ?? $name;
+        return self::$extensionKeyToPackageNameMap[basename($name)] ?? $name;
     }
 
     /**

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -118,8 +118,10 @@ final class ComposerPackageManager
         $packageName = $package['name'];
         $packagePath = $this->getPackageInstallPath($packageName);
         $packageRealPath = $this->realPath($packagePath);
-        $info = $this->getPackageComposerJson($packagePath) ?? [];
+        $info = $this->getPackageComposerJson($packagePath);
         $packageType = $info['type'] ?? '';
+        $extEmConf = $this->getExtEmConf($packagePath);
+        $extensionKey = $this->determineExtensionKey($packagePath, $info, $extEmConf);
 
         $packageInfo = new PackageInfo(
             $packageName,
@@ -127,7 +129,9 @@ final class ComposerPackageManager
             $packagePath,
             $packageRealPath,
             $package['pretty_version'],
-            $info
+            $extensionKey,
+            $info,
+            $extEmConf
         );
         self::$rootPackage = $packageInfo;
         $this->addPackageInfo($packageInfo);
@@ -159,6 +163,8 @@ final class ComposerPackageManager
             $info = $this->getPackageComposerJson($packageRealPath);
             $packageName = $info['name'] ?? '';
             $packageType = $info['type'] ?? '';
+            $extEmConf = $this->getExtEmConf($packageRealPath);
+            $extensionKey = $this->determineExtensionKey($packageRealPath, $info, $extEmConf);
             $packageInfo = new PackageInfo(
                 $packageName,
                 $packageType,
@@ -166,7 +172,9 @@ final class ComposerPackageManager
                 $packageRealPath,
                 // System extensions in mono-repository are exactly the same version as the root package. Use it.
                 $this->rootPackage()->getVersion(),
-                $info
+                $extensionKey,
+                $info,
+                $extEmConf,
             );
             if (!$packageInfo->isSystemExtension()) {
                 continue;
@@ -184,15 +192,19 @@ final class ComposerPackageManager
             foreach ($loader['versions'] as $packageName => $version) {
                 $packagePath = $this->getPackageInstallPath($packageName);
                 $packageRealPath = $this->realPath($packagePath);
-                $info = $this->getPackageComposerJson($packagePath) ?? [];
+                $info = $this->getPackageComposerJson($packagePath);
+                $extEmConf = $this->getExtEmConf($packagePath);
                 $packageType = $info['type'] ?? '';
+                $extensionKey = $this->determineExtensionKey($packagePath, $info, $extEmConf);
                 $this->addPackageInfo(new PackageInfo(
                     $packageName,
                     $packageType,
                     $packagePath,
                     $packageRealPath,
-                    (string)($version['pretty_version'] ?? ''),
-                    $info
+                    (string)($version['pretty_version'] ?? $this->prettifyVersion($extEmConf['version'] ?? '')),
+                    $extensionKey,
+                    $info,
+                    $extEmConf
                 ));
             }
         }
@@ -222,6 +234,9 @@ final class ComposerPackageManager
 
     private function getPackageComposerJson(string $path): ?array
     {
+        if ($path === '') {
+            return null;
+        }
         $composerFile = rtrim($path, '/') . '/composer.json';
         if (!file_exists($composerFile) || !is_readable($composerFile)) {
             return null;
@@ -231,6 +246,28 @@ final class ComposerPackageManager
         } catch(\Throwable $t) {
             // skipped
         }
+        return null;
+    }
+
+    private function getExtEmConf(string $path): ?array
+    {
+        if ($path === '') {
+            return null;
+        }
+        $extEmConfFile = rtrim($path, '/') . 'ext_emconf.php';
+        if (!file_exists($extEmConfFile) || !is_readable($extEmConfFile)) {
+            return null;
+        }
+
+        try {
+            /** @var array<non-empty-string, array> $EM_CONF */
+            $EM_CONF = [];
+            $_EXTKEY = '__EXTKEY__';
+            @include $extEmConfFile;
+            return $EM_CONF[$_EXTKEY] ?? null;
+        } catch (\Throwable $t) {
+        }
+
         return null;
     }
 
@@ -374,5 +411,35 @@ final class ComposerPackageManager
         }
 
         return $canonicalParts;
+    }
+
+    private function determineExtensionKey(
+        string $packagePath,
+        ?array $info = null,
+        ?array $extEmConf = null
+    ): string {
+        $isExtension = in_array($info['type'] ?? '', ['typo3-cms-framework', 'typo3-cms-extension'], true)
+            || ($extEmConf !== null);
+        if (!$isExtension) {
+            return '';
+        }
+        $baseName = basename($packagePath);
+        return $info['extra']['typo3/cms']['extension-key'] ?? $baseName;
+    }
+
+    private function prettifyVersion(string $version): string
+    {
+        if ($version === '') {
+            return '';
+        }
+        $parts =  array_pad(explode('.', $version), 3, '0');
+        return implode(
+            '.',
+            [
+                $parts[0] ?? '0',
+                $parts[1] ?? '0',
+                $parts[2] ?? '0',
+            ],
+        );
     }
 }

--- a/Classes/Composer/PackageInfo.php
+++ b/Classes/Composer/PackageInfo.php
@@ -120,4 +120,18 @@ final class PackageInfo
     {
         return (string)($this->info['extra']['typo3/cms']['web-dir'] ?? '');
     }
+
+    /**
+     * @return string[]
+     */
+    public function getReplacesPackageNames(): array
+    {
+        $keys = array_keys($this->info['replace'] ?? []);
+        if ($this->isMonoRepository()) {
+            // Monorepo root composer.json replaces core system extension. We do not want that happen, so
+            // ignore only replaced core extensions.
+            $keys = array_filter($keys, static fn ($value) => !str_starts_with($value, 'typo3/cms-'));
+        }
+        return $keys;
+    }
 }

--- a/Classes/Composer/PackageInfo.php
+++ b/Classes/Composer/PackageInfo.php
@@ -27,7 +27,9 @@ final class PackageInfo
     private string $path;
     private string $realPath;
     private string $version;
-    private array $info;
+    private string $extensionKey;
+    private ?array $info = null;
+    private ?array $extEmConf = null;
 
     public function __construct(
         string $name,
@@ -35,14 +37,18 @@ final class PackageInfo
         string $path,
         string $realPath,
         string $version,
-        array $info
+        string $extensionKey,
+        ?array $info = null,
+        ?array $extEmConf = null
     ) {
         $this->name = $name;
         $this->type = $type;
         $this->path = $path;
         $this->realPath = $realPath;
         $this->version = $version;
+        $this->extensionKey = $extensionKey;
         $this->info = $info;
+        $this->extEmConf = $extEmConf;
     }
 
     public function getName(): string
@@ -70,6 +76,16 @@ final class PackageInfo
         return $this->version;
     }
 
+    public function getInfo(): ?array
+    {
+        return $this->info;
+    }
+
+    public function getExtEmConf(): ?array
+    {
+        return $this->extEmConf;
+    }
+
     public function isSystemExtension(): bool
     {
         return $this->type === 'typo3-cms-framework';
@@ -85,9 +101,14 @@ final class PackageInfo
         return $this->type === 'typo3-cms-core';
     }
 
+    public function isComposerPackage(): bool
+    {
+        return $this->info !== null;
+    }
+
     public function getExtensionKey(): string
     {
-        return (string)($this->info['extra']['typo3/cms']['extension-key'] ?? '');
+        return $this->extensionKey;
     }
 
     public function getVendorDir(): string

--- a/Classes/Composer/PackageInfo.php
+++ b/Classes/Composer/PackageInfo.php
@@ -115,4 +115,9 @@ final class PackageInfo
     {
         return (string)($this->info['config']['vendor-dir'] ?? '');
     }
+
+    public function getWebDir(): string
+    {
+        return (string)($this->info['extra']['typo3/cms']['web-dir'] ?? '');
+    }
 }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -210,7 +210,7 @@ class Testbase
             $coreExtensions = $this->composerPackageManager->getSystemExtensionExtensionKeys();
         }
         foreach ($coreExtensions as $coreExtension) {
-            $packageInfo = $this->composerPackageManager->getPackageInfo($coreExtension);
+            $packageInfo = $this->composerPackageManager->getPackageInfoWithFallback($coreExtension);
             if ($packageInfo === null || !$packageInfo->isSystemExtension()) {
                 continue;
             }
@@ -274,7 +274,7 @@ class Testbase
     public function linkTestExtensionsToInstance(string $instancePath, array $extensionPaths): void
     {
         foreach ($extensionPaths as $extensionPath) {
-            $packageInfo = $this->composerPackageManager->getPackageInfo($extensionPath);
+            $packageInfo = $this->composerPackageManager->getPackageInfoWithFallback($extensionPath);
             if ($packageInfo instanceof PackageInfo) {
                 $installPath = $packageInfo->getRealPath() . '/';
                 $destinationPath = $instancePath . '/typo3conf/ext/' . $packageInfo->getExtensionKey();

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -18,6 +18,7 @@ namespace TYPO3\TestingFramework\Tests\Unit\Composer;
  */
 
 use TYPO3\TestingFramework\Composer\ComposerPackageManager;
+use TYPO3\TestingFramework\Composer\PackageInfo;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class ComposerPackageManagerTest extends UnitTestCase
@@ -141,5 +142,47 @@ final class ComposerPackageManagerTest extends UnitTestCase
     {
         $subject = new ComposerPackageManager();
         self::assertSame($expectedPath, $subject->sanitizePath($path));
+    }
+
+    /**
+     * @test
+     */
+    public function coreExtensionCanBeResolvedByExtensionKey(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfo('core');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('typo3/cms-core', $packageInfo->getName());
+        self::assertSame('core', $packageInfo->getExtensionKey());
+        self::assertTrue($packageInfo->isSystemExtension());
+    }
+
+    /**
+     * @test
+     */
+    public function coreExtensionCanBeResolvedByPackageName(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfo('typo3/cms-core');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('typo3/cms-core', $packageInfo->getName());
+        self::assertSame('core', $packageInfo->getExtensionKey());
+        self::assertTrue($packageInfo->isSystemExtension());
+    }
+
+    /**
+     * @test
+     */
+    public function coreExtensionCanBeResolvedWithRelativeLegacyPathPrefix(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfo('typo3/sysext/core');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('typo3/cms-core', $packageInfo->getName());
+        self::assertSame('core', $packageInfo->getExtensionKey());
+        self::assertTrue($packageInfo->isSystemExtension());
     }
 }

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Tests\Unit\Composer;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\TestingFramework\Composer\ComposerPackageManager;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ComposerPackageManagerTest extends UnitTestCase
+{
+    public static function sanitizePathReturnsExpectedValueDataProvider(): \Generator
+    {
+        // relative paths (forward slash)
+        yield ['css/./style.css', 'css/style.css'];
+        yield ['css/../style.css', 'style.css'];
+        yield ['css/./../style.css', 'style.css'];
+        yield ['css/.././style.css', 'style.css'];
+        yield ['css/../../style.css', '../style.css'];
+        yield ['./css/style.css', 'css/style.css'];
+        yield ['../css/style.css', '../css/style.css'];
+        yield ['./../css/style.css', '../css/style.css'];
+        yield ['.././css/style.css', '../css/style.css'];
+        yield ['../../css/style.css', '../../css/style.css'];
+        yield ['', ''];
+        yield ['.', ''];
+        yield ['..', '..'];
+        yield ['./..', '..'];
+        yield ['../.', '..'];
+        yield ['../..', '../..'];
+
+        // relative paths (backslash)
+        yield ['css\\.\\style.css', 'css/style.css'];
+        yield ['css\\..\\style.css', 'style.css'];
+        yield ['css\\.\\..\\style.css', 'style.css'];
+        yield ['css\\..\\.\\style.css', 'style.css'];
+        yield ['css\\..\\..\\style.css', '../style.css'];
+        yield ['.\\css\\style.css', 'css/style.css'];
+        yield ['..\\css\\style.css', '../css/style.css'];
+        yield ['.\\..\\css\\style.css', '../css/style.css'];
+        yield ['..\\.\\css\\style.css', '../css/style.css'];
+        yield ['..\\..\\css\\style.css', '../../css/style.css'];
+
+        // absolute paths (forward slash, UNIX)
+        yield ['/css/style.css', '/css/style.css'];
+        yield ['/css/./style.css', '/css/style.css'];
+        yield ['/css/../style.css', '/style.css'];
+        yield ['/css/./../style.css', '/style.css'];
+        yield ['/css/.././style.css', '/style.css'];
+        yield ['/./css/style.css', '/css/style.css'];
+        yield ['/../css/style.css', '/css/style.css'];
+        yield ['/./../css/style.css', '/css/style.css'];
+        yield ['/.././css/style.css', '/css/style.css'];
+        yield ['/../../css/style.css', '/css/style.css'];
+
+        // absolute paths (backslash, UNIX)
+        yield ['\\css\\style.css', '/css/style.css'];
+        yield ['\\css\\.\\style.css', '/css/style.css'];
+        yield ['\\css\\..\\style.css', '/style.css'];
+        yield ['\\css\\.\\..\\style.css', '/style.css'];
+        yield ['\\css\\..\\.\\style.css', '/style.css'];
+        yield ['\\.\\css\\style.css', '/css/style.css'];
+        yield ['\\..\\css\\style.css', '/css/style.css'];
+        yield ['\\.\\..\\css\\style.css', '/css/style.css'];
+        yield ['\\..\\.\\css\\style.css', '/css/style.css'];
+        yield ['\\..\\..\\css\\style.css', '/css/style.css'];
+
+        // absolute paths (forward slash, Windows)
+        yield ['C:/css/style.css', 'C:/css/style.css'];
+        yield ['C:/css/./style.css', 'C:/css/style.css'];
+        yield ['C:/css/../style.css', 'C:/style.css'];
+        yield ['C:/css/./../style.css', 'C:/style.css'];
+        yield ['C:/css/.././style.css', 'C:/style.css'];
+        yield ['C:/./css/style.css', 'C:/css/style.css'];
+        yield ['C:/../css/style.css', 'C:/css/style.css'];
+        yield ['C:/./../css/style.css', 'C:/css/style.css'];
+        yield ['C:/.././css/style.css', 'C:/css/style.css'];
+        yield ['C:/../../css/style.css', 'C:/css/style.css'];
+
+        // absolute paths (backslash, Windows)
+        yield ['C:\\css\\style.css', 'C:/css/style.css'];
+        yield ['C:\\css\\.\\style.css', 'C:/css/style.css'];
+        yield ['C:\\css\\..\\style.css', 'C:/style.css'];
+        yield ['C:\\css\\.\\..\\style.css', 'C:/style.css'];
+        yield ['C:\\css\\..\\.\\style.css', 'C:/style.css'];
+        yield ['C:\\.\\css\\style.css', 'C:/css/style.css'];
+        yield ['C:\\..\\css\\style.css', 'C:/css/style.css'];
+        yield ['C:\\.\\..\\css\\style.css', 'C:/css/style.css'];
+        yield ['C:\\..\\.\\css\\style.css', 'C:/css/style.css'];
+        yield ['C:\\..\\..\\css\\style.css', 'C:/css/style.css'];
+
+        // Windows special case
+        yield ['C:', 'C:/'];
+
+        // Don't change malformed path
+        yield ['C:css/style.css', 'C:css/style.css'];
+
+        // absolute paths (stream, UNIX)
+        yield ['phar:///css/style.css', 'phar:///css/style.css'];
+        yield ['phar:///css/./style.css', 'phar:///css/style.css'];
+        yield ['phar:///css/../style.css', 'phar:///style.css'];
+        yield ['phar:///css/./../style.css', 'phar:///style.css'];
+        yield ['phar:///css/.././style.css', 'phar:///style.css'];
+        yield ['phar:///./css/style.css', 'phar:///css/style.css'];
+        yield ['phar:///../css/style.css', 'phar:///css/style.css'];
+        yield ['phar:///./../css/style.css', 'phar:///css/style.css'];
+        yield ['phar:///.././css/style.css', 'phar:///css/style.css'];
+        yield ['phar:///../../css/style.css', 'phar:///css/style.css'];
+
+        // absolute paths (stream, Windows)
+        yield ['phar://C:/css/style.css', 'phar://C:/css/style.css'];
+        yield ['phar://C:/css/./style.css', 'phar://C:/css/style.css'];
+        yield ['phar://C:/css/../style.css', 'phar://C:/style.css'];
+        yield ['phar://C:/css/./../style.css', 'phar://C:/style.css'];
+        yield ['phar://C:/css/.././style.css', 'phar://C:/style.css'];
+        yield ['phar://C:/./css/style.css', 'phar://C:/css/style.css'];
+        yield ['phar://C:/../css/style.css', 'phar://C:/css/style.css'];
+        yield ['phar://C:/./../css/style.css', 'phar://C:/css/style.css'];
+        yield ['phar://C:/.././css/style.css', 'phar://C:/css/style.css'];
+        yield ['phar://C:/../../css/style.css', 'phar://C:/css/style.css'];
+    }
+
+    /**
+     * @test
+     * @dataProvider sanitizePathReturnsExpectedValueDataProvider
+     */
+    public function sanitizePathReturnsExpectedValue(string $path, string $expectedPath): void
+    {
+        $subject = new ComposerPackageManager();
+        self::assertSame($expectedPath, $subject->sanitizePath($path));
+    }
+}

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -146,6 +146,24 @@ final class ComposerPackageManagerTest extends UnitTestCase
 
     /**
      * @test
+     * @internal Ensure the TF related special case is in place as baseline for followup tests.
+     */
+    public function testingFrameworkCanBeResolvedAsExtensionKey(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfo('testing_framework');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('typo3/testing-framework', $packageInfo->getName());
+        self::assertSame('', $packageInfo->getExtensionKey());
+        self::assertFalse($packageInfo->isExtension());
+        self::assertFalse($packageInfo->isSystemExtension());
+        self::assertNull($packageInfo->getExtEmConf());
+        self::assertNotNull($packageInfo->getInfo());
+    }
+
+    /**
+     * @test
      */
     public function coreExtensionCanBeResolvedByExtensionKey(): void
     {
@@ -184,5 +202,118 @@ final class ComposerPackageManagerTest extends UnitTestCase
         self::assertSame('typo3/cms-core', $packageInfo->getName());
         self::assertSame('core', $packageInfo->getExtensionKey());
         self::assertTrue($packageInfo->isSystemExtension());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithoutJsonCanBeResolvedByAbsolutePath(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Extensions/ext_without_composerjson_absolute');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('ext_without_composerjson_absolute', $packageInfo->getExtensionKey());
+        self::assertSame('unknown-vendor/ext-without-composerjson-absolute', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithoutJsonCanBeResolvedRelativeFromRoot(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfoWithFallback('Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_relativefromroot');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('ext_without_composerjson_relativefromroot', $packageInfo->getExtensionKey());
+        self::assertSame('unknown-vendor/ext-without-composerjson-relativefromroot', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithoutJsonCanBeResolvedByLegacyPath(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfoWithFallback('typo3conf/ext/testing_framework/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_fallbackroot');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('ext_without_composerjson_fallbackroot', $packageInfo->getExtensionKey());
+        self::assertSame('unknown-vendor/ext-without-composerjson-fallbackroot', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithJsonCanBeResolvedByAbsolutePath(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Extensions/ext_absolute');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('absolute_real', $packageInfo->getExtensionKey());
+        self::assertSame('testing-framework/extension-absolute', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNotNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithJsonCanBeResolvedRelativeFromRoot(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfoWithFallback('Tests/Unit/Composer/Fixtures/Extensions/ext_relativefromroot');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('relativefromroot_real', $packageInfo->getExtensionKey());
+        self::assertSame('testing-framework/extension-relativefromroot', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNotNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithJsonCanBeResolvedByLegacyPath(): void
+    {
+        $subject = new ComposerPackageManager();
+        $packageInfo = $subject->getPackageInfoWithFallback('typo3conf/ext/testing_framework/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('fallbackroot_real', $packageInfo->getExtensionKey());
+        self::assertSame('testing-framework/extension-fallbackroot', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNotNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
+    }
+
+    /**
+     * @test
+     */
+    public function extensionWithJsonCanBeResolvedByRelativeLegacyPath(): void
+    {
+        $subject = new ComposerPackageManager();
+        $projectFolderName = basename($subject->getRootPath());
+        $packageInfo = $subject->getPackageInfoWithFallback('../' . $projectFolderName . '/typo3conf/ext/testing_framework/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('fallbackroot_real', $packageInfo->getExtensionKey());
+        self::assertSame('testing-framework/extension-fallbackroot', $packageInfo->getName());
+        self::assertSame('typo3-cms-extension', $packageInfo->getType());
+        self::assertNotNull($packageInfo->getInfo());
+        self::assertNotNull($packageInfo->getExtEmConf());
     }
 }

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_absolute/composer.json
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_absolute/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "testing-framework/extension-absolute",
+    "description": "ext-absolute",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech"
+        }
+    ],
+    "require": {},
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "absolute_real"
+        }
+    }
+}

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_absolute/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_absolute/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension With ComposerJson',
+    'description' => 'Extension With ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot/composer.json
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "testing-framework/extension-fallbackroot",
+    "description": "ext-fallbackroot",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech"
+        }
+    ],
+    "require": {},
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "fallbackroot_real"
+        }
+    }
+}

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension With ComposerJson',
+    'description' => 'Extension With ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_relativefromroot/composer.json
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_relativefromroot/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "testing-framework/extension-relativefromroot",
+    "description": "ext-relativefromroot",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech"
+        }
+    ],
+    "require": {},
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "relativefromroot_real"
+        }
+    }
+}

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_relativefromroot/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_relativefromroot/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension With ComposerJson',
+    'description' => 'Extension With ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_relativelegacy/composer.json
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_relativelegacy/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "testing-framework/extension-relativelegacy",
+    "description": "ext-relativelegacy",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech"
+        }
+    ],
+    "require": {},
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "relativelegacy_real"
+        }
+    }
+}

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_relativelegacy/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_relativelegacy/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension With ComposerJson',
+    'description' => 'Extension With ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_absolute/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_absolute/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension Without ComposerJson',
+    'description' => 'Extension Without ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_fallbackroot/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_fallbackroot/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension Without ComposerJson',
+    'description' => 'Extension Without ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_relativefromroot/ext_emconf.php
+++ b/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_relativefromroot/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Extension Without ComposerJson',
+    'description' => 'Extension Without ComposerJson',
+    'category' => 'example',
+    'version' => '1.0.0',
+    'state' => 'beta',
+    'author' => 'Stefan Bürk',
+    'author_email' => 'stefan@buerk.tech',
+    'author_company' => '',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.0.0-99.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];


### PR DESCRIPTION
> BACKPORT of #467

Several issues and headaches have been reported. For example:

* TYPO3 v11 composer minor with <11.5 failed due not existing PathComponent in `symfony/filesystem` in that low version
* Test extension (root) using `typo3conf/ext/extension_key` did not worked
* Test fixture extension loading did not worked, e.g. `typo3conf/ext/extension_key/Some/Paths/test_extension`
* Test extensions without a `composer.json` no longer could loaded (TF7 for v11 and composer installers 3)
* Test extensions with some relative folder names did not resolved properly

Therefore, several patches have been implemented in chain to tackle these issues and improve the overall handling and compat high, minimizing the need for "test case" adoptions.

See each commit message for more detailed information on it.

- [TASK] Avoid direct "symfony/filesystem" dependency (alternative for #463)
- [TASK] Include `ext_emconf.php` data in `PackageInfo`
- [TASK] Add some basic `ComposerPackageManager` tests
- [TASK] Simplify `resolvePackageName` for `ComposerPackageManager`
- [TASK] Normalize guessed extension key from path/packages.
- [BUGFIX] Ensure test fixture extension can be found
- [TASK] Handle replaced packages properly
- [TASK] Use phpunit configuration template for own testing


That mean, that now it's possible to load core and extensions, which are required by the root composer.json by simply using the `extension-key` or the `package name`. PackageName should be emphasised for future proof settings.

Regarding old path syntax `typo3conf/ext/extension-key` it removes the `typo3conf/ext/` and tries to find it through composer.json information. This means, that direct extensions must be required through composer.json. This counts for 3rd party extensions needed for tests, the same way (local path, packagist, ...).

Regarding test fixture extensions, these can now be required wir absolute/resolvable as absolute and also with old legacy path syntax as sub from the root extension:

> Extensions without a composer.json at least need a `ext_emconf.php` then, otherwise they are not symlinked into `typo3conf/ext/` of the test instance

```php
protected array $testExtensionsToLoad = [
  // 3rd party extension required/required-dev in root composer.json
  'my-vendor/package-one',
  
  // 'my-vendor/package-two' required/required-dev in root composer.json
  'extension_two',
  'typo3conf/ext/extension_two', 

  // extension level testing, root extension
  'typo3conf/ext/root_extension',
  
  // extension testing, test fixture extensions
  __DIR__ . '/Fixtures/Extensions/test_extension',    // with or without composer.json
  __DIR__ . '/../Fixtures/Extensions/test_extension', // with or without composer.json
  '../../Tests/Fixtures/Extensions/test_extension',   // with or without composer.json
                                                      // to be relative from '.Build/Web/'
  // subpath from root extension as legacy path
  'typo3conf/ext/root_extension/Tests/Functional/Extensions/test_extension',
  'typo3conf/../typo3conf/ext/root_extension/Tests/Functional/Extensions/test_extension',
];
```

For core extension, extension key, package name or `typo3/sysext/extension_key` can be used:

```php
protected array $coreExtensionsToLoad = [
  'typo3/sysext/core',
  '../Web/typo3/sysext/core',
  'typo3/cms-core',
  'core',
];
```

Requiring "test-fixture" extensions in the root composer.json should not be needed, but would not hurt. That means, that test fixture extensions needs a `composer.json`, which is good to add anyway. In the future composer install based test instances may be build, and then it would be a hard requirement anyway.