### PR TITLE
[TASK] Do not load EXT:install in functional tests

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Core\Http\Application as CoreHttpApplication;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
@@ -293,9 +294,12 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
                 'backend',
                 'frontend',
                 'extbase',
-                'install',
                 'fluid',
             ];
+            if ((new Typo3Version())->getMajorVersion() < 13) {
+                // @todo: Remove with next major TF version
+                $defaultCoreExtensionsToLoad[] = 'install';
+            }
             $frameworkExtension = [
                 'Resources/Core/Functional/Extensions/json_response',
                 'Resources/Core/Functional/Extensions/private_container',

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -239,8 +239,10 @@ class Testbase
         if ($hasConsolidatedHttpEntryPoint) {
             $entryPointsToSet = [
                 $instancePath . '/typo3/sysext/core/Resources/Private/Php/index.php' => $instancePath . '/index.php',
-                $instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php' => $instancePath . '/typo3/install.php',
             ];
+            if (in_array('install', $coreExtensions, true)) {
+                $entryPointsToSet[$instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php'] = $instancePath . '/typo3/install.php';
+            }
         } else {
             $entryPointsToSet = [
                 $instancePath . '/typo3/sysext/backend/Resources/Private/Php/backend.php' => $instancePath . '/typo3/index.php',


### PR DESCRIPTION
The install tool extension EXT:install is no longer a hard requirement of TYPO3 core v13. Functional tests should reflect this and stop loading it by default.