### PR TITLE
[TASK] Clean up phpunit setup

### DIFF
--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,23 +1,7 @@
 <?xml version="1.0"?>
-<!--
-    Boilerplate for a unit test suite setup.
-
-    This file is loosely maintained within TYPO3 testing-framework, extensions
-    are encouraged to not use it directly, but to copy it to an own place,
-    for instance Build/UnitTests.xml.
-    Note UnitTestsBootstrap.php should be copied along the way.
-
-    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
-    take a look at this class for further documentation on how to run the suite.
-
-    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
-    file is located next to this .xml as FunctionalTestsBootstrap.php
--->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
-         backupGlobals="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="../../Resources/Core/Build/UnitTestsBootstrap.php"
          cacheDirectory=".phpunit.cache"
          cacheResult="false"
          colors="true"
@@ -29,19 +13,13 @@
          failOnNotice="true"
          failOnRisky="true"
          failOnWarning="true"
-         requireCoverageMetadata="false"
 >
     <testsuites>
         <testsuite name="Unit tests">
-            <!--
-                This path either needs an adaption in extensions, or an extension's
-                test location path needs to be given to phpunit.
-            -->
             <directory>../../Tests/Unit/</directory>
         </testsuite>
     </testsuites>
     <php>
         <ini name="display_errors" value="1"/>
-        <env name="TYPO3_CONTEXT" value="Testing"/>
     </php>
 </phpunit>


### PR DESCRIPTION
Unit tests of TF itself don't need custom boostrap, and backupGlobals=true isn't needed either. Clean
up the xml file.