### PR TITLE
[TASK] Avoid deprecated `AbstractSchemaManager::getDatabasePlatform()`

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -659,9 +659,10 @@ class Testbase
         // @todo: This should by now work with using "our" ConnectionPool again, it does now, though.
         $connectionParameters = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
         unset($connectionParameters['dbname']);
-        $schemaManager = DriverManager::getConnection($connectionParameters)->createSchemaManager();
+        $connection = DriverManager::getConnection($connectionParameters);
+        $schemaManager = $connection->createSchemaManager();
 
-        if ($schemaManager->getDatabasePlatform()->getName() === 'sqlite') {
+        if ($connection->getDatabasePlatform()->getName() === 'sqlite') {
             // This is the "path" option in sqlite: one file = one db
             $schemaManager->dropDatabase($databaseName);
         } elseif (in_array($databaseName, $schemaManager->listDatabases(), true)) {


### PR DESCRIPTION
The doctrine team deprecated the `AbstractSchemaManager::getDatabasePlatform()`
method has been deprecated. [1]

Use `Connection::getDatabasePlatform()` instead to mitigate this deprecation.

[1] https://github.com/doctrine/dbal/blob/3.7.x/UPGRADE.md#deprecated-abstractschemamanagergetdatabaseplatform

Releases: main
