### PR TITLE
[BUGFIX] Check for install.php existance

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -295,7 +295,9 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
                 'extbase',
                 'fluid',
             ];
-            if ((new Typo3Version())->getMajorVersion() < 13) {
+            if ((new Typo3Version())->getMajorVersion() < 13
+                && class_exists(\TYPO3\CMS\Install\Exception::class)
+            ) {
                 // @todo: Remove with next major TF version
                 $defaultCoreExtensionsToLoad[] = 'install';
             }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -236,19 +236,22 @@ class Testbase
         // of the testing framework.
         // @todo: Remove else branch when dropping support for v12
         $hasConsolidatedHttpEntryPoint = class_exists(CoreHttpApplication::class);
+        $installPhpExists = file_exists($instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php');
         if ($hasConsolidatedHttpEntryPoint) {
             $entryPointsToSet = [
                 $instancePath . '/typo3/sysext/core/Resources/Private/Php/index.php' => $instancePath . '/index.php',
             ];
-            if (in_array('install', $coreExtensions, true)) {
+            if ($installPhpExists && in_array('install', $coreExtensions, true)) {
                 $entryPointsToSet[$instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php'] = $instancePath . '/typo3/install.php';
             }
         } else {
             $entryPointsToSet = [
                 $instancePath . '/typo3/sysext/backend/Resources/Private/Php/backend.php' => $instancePath . '/typo3/index.php',
                 $instancePath . '/typo3/sysext/frontend/Resources/Private/Php/frontend.php' => $instancePath . '/index.php',
-                $instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php' => $instancePath . '/typo3/install.php',
             ];
+            if ($installPhpExists) {
+                $entryPointsToSet[$instancePath . '/typo3/sysext/install/Resources/Private/Php/install.php'] = $instancePath . '/typo3/install.php';
+            }
         }
         $autoloadFile = dirname(__DIR__, 4) . '/autoload.php';
 


### PR DESCRIPTION
TF 8.1.0 removed 'composer req' of typo3/cms-install. Extension functional tests may now fail when trying to create the 'install.php' link - the file no longer exists if the extension itself has no requirement to typo3/cms-install, which most extensions don't have.

Resolves: #566