### PR TITLE
[TASK] Avoid deprecated `SchemaManager->listTableDetails()` method

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -73,7 +73,7 @@ final class DataSet
             $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tableName);
             $platform = $connection->getDatabasePlatform();
             // @todo Check if we can use the cached schema information here instead.
-            $tableDetails = $connection->createSchemaManager()->listTableDetails($tableName);
+            $tableDetails = $connection->createSchemaManager()->introspectTable($tableName);
             foreach ($dataSet->getElements($tableName) as $element) {
                 // Some DBMS like postgresql are picky about inserting blob types with correct cast, setting
                 // types correctly (like Connection::PARAM_LOB) allows doctrine to create valid SQL


### PR DESCRIPTION
Doctrine DBAL deprecated `SchemaManager->listTableDetails()`
within `3.x` [1]. That means that this method will be removed
with `doctrine/dbal 4.x`.

To pave the way towards the next `doctrine/dbal` major version,
the usage is replaced with the `SchemaManager->introspectTable()`
method.

[1] https://github.com/doctrine/dbal/blob/3.7.x/UPGRADE.md#deprecated-abstractschemamanager-schema-introspection-methods

Releases: main
