### PR TITLE
[TASK] Detect duplicate table records within `importCSVDataSet()`

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -32,9 +32,9 @@ class DataSet
      * @param bool $applyDefaultValues
      * @return DataSet
      */
-    public static function read(string $fileName, bool $applyDefaultValues = false): DataSet
+    public static function read(string $fileName, bool $applyDefaultValues = false, bool $checkForDuplicates = false): DataSet
     {
-        $data = self::parseData(self::readData($fileName));
+        $data = self::parseData(self::readData($fileName), $fileName, $checkForDuplicates);
 
         if ($applyDefaultValues) {
             $data = self::applyDefaultValues($data);
@@ -79,7 +79,7 @@ class DataSet
      * @param array $rawData
      * @return array
      */
-    protected static function parseData(array $rawData): array
+    protected static function parseData(array $rawData, string $fileName, bool $checkForDuplicates): array
     {
         $data = [];
         $tableName = null;
@@ -137,8 +137,30 @@ class DataSet
                     unset($value);
                     $element = array_combine($data[$tableName]['fields'], $values);
                     if ($idIndex !== null) {
+                        if ($checkForDuplicates && is_array($data[$tableName]['elements'][$values[$idIndex]] ?? false)) {
+                            throw new \RuntimeException(
+                                sprintf(
+                                    'DataSet "%s" containes a duplicate record for idField "%s.uid" => %s',
+                                    $fileName,
+                                    $tableName,
+                                    $values[$idIndex]
+                                ),
+                                1690538506
+                            );
+                        }
                         $data[$tableName]['elements'][$values[$idIndex]] = $element;
                     } elseif ($hashIndex !== null) {
+                        if ($checkForDuplicates && is_array($data[$tableName]['elements'][$values[$hashIndex]] ?? false)) {
+                            throw new \RuntimeException(
+                                sprintf(
+                                    'DataSet "%s" containes a duplicate record for idHash "%s.hash" => %s',
+                                    $fileName,
+                                    $tableName,
+                                    $values[$hashIndex]
+                                ),
+                                1690541069
+                            );
+                        }
                         $data[$tableName]['elements'][$values[$hashIndex]] = $element;
                     } else {
                         $data[$tableName]['elements'][] = $element;

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -678,7 +678,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      */
     public function importCSVDataSet(string $path): void
     {
-        $dataSet = DataSet::read($path, true);
+        $dataSet = DataSet::read($path, true, true);
 
         foreach ($dataSet->getTableNames() as $tableName) {
             $connection = $this->getConnectionPool()->getConnectionForTable($tableName);


### PR DESCRIPTION
The testing-frameworks provides the ability to read csv fixture
files to import database datasets. The internal `DataSet::import()`
implementation is provided by `FunctionalTestCase->importCSVDataSet()`.

Sometimes duplicate rows with the same identifier (`uid` or `hash`)
are included in a csv dataset file which are overriden.

This change now checks during the dataseet import phase for these
duplicates and throw a exception stating the table and id value
to make the usage easier and helps with finding test-setup issues.

Note: `assertCSVDataSet()` counter part will not check for duplicates.

Resolves: #478
Releases: main, 7
