### PR TITLE
[TASK] Ensure root package extension is symlinked

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: ../../Classes/Composer/ExtensionTestEnvironment.php
 
 		-
-			message: "#^Call to method getIO\\(\\) on an unknown class Composer\\\\Script\\\\Event\\.$#"
-			count: 1
-			path: ../../Classes/Composer/ExtensionTestEnvironment.php
-
-		-
 			message: "#^Call to method isSymlinkedDirectory\\(\\) on an unknown class Composer\\\\Util\\\\Filesystem\\.$#"
 			count: 1
 			path: ../../Classes/Composer/ExtensionTestEnvironment.php

--- a/Classes/Composer/ExtensionTestEnvironment.php
+++ b/Classes/Composer/ExtensionTestEnvironment.php
@@ -19,7 +19,6 @@ namespace TYPO3\TestingFramework\Composer;
 use Composer\Script\Event;
 use Composer\Util\Filesystem;
 use TYPO3\CMS\Composer\Plugin\Config;
-use TYPO3\CMS\Core\Composer\PackageArtifactBuilder;
 
 /**
  * If a TYPO3 extension should be tested, the extension needs to be embedded in
@@ -54,11 +53,6 @@ final class ExtensionTestEnvironment
      */
     public static function prepare(Event $event): void
     {
-        if (class_exists(PackageArtifactBuilder::class)) {
-            // TYPO3 11.5 already takes care of creating the symlink if strictly required
-            $event->getIO()->warning('ExtensionTestEnvironment is not required any more for TYPO3 11.5 LTS');
-            return;
-        }
         $composer = $event->getComposer();
         $rootPackage = $composer->getPackage();
         if ($rootPackage->getType() !== 'typo3-cms-extension') {


### PR DESCRIPTION
With https://github.com/TYPO3/testing-framework/pull/307 symlinking of the root package extensions is no
longer handled by the testing-framework composer script for
TYPO3 v11 based testing environments. This has been shifted
to the core.

TYPO3 v11 core implemention do no longer symlink root package
extensions to the extension folder, if no `Resources/Public/`
resources exists in the extension.

This change reverts the no-op check and let the root package
extension be symlinked again, in all circumstances.

This avoids this edge case.

**Note** TYPO3 v11 testing using `typor/cms-composer-installers`
version 4RC1 is still not supported. Switch to TF7+ for support.

Used command(s):

```shell
Build/Scripts/runTests.sh -s phpstanGenerateBaseline
```

Releases: 6
Related: https://github.com/TYPO3/testing-framework/commit/506837852eebbfe88c551058a5390323792f66f6
