### PR TITLE
[TASK] Streamline `Testbase->setUpTestDatabase()`

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -626,10 +626,14 @@ class Testbase
     public function setUpTestDatabase(string $databaseName, string $originalDatabaseName): void
     {
         // First close existing connections from a possible previous test case and
-        // tell our ConnectionPool there are no current connections anymore.
+        // tell our ConnectionPool there are no current connections anymore. In case
+        // database does not exist yet, an exception is thrown which we catch here.
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $connection = $connectionPool->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
-        $connection->close();
+        try {
+            $connection = $connectionPool->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+            $connection->close();
+        } catch (DBALException $_) {
+        }
         $connectionPool->resetConnections();
 
         // Drop database if exists. Directly using the Doctrine DriverManager to


### PR DESCRIPTION
The `Testbase->setUpTestDatabase()` takes care of
correct database setup for each test instance and
that the database is created. To accomplish that,
current TYPO3 connections are closed.

Doctrine DriverManager is used as lowlevel tool
to create the instance database.

In case that the database has not been created,
which occures on the first test execution per
test-case, an exception is thrown and disturbes
the `getDatabasePlatform <-> getServerVersion()`
detection with the Doctrine construct. That has
been mitigated by catching the exception within
`Connection->getServerVersion()` and returning
an empty string ending up retrieving at least a
the lowest default platform for the driver. That
was mainly a workaround in functional test runs.

Doctrine DBAL 3.9.x & 4.1.x will introduce a new
version based postgres platform class along with
a new exception, if the server version does not
match the version pattern - which is the case for
an emtpy string and not returning a PostgresSQL
platform anymore - failing to create the database.

This change catches the exception for non existing
database to prepare the removal of the connection
workaround in `Connection->getServerVersion()`, but
still ensures the ConnectionPool instances are closed.

Minor code cleanups within the method are applied
in the same run.
