### PR TITLE
[BUGFIX] Allow importing empty CSV table

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -160,9 +160,9 @@ final class DataSet
      * Return a list of rows of given table. Keys are the uid or hash
      * index fields of that table.
      */
-    public function getElements(string $tableName): ?array
+    public function getElements(string $tableName): array
     {
-        $elements = null;
+        $elements = [];
         if (isset($this->data[$tableName]['elements'])) {
             $elements = $this->data[$tableName]['elements'];
         }

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -580,7 +580,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             $hasUidField = ($dataSet->getIdIndex($tableName) !== null);
             $hasHashField = ($dataSet->getHashIndex($tableName) !== null);
             $records = $this->getAllRecords($tableName, $hasUidField, $hasHashField);
-            $assertions = (array)$dataSet->getElements($tableName);
+            $assertions = $dataSet->getElements($tableName);
             foreach ($assertions as $assertion) {
                 $result = $this->assertInRecords($assertion, $records);
                 if ($result === false) {


### PR DESCRIPTION
When importing a .csv with a table definition and
no rows, a warning is raised: DataSet->getElements() may return null, and this fails in the foreach in
DataSet->import(). It is more clean to return an
empty array in getElements(), which is done with
the patch.