### PR TITLE
[TASK] Expect LocalizationUtility::configurationManager is gone

### DIFF
--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -186,9 +186,14 @@ abstract class UnitTestCase extends BaseTestCase
         );
 
         // Verify LocalizationUtility class internal state has been reset properly if a test fiddled with it
+        // @deprecated: Remove in TF main for core v12 & v13 when https://review.typo3.org/c/Packages/TYPO3.CMS/+/80735 is merged.
         $reflectionClass = new \ReflectionClass(LocalizationUtility::class);
-        $property = $reflectionClass->getProperty('configurationManager');
-        self::assertNull($property->getValue());
+        try {
+            $property = $reflectionClass->getProperty('configurationManager');
+            self::assertNull($property->getValue());
+        } catch (\ReflectionException) {
+            // Do not assert property does not exist - it has been removed in v12.
+        }
 
         self::assertTrue($this->setUpMethodCallChainValid, 'tearDown() integrity check detected that setUp has a '
             . 'broken parent call chain. Please check that setUp() methods properly calls parent::setUp(), starting from "'


### PR DESCRIPTION
TYPO3 v12 and v13 removes this property, so it can't be reflected anymore. Current main/v8 TF should remove this, while v7 (core v11 & v12) should implement a fallback.

Releases: main, 7