### PR TITLE
[!!!][TASK] FuncionalTestCase->assertCSVDataSet() needs abs path

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -34,7 +34,6 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\HttpUtility;
-use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Http\Application;
 use TYPO3\TestingFramework\Core\BaseTestCase;
@@ -549,11 +548,6 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      */
     protected function assertCSVDataSet(string $fileName): void
     {
-        if (!PathUtility::isAbsolutePath($fileName)) {
-            // @deprecated: Always feed absolute paths.
-            $fileName = GeneralUtility::getFileAbsFileName($fileName);
-        }
-
         $dataSet = DataSet::read($fileName);
         $failMessages = [];
 


### PR DESCRIPTION
Method FuncionalTestCase->assertCSVDataSet(string $fileName) always needs an absole path. A typical solution is relative to current test case like
$this->assertCSVDataSet(__DIR__ . '/Fixtures/some.csv') to resolve properly. A syntax like 'EXT:...' is no longer resolved.