### PR TITLE
[TASK] Avoid php deprecation in FrameworkState (6)

### DIFF
--- a/Classes/Core/Functional/Framework/FrameworkState.php
+++ b/Classes/Core/Functional/Framework/FrameworkState.php
@@ -89,7 +89,7 @@ class FrameworkState
         $generalUtilityReflection = new \ReflectionClass(GeneralUtility::class);
         $generalUtilityIndpEnvCache = $generalUtilityReflection->getProperty('indpEnvCache');
         $generalUtilityIndpEnvCache->setAccessible(true);
-        $generalUtilityIndpEnvCache->setValue([]);
+        $generalUtilityIndpEnvCache->setValue(null, []);
 
         GeneralUtility::resetSingletonInstances([]);
 
@@ -126,19 +126,19 @@ class FrameworkState
         $generalUtilityReflection = new \ReflectionClass(GeneralUtility::class);
         $generalUtilityIndpEnvCache = $generalUtilityReflection->getProperty('indpEnvCache');
         $generalUtilityIndpEnvCache->setAccessible(true);
-        $generalUtilityIndpEnvCache->setValue($state['generalUtilityIndpEnvCache']);
+        $generalUtilityIndpEnvCache->setValue(null, $state['generalUtilityIndpEnvCache']);
 
         GeneralUtility::resetSingletonInstances($state['generalUtilitySingletonInstances']);
 
         $rootlineUtilityReflection = new \ReflectionClass(RootlineUtility::class);
         $rootlineUtilityLocalCache = $rootlineUtilityReflection->getProperty('localCache');
         $rootlineUtilityLocalCache->setAccessible(true);
-        $rootlineUtilityLocalCache->setValue($state['rootlineUtilityLocalCache']);
+        $rootlineUtilityLocalCache->setValue(null, $state['rootlineUtilityLocalCache']);
         $rootlineUtilityRootlineFields = $rootlineUtilityReflection->getProperty('rootlineFields');
         $rootlineUtilityRootlineFields->setAccessible(true);
-        $rootlineUtilityRootlineFields->setValue($state['rootlineUtilityRootlineFields']);
+        $rootlineUtilityRootlineFields->setValue(null, $state['rootlineUtilityRootlineFields']);
         $rootlineUtilityPageRecordCache = $rootlineUtilityReflection->getProperty('pageRecordCache');
         $rootlineUtilityPageRecordCache->setAccessible(true);
-        $rootlineUtilityPageRecordCache->setValue($state['rootlineUtilityPageRecordCache']);
+        $rootlineUtilityPageRecordCache->setValue(null, $state['rootlineUtilityPageRecordCache']);
     }
 }


### PR DESCRIPTION
With PHP8.3 the `ReflectionProperty->setValue()` method
emits a E_DEPRECATED if a value should be set to a class
and the context is not set as first argument.

For instanciated classes the class needs to be provided,
which is not possible for a static class or property.

The solution for this is to use `null` as first argument
as context object. That avoids the deprecation and keeps
the backward compatibility.

The testing-framework provides a tool to keep and handle
static Framework state, which uses reflection under the
hood and therefore needs the null context for `setValue()`.

Releases: main, 7, 6
