### PR TITLE
[TASK] Avoid implicitly nullable method parameter (#896)

### DIFF
--- a/Build/php-cs-fixer/config.php
+++ b/Build/php-cs-fixer/config.php
@@ -56,6 +56,10 @@ return (new \PhpCsFixer\Config())
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => true,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
         'php_unit_mock_short_will_return' => true,

--- a/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
+++ b/Classes/Core/Functional/Framework/AssignablePropertyTrait.php
@@ -25,7 +25,7 @@ trait AssignablePropertyTrait
      * @param callable|null $cast
      * @return static
      */
-    private function assign(array $data, callable $cast = null)
+    private function assign(array $data, ?callable $cast = null)
     {
         if ($cast !== null) {
             $data = array_map($cast, $data);

--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -111,7 +111,7 @@ class ActionService
      * modifyRecord('tt_content', 42, ['hidden' => '1']); // Modify a single record
      * modifyRecord('tt_content', 42, ['hidden' => '1'], ['tx_irre_table' => [4]]); // Modify a record and delete a child
      */
-    public function modifyRecord(string $tableName, int $uid, array $recordData, array $deleteTableRecordIds = null)
+    public function modifyRecord(string $tableName, int $uid, array $recordData, ?array $deleteTableRecordIds = null)
     {
         $dataMap = [
             $tableName => [
@@ -266,7 +266,7 @@ class ActionService
      * Example:
      * copyRecord('tt_content', 42, 5, ['header' => 'Testing #1']);
      */
-    public function copyRecord(string $tableName, int $uid, int $pageId, array $recordData = null): array
+    public function copyRecord(string $tableName, int $uid, int $pageId, ?array $recordData = null): array
     {
         $commandMap = [
             $tableName => [
@@ -302,7 +302,7 @@ class ActionService
      * @param array $recordData Additional record data to change when moving.
      * @return array
      */
-    public function moveRecord(string $tableName, int $uid, int $targetUid, array $recordData = null): array
+    public function moveRecord(string $tableName, int $uid, int $targetUid, ?array $recordData = null): array
     {
         $commandMap = [
             $tableName => [

--- a/Classes/Core/Functional/Framework/DataHandling/CsvWriterStreamFilter.php
+++ b/Classes/Core/Functional/Framework/DataHandling/CsvWriterStreamFilter.php
@@ -49,7 +49,7 @@ class CsvWriterStreamFilter extends \php_user_filter
      * @param resource $stream
      * @param string $sequence
      */
-    public static function apply($stream, string $sequence = null): \Closure
+    public static function apply($stream, ?string $sequence = null): \Closure
     {
         static::register();
         if ($sequence === null) {

--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -299,7 +299,7 @@ class DataSet
      * @param int|null $padding
      * @deprecated Will be removed with core v12 compatible testing-framework.
      */
-    public function persist(string $fileName, int $padding = null)
+    public function persist(string $fileName, ?int $padding = null)
     {
         $fileHandle = fopen($fileName, 'w');
         $modifier = CsvWriterStreamFilter::apply($fileHandle);
@@ -330,7 +330,7 @@ class DataSet
      * @return array
      * @deprecated Will be removed with core v12 compatible testing-framework.
      */
-    protected function pad(array $values, int $padding = null): array
+    protected function pad(array $values, ?int $padding = null): array
     {
         if ($padding === null) {
             return $values;

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
@@ -110,8 +110,8 @@ class DataHandlerFactory
      */
     private function processEntities(
         array $settings,
-        string $nodeId = null,
-        string $parentId = null
+        ?string $nodeId = null,
+        ?string $parentId = null
     ): void {
         foreach ($settings as $entityName => $entitySettings) {
             $entityConfiguration = $this->provideEntityConfiguration($entityName);
@@ -135,8 +135,8 @@ class DataHandlerFactory
     private function processEntityItem(
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
-        string $nodeId = null,
-        string $parentId = null
+        ?string $nodeId = null,
+        ?string $parentId = null
     ): void {
         $values = $this->processEntityValues(
             $entityConfiguration,
@@ -199,7 +199,7 @@ class DataHandlerFactory
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
         array $ancestorIds,
-        string $nodeId = null
+        ?string $nodeId = null
     ): void {
         $values = $this->processEntityValues(
             $entityConfiguration,
@@ -240,7 +240,7 @@ class DataHandlerFactory
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
         string $ancestorId,
-        string $nodeId = null
+        ?string $nodeId = null
     ): void {
         if (isset($itemSettings['self'])) {
             throw new \LogicException(
@@ -284,8 +284,8 @@ class DataHandlerFactory
     private function processEntityValues(
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
-        string $nodeId = null,
-        string $parentId = null
+        ?string $nodeId = null,
+        ?string $parentId = null
     ): array {
         if (isset($itemSettings['self']) && isset($itemSettings['version'])) {
             throw new \LogicException(

--- a/Classes/Core/Functional/Framework/Frontend/Collector.php
+++ b/Classes/Core/Functional/Framework/Frontend/Collector.php
@@ -52,7 +52,7 @@ class Collector implements SingletonInterface
      */
     public $cObj;
 
-    public function addRecordData($content, array $configuration = null): void
+    public function addRecordData($content, ?array $configuration = null): void
     {
         $recordIdentifier = $this->cObj->currentRecord;
         [$tableName] = explode(':', $recordIdentifier);
@@ -71,7 +71,7 @@ class Collector implements SingletonInterface
         }
     }
 
-    public function addFileData($content, array $configuration = null): void
+    public function addFileData($content, ?array $configuration = null): void
     {
         $currentFile = $this->cObj->getCurrentFile();
 
@@ -134,7 +134,7 @@ class Collector implements SingletonInterface
      * @param string $content
      * @param array|null $configuration
      */
-    public function attachSection($content, array $configuration = null): void
+    public function attachSection($content, ?array $configuration = null): void
     {
         $section = [
             'structure' => $this->structure,

--- a/Classes/Core/Functional/Framework/Frontend/Renderer.php
+++ b/Classes/Core/Functional/Framework/Frontend/Renderer.php
@@ -38,7 +38,7 @@ class Renderer implements SingletonInterface
      * @param string $content
      * @param array|null $configuration
      */
-    public function parseValues($content, array $configuration = null)
+    public function parseValues($content, ?array $configuration = null)
     {
         if (empty($content)) {
             return;
@@ -82,7 +82,7 @@ class Renderer implements SingletonInterface
      * @param string $content
      * @param array|null $configuration
      */
-    public function renderValues($content, array $configuration = null)
+    public function renderValues($content, ?array $configuration = null)
     {
         if (empty($configuration['values.'])) {
             return;
@@ -110,7 +110,7 @@ class Renderer implements SingletonInterface
      * @param array|null $configuration
      * @return string
      */
-    public function renderSections($content, array $configuration = null)
+    public function renderSections($content, ?array $configuration = null)
     {
         return json_encode($this->sections);
     }

--- a/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
+++ b/Classes/Core/Functional/Framework/Frontend/RequestBootstrap.php
@@ -58,7 +58,7 @@ class RequestBootstrap
      * @param string $documentRoot
      * @param array|null $this->requestArguments
      */
-    public function __construct(string $documentRoot, array $requestArguments = null)
+    public function __construct(string $documentRoot, ?array $requestArguments = null)
     {
         $this->documentRoot = $documentRoot;
         $this->requestArguments = $requestArguments;

--- a/Classes/Core/Functional/Framework/Frontend/ResponseContent.php
+++ b/Classes/Core/Functional/Framework/Frontend/ResponseContent.php
@@ -43,7 +43,7 @@ class ResponseContent
      */
     protected $scope = [];
 
-    public static function fromString(string $data, ResponseContent $target = null): ResponseContent
+    public static function fromString(string $data, ?ResponseContent $target = null): ResponseContent
     {
         $target = $target ?? new static();
         $content = json_decode($data, true);
@@ -65,7 +65,7 @@ class ResponseContent
     /**
      * @param Response $response (deprecated)
      */
-    final public function __construct(Response $response = null)
+    final public function __construct(?Response $response = null)
     {
         if ($response instanceof Response) {
             static::fromString($response->getContent(), $this);

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1117,7 +1117,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      */
     protected function executeFrontendSubRequest(
         InternalRequest $request,
-        InternalRequestContext $context = null,
+        ?InternalRequestContext $context = null,
         bool $followRedirects = false
     ): InternalResponse {
         if ($context === null) {
@@ -1285,7 +1285,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      */
     protected function executeFrontendRequest(
         InternalRequest $request,
-        InternalRequestContext $context = null,
+        ?InternalRequestContext $context = null,
         bool $followRedirects = false
     ): InternalResponse {
         if ($context === null) {


### PR DESCRIPTION
Implicit nullable method parameters are deprecated with PHP 8.4. The patch prepares affected method
signatures and activates an according php-cs-fixer rule.