### PR TITLE
[TASK] Avoid no longer needed unset() in tearDown()

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -406,15 +406,6 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         ) {
             @unlink($this->instancePath . '/typo3temp/var/cache/code/core/sites-configuration.php');
         }
-
-        // Unset especially the container after each test, it is a huge memory hog.
-        // Test class instances in phpunit are kept until end of run, this sums up.
-        unset($this->container);
-        unset($this->identifier, $this->instancePath, $this->coreExtensionsToLoad);
-        unset($this->testExtensionsToLoad, $this->pathsToLinkInTestInstance);
-        unset($this->pathsToProvideInTestInstance, $this->configurationToUseInTestInstance);
-        unset($this->additionalFoldersToCreate);
-
         parent::tearDown();
     }
 


### PR DESCRIPTION
Recent phpunit 10.5 and 11.2 versions improved internal memory handling significantly. This obsoletes the
dedicated unset() calls we had in tearDown() of
functional test cases.