### PR TITLE
[TASK] Happify phpstan again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '8.1' , '8.2' ]
+        php: [ '8.1' , '8.2', '8.3' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,6 +29,7 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
 
       - name: Phpstan
+        if: ${{ matrix.php >= '8.2' }}
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
 
       - name: Unit Tests

--- a/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Snapshot/DatabaseSnapshot.php
@@ -102,15 +102,12 @@ class DatabaseSnapshot
     }
 
     /**
-     * @todo Replace usages by direct instanceof checks when TYPO3 v13.0 / Doctrine DBAL 4 is lowes supported version.
-     *
-     * @param Connection $connection
-     * @return bool
+     * @todo Replace usages by direct instanceof checks when
+     *       TYPO3 v13.0 / Doctrine DBAL 4 is lowest supported version.
      * @throws \Doctrine\DBAL\Exception
      */
     private function isSQLite(Connection $connection): bool
     {
-        /** @phpstan-ignore-next-line */
         return $connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SQLitePlatform;
     }
 }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -1023,15 +1023,12 @@ class Testbase
     }
 
     /**
-     * @todo Replace usages by direct instanceof checks when TYPO3 v13.0 / Doctrine DBAL 4 is lowes supported version.
-     *
-     * @param Connection|DoctrineConnection $connection
-     * @return bool
+     * @todo Replace usages by direct instanceof checks when
+     *       TYPO3 v13.0 / Doctrine DBAL 4 is lowest supported version.
      * @throws DBALException
      */
     private static function isSQLite(Connection|DoctrineConnection $connection): bool
     {
-        /** @phpstan-ignore-next-line */
         return $connection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SQLitePlatform;
     }
 }


### PR DESCRIPTION
It seems that `@phpstan-ignore-next-line` mumbles when it does non actively suppress something. With the release of doctrine 4, this kicks in for two lines which phpstan gets right now.

phpstan with PHP 8.2 now collides with 8.1, we skip the 8.1 run. Also add PHP 8.3 to the matrix.