### PR TITLE
[TASK] Avoid calling deprecated `Platform->getName()`

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\SqlitePlatform as DoctrineSQLitePlatform;
 
 /**
  * Implement the database snapshot and callback logic.
@@ -61,7 +62,7 @@ class DatabaseSnapshot
      */
     public function create(DatabaseAccessor $accessor, Connection $connection): void
     {
-        if ($connection->getDatabasePlatform()->getName() === 'sqlite') {
+        if ($connection->getDatabasePlatform() instanceof DoctrineSQLitePlatform) {
             // With sqlite, we simply copy the db-file to a different place
             $connection->close();
             copy(
@@ -87,7 +88,7 @@ class DatabaseSnapshot
      */
     public function restore(DatabaseAccessor $accessor, Connection $connection): void
     {
-        if ($connection->getDatabasePlatform()->getName() === 'sqlite') {
+        if ($connection->getDatabasePlatform() instanceof DoctrineSQLitePlatform) {
             $connection->close();
             copy(
                 $this->sqliteDir . 'test_' . $this->identifier . '.snapshot.sqlite',

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -17,7 +17,7 @@ namespace TYPO3\TestingFramework\Core\Functional;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform as DoctrinePostgreSQLPlatform;
 use PHPUnit\Framework\ExpectationFailedException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -855,7 +855,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         }
         // @todo: Check if this constant is still needed
         $databasePlatform = 'mysql';
-        if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+        if ($connection->getDatabasePlatform() instanceof DoctrinePostgreSQLPlatform) {
             $databasePlatform = 'postgresql';
         }
         $templateFields['constants'] .= 'databasePlatform = ' . $databasePlatform . LF;


### PR DESCRIPTION
The doctrine team deprecated the `getName()` method
for platform classes within `doctrine/dbal 3.x` [1].

This change modifes userland code to

a) replace `getName()` with `instanceof` checks

Using `instanceof` checks against the connection platform
is the propose replacement for the deprecated `getName()`
method.

b) Use prefixed class namespace alias for imported platforms

Instead of

  use Doctrine\DBAL\Platforms\SqlitePlatform;

prefixed alias is used:

  use Doctrine\DBAL\Platforms\SqlitePlatform
    as DoctrineSQLitePlatform;

Only caveat is, that static code analysers like PHPStan
may report it.

[1] https://github.com/doctrine/dbal/blob/3.7.x/UPGRADE.md#deprecated-abstractplatformgetname

Releases: main
