### PR TITLE
[BUGFIX] Do not consider "0" as empty in the CSV DB import

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -225,12 +225,12 @@ final class DataSet
                 $fieldCount = null;
                 $idIndex = null;
                 $hashIndex = null;
-            } elseif ($tableName !== null && !empty($values[1])) {
+            } elseif ($tableName !== null && (string)$values[1] !== '') {
                 array_shift($values);
                 if (!isset($data[$tableName]['fields'])) {
                     $data[$tableName]['fields'] = [];
                     foreach ($values as $value) {
-                        if (empty($value)) {
+                        if ((string)$value === '') {
                             continue;
                         }
                         $data[$tableName]['fields'][] = $value;


### PR DESCRIPTION
A DB column value "0" is a perfectly valid value and should not be considered to be empty.

Particularly, having a "0" value as the first value in a DB row in a CSV file should still allow the DB row to get importet.

(In general, `empty()` in PHP behaves in mysterious ways and should be avoided in favor of more explicit and human-predicable checks.)

Fixes #488

Releases: main, 7, 6