### PR TITLE
[TASK] Ignore insecure file download JavaScript errors

### DIFF
--- a/Classes/Core/Acceptance/Helper/Acceptance.php
+++ b/Classes/Core/Acceptance/Helper/Acceptance.php
@@ -111,7 +111,10 @@ class Acceptance extends Module
      */
     protected function isJSError($logEntryLevel, $message)
     {
-        return $logEntryLevel === 'SEVERE' && strpos($message, 'ERR_PROXY_CONNECTION_FAILED') === false;
+        return $logEntryLevel === 'SEVERE'
+            && !str_contains($message, 'ERR_PROXY_CONNECTION_FAILED')
+            && !str_contains($message, 'was loaded over an insecure connection. This file should be served over HTTPS.')
+        ;
     }
 
     /**


### PR DESCRIPTION
The chrome option `--unsafely-treat-insecure-origin-as-secure`
seems to not working in all cases during acceptance tests in
the core. JavaScript errors like following example are still
emitted and leading in some circumstances to test failures:

```
The file at 'http://web/typo3/record/download?token=sometoken'
was loaded over an insecure connection. This file should be
served over HTTPS.
```

Furthermore, the testing-framework provides an `isJsError()`
check which is executed after each step.

This change now ignores such insecure errors like the already
included `ERR_PROXY_CONNECTION_FAILED` check. `strpos()` are
replaced with more readable `str_contains()` checks.

Releases: main
