### PR TITLE
[TASK] Make all `in_array` calls strict

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -236,11 +236,11 @@ final class DataSet
                         $data[$tableName]['fields'][] = $value;
                         $fieldCount = count($data[$tableName]['fields']);
                     }
-                    if (in_array('uid', $values)) {
+                    if (in_array('uid', $values, true)) {
                         $idIndex = array_search('uid', $values);
                         $data[$tableName]['idIndex'] = $idIndex;
                     }
-                    if (in_array('hash', $values)) {
+                    if (in_array('hash', $values, true)) {
                         $hashIndex = array_search('hash', $values);
                         $data[$tableName]['hashIndex'] = $hashIndex;
                     }
@@ -304,11 +304,11 @@ final class DataSet
             $fields = $sections['fields'];
             foreach ($GLOBALS['TCA'][$tableName]['columns'] as $tcaFieldName => $tcaFieldConfiguration) {
                 // Skip if field was already imported
-                if (in_array($tcaFieldName, $fields)) {
+                if (in_array($tcaFieldName, $fields, true)) {
                     continue;
                 }
                 // Skip if field is an enable-column (it's expected that those fields have proper DBMS defaults)
-                if (!empty($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']) && in_array($tcaFieldName, $GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns'])) {
+                if (!empty($GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns']) && in_array($tcaFieldName, $GLOBALS['TCA'][$tableName]['ctrl']['enablecolumns'], true)) {
                     continue;
                 }
                 // Skip if no default value is defined in the accordant TCA definition (NULL values might occur as well)

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -382,8 +382,8 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
     protected function tearDown(): void
     {
         // Remove any site configuration, and it's cache files, most likely created by SiteBasedTestTrait
-        if (!in_array('typo3conf/sites', $this->pathsToLinkInTestInstance)
-            && !in_array('typo3conf/sites/', $this->pathsToLinkInTestInstance)
+        if (!in_array('typo3conf/sites', $this->pathsToLinkInTestInstance, true)
+            && !in_array('typo3conf/sites/', $this->pathsToLinkInTestInstance, true)
             && is_dir($this->instancePath . '/typo3conf/sites')
         ) {
             GeneralUtility::rmdir($this->instancePath . '/typo3conf/sites', true);
@@ -993,7 +993,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             $body->write(\GuzzleHttp\Psr7\Query::build($parsedBody));
             $serverRequest = $serverRequest->withBody($body);
         }
-        if (empty($parsedBody) && !empty((string)$body) && in_array($serverRequest->getMethod(), ['PUT', 'PATCH', 'POST', 'DELETE'])) {
+        if (empty($parsedBody) && !empty((string)$body) && in_array($serverRequest->getMethod(), ['PUT', 'PATCH', 'POST', 'DELETE'], true)) {
             parse_str((string)$body, $parsedBody);
             $serverRequest = $serverRequest->withParsedBody($parsedBody);
         }


### PR DESCRIPTION
This avoids false positives in cases where PHP would cast values.

Releases: main, 7, 6