### PR TITLE
[TASK] Use /index.php as application entry point

### DIFF
--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -39,7 +39,7 @@ class Login extends Module
     ];
 
     /**
-     * Set a backend user session cookie and load the backend index.php.
+     * Set a backend user session cookie and load the backend entrypoint.
      *
      * Use this action to change the backend user and avoid switching between users in the backend module
      * "Backend Users" as this will change the user session ID and make it useless for subsequent calls of this action.
@@ -55,21 +55,21 @@ class Login extends Module
 
         $hasSession = $this->_loadSession();
         if ($hasSession && $newUserSessionId !== '' && $newUserSessionId !== $this->getUserSessionId()) {
-            $webDriver->amOnPage('/typo3/index.php');
+            $webDriver->amOnPage('/typo3');
             $webDriver->wait($waitTime);
             $this->_deleteSession();
             $hasSession = false;
         }
 
         if (!$hasSession) {
-            $webDriver->amOnPage('/typo3/index.php');
+            $webDriver->amOnPage('/typo3');
             $webDriver->wait($waitTime);
             $webDriver->waitForElement('body[data-typo3-login-ready]');
             $this->_createSession($newUserSessionId);
         }
 
         // Reload the page to have a logged in backend.
-        $webDriver->amOnPage('/typo3/index.php');
+        $webDriver->amOnPage('/typo3');
         $webDriver->wait($waitTime);
 
         // Ensure main content frame is fully loaded, otherwise there are load-race-conditions ..

--- a/Classes/Core/SystemEnvironmentBuilder.php
+++ b/Classes/Core/SystemEnvironmentBuilder.php
@@ -40,6 +40,9 @@ use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder as CoreSystemEnvironmentBuilder
  */
 class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
 {
+    /**
+     * @todo: Change default $requestType to 0 when dropping support for TYPO3 v12
+     */
     public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE, bool $composerMode = false)
     {
         CoreSystemEnvironmentBuilder::run($entryPointLevel, $requestType);

--- a/Resources/Core/Build/UnitTestsBootstrap.php
+++ b/Resources/Core/Build/UnitTestsBootstrap.php
@@ -48,8 +48,15 @@
     // We can use the "typo3/cms-composer-installers" constant "TYPO3_COMPOSER_MODE" to determine composer mode.
     // This should be always true except for TYPO3 mono repository.
     $composerMode = defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE === true;
-    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
-    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
+
+    // @todo: Remove else branch when dropping support for v12
+    $hasConsolidatedHttpEntryPoint = class_exists(CoreHttpApplication::class);
+    if ($hasConsolidatedHttpEntryPoint) {
+        \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI, $composerMode);
+    } else {
+        $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+        \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType, $composerMode);
+    }
 
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
     $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');


### PR DESCRIPTION
/typo3/index.php is deprecated and must not longer be used.

See https://forge.typo3.org/issues/87889 and
https://review.typo3.org/c/Packages/TYPO3.CMS/+/74366

Releases: main