### PR TITLE
[TASK] Add dummy coverage configuration for PHPUnit

### DIFF
--- a/Resources/Core/Build/FunctionalTests.xml
+++ b/Resources/Core/Build/FunctionalTests.xml
@@ -31,6 +31,7 @@
          failOnWarning="true"
          requireCoverageMetadata="false"
 >
+    <coverage/>
     <testsuites>
         <testsuite name="Functional tests">
             <!--

--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -31,6 +31,7 @@
          failOnWarning="true"
          requireCoverageMetadata="false"
 >
+    <coverage/>
     <testsuites>
         <testsuite name="Unit tests">
             <!--


### PR DESCRIPTION
Newer PHPUnit versions require the configuration files to have a `coverage` node (which can also be empty, but it needs to exist). Otherwise, PHPUnit will complain about the configuration file being outdated.