### PR TITLE
[TASK] Ensure package dependencies in functional/acceptance tests

### DIFF
--- a/Classes/Core/PackageCollection.php
+++ b/Classes/Core/PackageCollection.php
@@ -36,8 +36,6 @@ use TYPO3\CMS\Core\Utility\PathUtility;
  */
 class PackageCollection
 {
-    protected \Closure $isComposerDependency;
-
     /**
      * @var array<PackageKey, PackageInterface>
      */
@@ -61,7 +59,6 @@ class PackageCollection
 
     public function __construct(PackageInterface ...$packages)
     {
-        $this->isComposerDependency = static fn (): bool => false;
         $this->packages = array_combine(
             array_map(
                 static fn (PackageInterface $package) => $package->getPackageKey(),
@@ -293,5 +290,10 @@ class PackageCollection
             }
         }
         return $frameworkKeys;
+    }
+
+    protected function isComposerDependency(string $packageKey): bool
+    {
+        return false;
     }
 }

--- a/Classes/Core/PackageCollection.php
+++ b/Classes/Core/PackageCollection.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\TestingFramework\Core;
+
+use TYPO3\CMS\Core\Package\MetaData;
+use TYPO3\CMS\Core\Package\MetaData\PackageConstraint;
+use TYPO3\CMS\Core\Package\Package;
+use TYPO3\CMS\Core\Package\PackageInterface;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
+
+/**
+ * The default TYPO3 Package Manager
+ *
+ * @phpstan-type PackageKey non-empty-string
+ * @phpstan-type PackageName non-empty-string
+ * @phpstan-type PackageConstraints array{dependencies: list<PackageKey>, suggestions: list<PackageKey>}
+ * @phpstan-type StateConfiguration array{packagePath?: non-empty-string}
+ */
+class PackageCollection
+{
+    protected \Closure $isComposerDependency;
+
+    /**
+     * @var array<PackageKey, PackageInterface>
+     */
+    protected array $packages;
+
+    /**
+     * @param PackageManager $packageManager
+     * @param array<PackageKey, StateConfiguration> $packageStates
+     */
+    public static function fromPackageStates(PackageManager $packageManager, string $basePath, array $packageStates): self
+    {
+        $packages = [];
+        foreach ($packageStates as $packageKey => $packageStateConfiguration) {
+            $packagePath = PathUtility::sanitizeTrailingSeparator(
+                rtrim($basePath, '/') . '/' . $packageStateConfiguration['packagePath']
+            );
+            $packages[] = new Package($packageManager, $packageKey, $packagePath);
+        }
+        return new self(...$packages);
+    }
+
+    public function __construct(PackageInterface ...$packages)
+    {
+        $this->isComposerDependency = static fn (): bool => false;
+        $this->packages = array_combine(
+            array_map(
+                static fn (PackageInterface $package) => $package->getPackageKey(),
+                $packages
+            ),
+            $packages
+        );
+    }
+
+    /**
+     * @return array<PackageKey, PackageInterface>
+     */
+    public function getPackages(): array
+    {
+        return $this->packages;
+    }
+
+    public function sortPackages(DependencyOrderingService $dependencyOrderingService = null): void
+    {
+        $sortedPackageKeys = $this->resolveSortedPackageKeys($dependencyOrderingService);
+        usort(
+            $this->packages,
+            static fn (PackageInterface $a, PackageInterface $b) =>
+                array_search($a->getPackageKey(), $sortedPackageKeys, true)
+                <=> array_search($b->getPackageKey(), $sortedPackageKeys, true)
+        );
+    }
+
+    /**
+     * @param array<PackageKey, StateConfiguration> $packageStates
+     * @return array<PackageKey, StateConfiguration>
+     */
+    public function sortPackageStates(array $packageStates, DependencyOrderingService $dependencyOrderingService = null): array
+    {
+        $sortedPackageKeys = $this->resolveSortedPackageKeys($dependencyOrderingService);
+        uksort(
+            $packageStates,
+            static fn (string $a, string $b) =>
+                array_search($a, $sortedPackageKeys, true)
+                <=> array_search($b, $sortedPackageKeys, true)
+        );
+        return $packageStates;
+    }
+
+    /**
+     * Builds the dependency graph for all packages
+     *
+     * This method also introduces dependencies among the dependencies
+     * to ensure the loading order is exactly as specified in the list.
+     *
+     * @return list<PackageKey>
+     */
+    public function resolveSortedPackageKeys(DependencyOrderingService $dependencyOrderingService = null): array
+    {
+        $dependencyOrderingService ??= GeneralUtility::makeInstance(DependencyOrderingService::class);
+        $allPackageConstraints = $this->resolveAllPackageConstraints();
+
+        // sort the packages by key at first, so we get a stable sorting of "equivalent" packages afterwards
+        ksort($allPackageConstraints);
+
+        $frameworkKeys = $this->findFrameworkKeys();
+        $frameworkDependencyGraph = $dependencyOrderingService->buildDependencyGraph(
+            $this->convertConfigurationForGraph($allPackageConstraints, $frameworkKeys)
+        );
+        $rootKeys = $dependencyOrderingService->findRootIds($frameworkDependencyGraph);
+        $allPackageConstraints = $this->addDependencyToFrameworkToAllExtensions($allPackageConstraints, $rootKeys, $frameworkKeys);
+
+        $packageKeys = array_keys($allPackageConstraints);
+        $dependencyGraph = $dependencyOrderingService->buildDependencyGraph(
+            $this->convertConfigurationForGraph($allPackageConstraints, $packageKeys)
+        );
+
+        return $dependencyOrderingService->calculateOrder($dependencyGraph);
+    }
+
+    /**
+     * Convert the package configuration into a dependency definition
+     *
+     * This converts "dependencies" and "suggestions" to "after" syntax for the usage in DependencyOrderingService
+     *
+     * @param array $allPackageConstraints
+     * @param array $packageKeys
+     * @return array
+     * @throws \UnexpectedValueException
+     */
+    protected function convertConfigurationForGraph(array $allPackageConstraints, array $packageKeys): array
+    {
+        $dependencies = [];
+        foreach ($packageKeys as $packageKey) {
+            if (!isset($allPackageConstraints[$packageKey]['dependencies']) && !isset($allPackageConstraints[$packageKey]['suggestions'])) {
+                continue;
+            }
+            $dependencies[$packageKey] = [
+                'after' => [],
+            ];
+            if (isset($allPackageConstraints[$packageKey]['dependencies'])) {
+                foreach ($allPackageConstraints[$packageKey]['dependencies'] as $dependentPackageKey) {
+                    if (!in_array($dependentPackageKey, $packageKeys, true)) {
+                        if ($this->isComposerDependency($dependentPackageKey)) {
+                            // The given package has a dependency to a Composer package that has no relation to TYPO3
+                            // We can ignore those, when calculating the extension order
+                            continue;
+                        }
+                        throw new \UnexpectedValueException(
+                            'The package "' . $packageKey . '" depends on "'
+                            . $dependentPackageKey . '" which is not present in the system.',
+                            1519931815
+                        );
+                    }
+                    $dependencies[$packageKey]['after'][] = $dependentPackageKey;
+                }
+            }
+            if (isset($allPackageConstraints[$packageKey]['suggestions'])) {
+                foreach ($allPackageConstraints[$packageKey]['suggestions'] as $suggestedPackageKey) {
+                    // skip suggestions on not existing packages
+                    if (in_array($suggestedPackageKey, $packageKeys, true)) {
+                        // Suggestions actually have never been meant to influence loading order.
+                        // We misuse this currently, as there is no other way to influence the loading order
+                        // for not-required packages (soft-dependency).
+                        // When considering suggestions for the loading order, we might create a cyclic dependency
+                        // if the suggested package already has a real dependency on this package, so the suggestion
+                        // has do be dropped in this case and must *not* be taken into account for loading order evaluation.
+                        $dependencies[$packageKey]['after-resilient'][] = $suggestedPackageKey;
+                    }
+                }
+            }
+        }
+        return $dependencies;
+    }
+
+    /**
+     * Adds all root packages of current dependency graph as dependency to all extensions
+     *
+     * This ensures that the framework extensions (aka sysext) are
+     * always loaded first, before any other external extension.
+     *
+     * @param array<PackageKey, PackageConstraints> $allPackageConstraints
+     * @param list<PackageKey> $rootPackageKeys
+     * @return array<PackageKey, PackageConstraints>
+     */
+    protected function addDependencyToFrameworkToAllExtensions(array $allPackageConstraints, array $rootPackageKeys, array $frameworkKeys): array
+    {
+        $extensionPackageKeys = array_diff(array_keys($allPackageConstraints), $frameworkKeys);
+        foreach ($extensionPackageKeys as $packageKey) {
+            // Remove framework packages from list
+            $packageKeysWithoutFramework = array_diff(
+                $allPackageConstraints[$packageKey]['dependencies'],
+                $frameworkKeys
+            );
+            // The order of the array_merge is crucial here,
+            // we want the framework first
+            $allPackageConstraints[$packageKey]['dependencies'] = array_merge(
+                $rootPackageKeys,
+                $packageKeysWithoutFramework
+            );
+        }
+        return $allPackageConstraints;
+    }
+
+    protected function resolveAllPackageConstraints(): array
+    {
+        $dependencies = [];
+        foreach ($this->packages as $package) {
+            $packageKey = $package->getPackageKey();
+            $dependencies[$packageKey]['dependencies'] = $this->getDependencyArrayForPackage($package);
+            $dependencies[$packageKey]['suggestions'] = $this->getSuggestionArrayForPackage($package);
+        }
+        return $dependencies;
+    }
+
+    /**
+     * Returns an array of dependent package keys for the given package. It will
+     * do this recursively, so dependencies of dependent packages will also be
+     * in the result.
+     *
+     * @param list<PackageInterface> $trace An array of already visited packages, to detect circular dependencies
+     * @return list<PackageKey> An array of direct or indirect dependent packages
+     */
+    protected function getDependencyArrayForPackage(PackageInterface $package, array &$dependentPackageKeys = [], array $trace = []): array
+    {
+        if (in_array($package, $trace, true)) {
+            return $dependentPackageKeys;
+        }
+        $trace[] = $package;
+        $dependentPackageConstraints = $package->getPackageMetaData()
+            ->getConstraintsByType(MetaData::CONSTRAINT_TYPE_DEPENDS);
+        foreach ($dependentPackageConstraints as $constraint) {
+            if ($constraint instanceof PackageConstraint) {
+                $dependentPackageKey = $constraint->getValue();
+                if (!in_array($dependentPackageKey, $dependentPackageKeys, true) && !in_array($dependentPackageKey, $trace, true)) {
+                    $dependentPackageKeys[] = $dependentPackageKey;
+                }
+                $this->getDependencyArrayForPackage($this->packages[$dependentPackageKey], $dependentPackageKeys, $trace);
+            }
+        }
+        return array_reverse($dependentPackageKeys);
+    }
+
+    /**
+     * Returns an array of suggested package keys for the given package.
+     *
+     * @return list<PackageKey> An array of directly suggested packages
+     */
+    protected function getSuggestionArrayForPackage(PackageInterface $package): array
+    {
+        $suggestedPackageKeys = [];
+        $suggestedPackageConstraints = $package->getPackageMetaData()
+            ->getConstraintsByType(MetaData::CONSTRAINT_TYPE_SUGGESTS);
+        foreach ($suggestedPackageConstraints as $constraint) {
+            if ($constraint instanceof PackageConstraint) {
+                $suggestedPackageKey = $constraint->getValue();
+                if (isset($this->packages[$suggestedPackageKey])) {
+                    $suggestedPackageKeys[] = $suggestedPackageKey;
+                }
+            }
+        }
+        return array_reverse($suggestedPackageKeys);
+    }
+
+    /**
+     * @return list<PackageKey>
+     */
+    protected function findFrameworkKeys(): array
+    {
+        $frameworkKeys = [];
+        foreach ($this->packages as $package) {
+            if ($package->getPackageMetaData()->isFrameworkType()) {
+                $frameworkKeys[] = $package->getPackageKey();
+            }
+        }
+        return $frameworkKeys;
+    }
+}

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -30,6 +30,8 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Schema\SchemaMigrator;
 use TYPO3\CMS\Core\Database\Schema\SqlReader;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Composer\ComposerPackageManager;
@@ -602,6 +604,23 @@ class Testbase
                 'packagePath' => 'typo3conf/ext/' . $extensionName . '/',
             ];
         }
+
+        $dependencyOrderingService = new DependencyOrderingService();
+        $packageManager = new PackageManager(
+            $dependencyOrderingService,
+            $instancePath . '/typo3conf/PackageStates.php',
+            $instancePath
+        );
+        // PackageManager is required to create a Package instance...
+        $packageCollection = PackageCollection::fromPackageStates(
+            $packageManager,
+            $instancePath,
+            $packageStates['packages']
+        );
+        $packageStates['packages'] = $packageCollection->sortPackageStates(
+            $packageStates['packages'],
+            $dependencyOrderingService
+        );
 
         $result = file_put_contents(
             $instancePath . '/typo3conf/PackageStates.php',


### PR DESCRIPTION
The new `PackageCollection` uses the behavior of the `PackageManager` to define proper dependency ordering of extensions when executing functional and acceptance tests.

Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/81076
Releases: main
