### PR TITLE
[TASK] Avoid invalid database name configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
       - name: Phpstan
-        if: ${{ matrix.php <= '8.1' }}
+        if: ${{ matrix.php <= '8.0' }}
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
 
       - name: Unit Tests

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
@@ -477,7 +477,7 @@ class DataHandlerFactory
         // current item did not have any values in data map, use last identifer
         if ($currentIndex === false && !empty($identifiers)) {
             $values['pid'] = '-' . $identifiers[count($identifiers) - 1];
-        // current item does have values in data map, use previous identifier
+            // current item does have values in data map, use previous identifier
         } elseif ($currentIndex > 0) {
             $previousIndex = $identifiers[$currentIndex - 1];
             $values['pid'] = '-' . $identifiers[$previousIndex];

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -343,6 +343,16 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             $dbDriver = $localConfiguration['DB']['Connections']['Default']['driver'];
             if ($dbDriver !== 'pdo_sqlite') {
                 $originalDatabaseName = $localConfiguration['DB']['Connections']['Default']['dbname'];
+                if ($originalDatabaseName !== preg_replace('/[^a-zA-Z0-9_]/', '', $originalDatabaseName)) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'Database name "%s" is invalid. Use a valid name, for example "%s".',
+                            $originalDatabaseName,
+                            preg_replace('/[^a-zA-Z0-9_]/', '', $originalDatabaseName)
+                        ),
+                        1695139917
+                    );
+                }
                 // Append the unique identifier to the base database name to end up with a single database per test case
                 $dbName = $originalDatabaseName . '_ft' . $this->identifier;
                 $localConfiguration['DB']['Connections']['Default']['dbname'] = $dbName;


### PR DESCRIPTION
Database name only allows a special set of characters.
Based on the configured database name, functional test
creates databases per functional test case.

Due to the general policy the typo3/testing-framework
should not silently fix setup errors. Therefore, invalid
database name configuration is now detected, throwing a
`\RuntimeException` with a use-full exception message.

Releases: main, 7
