### PR TITLE
[TASK] Expect LocalizationUtility::configurationManager is gone

### DIFF
--- a/Classes/Core/Unit/UnitTestCase.php
+++ b/Classes/Core/Unit/UnitTestCase.php
@@ -189,9 +189,13 @@ abstract class UnitTestCase extends BaseTestCase
 
         // Verify LocalizationUtility class internal state has been reset properly if a test fiddled with it
         $reflectionClass = new \ReflectionClass(LocalizationUtility::class);
-        $property = $reflectionClass->getProperty('configurationManager');
-        $property->setAccessible(true);
-        self::assertNull($property->getValue());
+        try {
+            $property = $reflectionClass->getProperty('configurationManager');
+            $property->setAccessible(true);
+            self::assertNull($property->getValue());
+        } catch (\ReflectionException $e) {
+            // Do not assert if property does not exist - it has been removed in v12.
+        }
     }
 
     /**


### PR DESCRIPTION
TYPO3 v12 and v13 removes this property, so it can't be reflected anymore. Current main/v8 TF should remove this, while v7 (core v11 & v12) should implement a fallback.

Releases: main, 7