### PR TITLE
[TASK] Avoid implicitly nullable method parameter

### DIFF
--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -56,6 +56,10 @@ return (new \PhpCsFixer\Config())
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => true,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
         'php_unit_mock_short_will_return' => true,

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -47,7 +47,7 @@ final class ComposerPackageManager
 
     private static string $publicPath = '';
 
-    private static PackageInfo|null $rootPackage = null;
+    private static ?PackageInfo $rootPackage = null;
 
     /**
      * @var array<string, PackageInfo>

--- a/Classes/Core/BaseTestCase.php
+++ b/Classes/Core/BaseTestCase.php
@@ -107,7 +107,7 @@ abstract class BaseTestCase extends TestCase
      */
     protected function getAccessibleMock(
         string $originalClassName,
-        array|null $methods = [],
+        ?array $methods = [],
         array $arguments = [],
         string $mockClassName = '',
         bool $callOriginalConstructor = true,

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -111,7 +111,7 @@ class ActionService
      * modifyRecord('tt_content', 42, ['hidden' => '1']); // Modify a single record
      * modifyRecord('tt_content', 42, ['hidden' => '1'], ['tx_irre_table' => [4]]); // Modify a record and delete a child
      */
-    public function modifyRecord(string $tableName, int $uid, array $recordData, array $deleteTableRecordIds = null): void
+    public function modifyRecord(string $tableName, int $uid, array $recordData, ?array $deleteTableRecordIds = null): void
     {
         $dataMap = [
             $tableName => [
@@ -266,7 +266,7 @@ class ActionService
      * Example:
      * copyRecord('tt_content', 42, 5, ['header' => 'Testing #1']);
      */
-    public function copyRecord(string $tableName, int $uid, int $pageId, array $recordData = null): array
+    public function copyRecord(string $tableName, int $uid, int $pageId, ?array $recordData = null): array
     {
         $commandMap = [
             $tableName => [
@@ -300,7 +300,7 @@ class ActionService
      *            the same table, and not a PID.
      * @param ?array $recordData Additional record data to change when moving.
      */
-    public function moveRecord(string $tableName, int $uid, int $targetUid, array $recordData = null): array
+    public function moveRecord(string $tableName, int $uid, int $targetUid, ?array $recordData = null): array
     {
         $commandMap = [
             $tableName => [

--- a/Classes/Core/Functional/Framework/Frontend/Collector.php
+++ b/Classes/Core/Functional/Framework/Frontend/Collector.php
@@ -81,7 +81,7 @@ final class Collector implements SingletonInterface
         $this->addToStructure($levelIdentifier, $recordIdentifier, $recordData);
     }
 
-    public function attachSection(string $content, array $configuration = null): void
+    public function attachSection(string $content, ?array $configuration = null): void
     {
         $section = [
             'structure' => $this->structure,

--- a/Classes/Core/Functional/Framework/Frontend/ResponseContent.php
+++ b/Classes/Core/Functional/Framework/Frontend/ResponseContent.php
@@ -33,7 +33,7 @@ final class ResponseContent
 
     final public function __construct() {}
 
-    public static function fromString(string $data, ResponseContent $target = null): ResponseContent
+    public static function fromString(string $data, ?ResponseContent $target = null): ResponseContent
     {
         $target = $target ?? new static();
         $content = json_decode($data, true);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -884,7 +884,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      */
     protected function executeFrontendSubRequest(
         InternalRequest $request,
-        InternalRequestContext $context = null,
+        ?InternalRequestContext $context = null,
         bool $followRedirects = false
     ): ResponseInterface {
         if ($context === null) {

--- a/Classes/Core/PackageCollection.php
+++ b/Classes/Core/PackageCollection.php
@@ -82,7 +82,7 @@ class PackageCollection
         return $this->packages;
     }
 
-    public function sortPackages(DependencyOrderingService $dependencyOrderingService = null): void
+    public function sortPackages(?DependencyOrderingService $dependencyOrderingService = null): void
     {
         $sortedPackageKeys = $this->resolveSortedPackageKeys($dependencyOrderingService);
         usort(
@@ -97,7 +97,7 @@ class PackageCollection
      * @param array<PackageKey, StateConfiguration> $packageStates
      * @return array<PackageKey, StateConfiguration>
      */
-    public function sortPackageStates(array $packageStates, DependencyOrderingService $dependencyOrderingService = null): array
+    public function sortPackageStates(array $packageStates, ?DependencyOrderingService $dependencyOrderingService = null): array
     {
         $sortedPackageKeys = $this->resolveSortedPackageKeys($dependencyOrderingService);
         uksort(
@@ -117,7 +117,7 @@ class PackageCollection
      *
      * @return list<PackageKey>
      */
-    public function resolveSortedPackageKeys(DependencyOrderingService $dependencyOrderingService = null): array
+    public function resolveSortedPackageKeys(?DependencyOrderingService $dependencyOrderingService = null): array
     {
         $dependencyOrderingService ??= GeneralUtility::makeInstance(DependencyOrderingService::class);
         $allPackageConstraints = $this->resolveAllPackageConstraints();


### PR DESCRIPTION
Implicit nullable method parameters are deprecated with PHP 8.4. The patch prepares affected method
signatures and activates an according php-cs-fixer rule.