### PR TITLE
[BUGFIX] Harden XPath query to limit search for page tree node

### DIFF
--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -52,7 +52,7 @@ abstract class AbstractPageTree
         foreach ($path as $pageName) {
             $context = $this->ensureTreeNodeIsOpen($pageName, $context);
         }
-        $context->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(self::$treeItemAnchorSelector))->click();
+        $context->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(static::$treeItemAnchorSelector))->click();
     }
 
     /**
@@ -65,7 +65,7 @@ abstract class AbstractPageTree
         $I = $this->tester;
         $I->switchToIFrame();
         return $I->executeInSelenium(function (\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
-            return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(self::$pageTreeSelector));
+            return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(static::$pageTreeSelector));
         });
     }
 
@@ -79,7 +79,7 @@ abstract class AbstractPageTree
     protected function ensureTreeNodeIsOpen(string $nodeText, RemoteWebElement $context)
     {
         $I = $this->tester;
-        $I->see($nodeText, self::$treeItemSelector);
+        $I->see($nodeText, static::$treeItemSelector);
 
         /** @var RemoteWebElement $context */
         $context = $I->executeInSelenium(function () use (

--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -86,7 +86,7 @@ abstract class AbstractPageTree
             $nodeText,
             $context
         ) {
-            return $context->findElement(\Facebook\WebDriver\WebDriverBy::xpath('//*[text()=\'' . $nodeText . '\']/..'));
+            return $context->findElement(\Facebook\WebDriver\WebDriverBy::xpath('.//following-sibling::*//*[text()=\'' . $nodeText . '\']/..'));
         });
 
         try {


### PR DESCRIPTION
Even if page tree nodes are queried from a given context node, the currently used XPath query searches for **all elements in the document instead**. That's because of the `//` syntax, which searches in the whole document, regardless of which context is given. This may lead to possible test failures in case the queried node text appears **multiple times in the document**, for example when trying to access the root page tree node whose text appears twice on the page – next to the TYPO3 logo in the topbar and as root node in the page tree. With the current implementation, the XPath query would match the text in the topbar instead of the text of the root node.

In order to avoid such behaviors and actually limit the XPath query to the given context, it is now prefixed with a dot (`.`). In addition, only following siblings of the current node are included since page tree nodes are presented as flat node structure. This way, the current context is now actually taken into account.

As an additional fix, property accesses of static properties in `AbstractPageTree` is now changed from `self::` to `static::` to properly respect overridden properties in extended classes. This is especially necessary for the overridden properties in TYPO3 core's [`FileTree`](https://github.com/TYPO3/typo3/blob/v12.4.3/typo3/sysext/core/Tests/Acceptance/Support/Helper/FileTree.php#L26-L29).

Patch in TYPO3 core: https://review.typo3.org/c/Packages/TYPO3.CMS/+/80039

:bulb: If this PR will be merged, I'll update the TYPO3 core patch accordingly.