### PR TITLE
[TASK] Replace `\PDO::PARAM_*` constants with `Connection::PARAM_*`

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -17,6 +17,7 @@ namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling;
  */
 
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -527,11 +528,11 @@ class ActionService
             ->where(
                 $queryBuilder->expr()->eq(
                     't3ver_oid',
-                    $queryBuilder->createNamedParameter($liveUid, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($liveUid, Connection::PARAM_INT)
                 ),
                 $queryBuilder->expr()->eq(
                     't3ver_wsid',
-                    $queryBuilder->createNamedParameter($workspaceId, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($workspaceId, Connection::PARAM_INT)
                 )
             )
             ->executeQuery()
@@ -551,19 +552,19 @@ class ActionService
             ->where(
                 $queryBuilder->expr()->eq(
                     'uid',
-                    $queryBuilder->createNamedParameter($liveUid, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($liveUid, Connection::PARAM_INT)
                 ),
                 $queryBuilder->expr()->eq(
                     't3ver_wsid',
-                    $queryBuilder->createNamedParameter($workspaceId, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($workspaceId, Connection::PARAM_INT)
                 ),
                 $queryBuilder->expr()->eq(
                     't3ver_oid',
-                    $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
                 ),
                 $queryBuilder->expr()->eq(
                     't3ver_state',
-                    $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter(1, Connection::PARAM_INT)
                 )
             )
             ->executeQuery()

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
@@ -486,7 +487,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $queryBuilder->getRestrictions()->removeAll();
         $result = $queryBuilder->select('*')
             ->from('be_users')
-            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($userId, \PDO::PARAM_INT)))
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($userId, Connection::PARAM_INT)))
             ->executeQuery();
         return $result->fetchAssociative() ?: null;
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
   },
   "require": {
     "php": "^8.1",
-    "ext-pdo": "*",
     "guzzlehttp/psr7": "^2.5.0",
     "phpunit/phpunit": "^10.1",
     "psr/container": "^1.1.0 || ^2.0.0",


### PR DESCRIPTION
This change replaces the `\PDO::PARAM_*` constants with the TYPO3
`\TYPO3\CMS\Core\Database\Connection::PARAM_*` alternatives. This
aligns the testing-framework with the core and the communicated
best-practice.

The direct dependency to `ext-pdo` is removed right away.

Note: `doctrine/dbal 4+` dropps support for the \PDO integer constants.
       Using the `Connection` constants allows us to change the mapping
       in that class and consuming code, like extensions or this package
       automaticlly uses the correct enum class on upgrade.

Used command(s):

```shell
composer remove ext-pdo
```

Releases: main, 7
