### PR TITLE
[BACKPORT][TASK] Configure frontend caches with NullBackend (#321)

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -24,7 +24,6 @@ use PHPUnit\Util\PHP\AbstractPhpProcess;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Core\Bootstrap;
@@ -367,8 +366,15 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
 
             $localConfiguration['SYS']['trustedHostsPattern'] = '.*';
             $localConfiguration['SYS']['encryptionKey'] = 'i-am-not-a-secure-encryption-key';
-            $localConfiguration['SYS']['caching']['cacheConfigurations']['extbase_object']['backend'] = NullBackend::class;
             $localConfiguration['GFX']['processor'] = 'GraphicsMagick';
+            // Set cache backends to null backend instead of database backend let us save time for creating
+            // database schema for it and reduces selects/inserts to the database for cache operations, which
+            // are generally not really needed for functional tests. Specific tests may restore this in if needed.
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['hash']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['imagesizes']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['pages']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['pagesection']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
+            $localConfiguration['SYS']['caching']['cacheConfigurations']['rootline']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\NullBackend';
             $testbase->setUpLocalConfiguration($this->instancePath, $localConfiguration, $this->configurationToUseInTestInstance);
             $defaultCoreExtensionsToLoad = [
                 'core',


### PR DESCRIPTION
The patch configures frontend related caches to ese the
NullBackend in functional tests. This avoids creating corresponding
tables and reduces SELECT and INSERT database statements.
This results in a performance increase running frontend functional
tests, with core, this is around 5-10% when using postgres DMBS.

Late backport of e45ee97112096c5a902093cc9e2a4c07af1cb49e
