### PR TITLE
[BUGFIX] Ignore non-typo3 packages in PackageState 

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -613,9 +613,10 @@ class Testbase
         );
         // PackageManager is required to create a Package instance...
         $packageCollection = PackageCollection::fromPackageStates(
+            $this->composerPackageManager,
             $packageManager,
             $instancePath,
-            $packageStates['packages']
+            $packageStates['packages'],
         );
         $packageStates['packages'] = $packageCollection->sortPackageStates(
             $packageStates['packages'],


### PR DESCRIPTION
The testing-framework creates test instances per
functional test-case based on properties defining
the system extensions, extension and fixture test
extension to symlink and load in the non-composer
test instances.

Therefore, the `PackageStates.php` file is created
on the first test run per test-case manually based
on the provided properties in the defined order.

With [1] a `PackageCollection` class has been added
to ensure proper extension sorting in the packages
state file based on dependency informations. That
is essentially for the loading and processing order.

Since TYPO3 v12 extensions in composer mode no longer
requires the presence of a `ext_emconf.php` versus
non-composer mode. The `ext_emconf.php` is still added
if a extension is published to TER. Therefore, some
extension authors removed a manual `ext_emconf.php`
from their extensions.

Extension composer.json may contain non-extension
packages as dependencies (`require`), which is not
handled by the PackageCollection due to the fact
that it assumes that all required packages are valid
extensions.

This change modifies the dependency validation method
`PackageCollection->isComposerDependency()` using the
`ComposerPackageManager` class information to determine
if a package is a extension or not.

For example platform requires like `"php"` or packages
like `"composer/installers"` are no longer used for
dependency ordering and therefore throwing a exception.

[1] b2b158fe68d6c1d9723ac0e84827a363da01c119

Resolves: #510
Releases: main
