### PR TITLE
[TASK] Reintroduce scheduled nightly

### DIFF
--- a/.github/workflows/nightly-7.yml
+++ b/.github/workflows/nightly-7.yml
@@ -1,0 +1,23 @@
+---
+name: "nightly-7"
+on:
+    schedule:
+        - cron: '42 5 * * *'
+    workflow_dispatch:
+
+jobs:
+    7:
+        name: "dispatch-nightly-7"
+        runs-on: ubuntu-22.04
+        permissions: write-all
+        steps:
+            - name: Checkout '7'
+              uses: actions/checkout@v4
+              with:
+                  ref: '7'
+
+            - name: Execute 'ci.yml' on '7'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh workflow run ci.yml --ref 7

--- a/.github/workflows/nightly-main.yml
+++ b/.github/workflows/nightly-main.yml
@@ -1,0 +1,23 @@
+---
+name: "nightly-main"
+on:
+    schedule:
+        - cron: '42 5 * * *'
+    workflow_dispatch:
+
+jobs:
+    main:
+        name: "dispatch-nightly-main"
+        runs-on: ubuntu-22.04
+        permissions: write-all
+        steps:
+            - name: Checkout 'main'
+              uses: actions/checkout@v4
+              with:
+                  ref: 'main'
+
+            - name: Execute 'ci.yml' on 'main'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh workflow run ci.yml --ref main


### PR DESCRIPTION
This change reintroduces scheduled
ci exectution. In contrast to the
prior setup the used way allows us
to have schedules not only for the
default branch.

As a side-effect we get the ability
to manually dispatch nightly on a
branch any time.