### PR TITLE
[TASK] Ensure Doctrine DBAL 3 and 4 dual support

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\Snapshot;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\SqlitePlatform as DoctrineSQLitePlatform;
 
 /**
  * Implement the database snapshot and callback logic.
@@ -62,7 +61,7 @@ class DatabaseSnapshot
      */
     public function create(DatabaseAccessor $accessor, Connection $connection): void
     {
-        if ($connection->getDatabasePlatform() instanceof DoctrineSQLitePlatform) {
+        if ($this->isSQLite($connection)) {
             // With sqlite, we simply copy the db-file to a different place
             $connection->close();
             copy(
@@ -88,7 +87,7 @@ class DatabaseSnapshot
      */
     public function restore(DatabaseAccessor $accessor, Connection $connection): void
     {
-        if ($connection->getDatabasePlatform() instanceof DoctrineSQLitePlatform) {
+        if ($this->isSQLite($connection)) {
             $connection->close();
             copy(
                 $this->sqliteDir . 'test_' . $this->identifier . '.snapshot.sqlite',
@@ -100,5 +99,18 @@ class DatabaseSnapshot
             }
             $accessor->import($this->inMemoryImport);
         }
+    }
+
+    /**
+     * @todo Replace usages by direct instanceof checks when TYPO3 v13.0 / Doctrine DBAL 4 is lowes supported version.
+     *
+     * @param Connection $connection
+     * @return bool
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function isSQLite(Connection $connection): bool
+    {
+        /** @phpstan-ignore-next-line */
+        return $connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SQLitePlatform;
     }
 }


### PR DESCRIPTION
* [1] Doctrine DBAL 4 removed `SqliteManager->createDatabase()`
  and `SqliteManager->dropDatabase()`. The engine is createing
  the SQLite file on connect, but do not remove it on close.
  The `Testbase->setUpTestDatabase()` code is modified to delete
  the sqlite file directly, and let the engine handle the sqlite
  file creation on connect.

* [2] Doctrine DBAL 4 changed the casing of some classes, for
  exmaple `SqlitePlatform` to `SQLitePlatform`, which is not an
  issue for code execution due to the case-insensitive nature of
  PHP - but static code analyser tools like PHPStan fall on their
  feed. Therefore, we use minor wrapping methods instead of php
  interfaceof checks directly to mitigate this and avoid jumping
  PHPStan baseline entry until Doctrine DBAL 4 is the minimal to
  support version.

  Note: The Doctrine DBAL 4 namespace casing is used.

[1] https://github.com/doctrine/dbal/blob/3.7.x/UPGRADE.md#deprecated-sqliteschemamanagercreatedatabase-and-dropdatabase-methods
[2] https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#bc-break-renamed-sqlite-platform-classes

Releases: main
