### PR TITLE
[FEATURE] Support custom one-to-many relations inside fixtures

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
@@ -96,7 +96,8 @@ class DataHandlerFactory
     private function processEntities(
         array $settings,
         ?string $nodeId = null,
-        ?string $parentId = null
+        ?string $parentId = null,
+        ?EntityConfiguration $parentEntityConfiguration = null,
     ): void {
         foreach ($settings as $entityName => $entitySettings) {
             $entityConfiguration = $this->provideEntityConfiguration($entityName);
@@ -105,7 +106,8 @@ class DataHandlerFactory
                     $entityConfiguration,
                     $itemSettings,
                     $nodeId,
-                    $parentId
+                    $parentId,
+                    $parentEntityConfiguration
                 );
             }
         }
@@ -115,7 +117,8 @@ class DataHandlerFactory
         EntityConfiguration $entityConfiguration,
         array $itemSettings,
         ?string $nodeId = null,
-        ?string $parentId = null
+        ?string $parentId = null,
+        ?EntityConfiguration $parentEntityConfiguration = null,
     ): void {
         $values = $this->processEntityValues(
             $entityConfiguration,
@@ -158,8 +161,22 @@ class DataHandlerFactory
             $this->processEntities(
                 $itemSettings['entities'],
                 $newId,
-                $parentId
+                $parentId,
+                $entityConfiguration,
             );
+        }
+        if (
+            $parentEntityConfiguration instanceof EntityConfiguration &&
+            $entityConfiguration->getParentRelationColumnName() !== null &&
+            $entityConfiguration->getParentRelationColumnName() !== '') {
+            $existingValues = array_filter(
+                explode(
+                    ',',
+                    (string)($this->dataMapPerWorkspace[$workspaceId][$parentEntityConfiguration->getTableName()][$nodeId][$entityConfiguration->getParentRelationColumnName()] ?? '')
+                )
+            );
+            $existingValues[] = $newId;
+            $this->dataMapPerWorkspace[$workspaceId][$parentEntityConfiguration->getTableName()][$nodeId][$entityConfiguration->getParentRelationColumnName()] = implode(',', $existingValues);
         }
     }
 

--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/EntityConfiguration.php
@@ -25,6 +25,7 @@ class EntityConfiguration
     private bool $isNode = false;
     private ?string $tableName = null;
     private ?string $parentColumnName = null;
+    private ?string $parentRelationColumnName = null;
     private ?string $nodeColumnName = null;
     private array $columnNames = [];
     private array $languageColumnNames = [];
@@ -42,6 +43,9 @@ class EntityConfiguration
         }
         if (!empty($settings['parentColumnName'])) {
             $target->parentColumnName = $settings['parentColumnName'];
+        }
+        if (!empty($settings['parentRelationColumnName'])) {
+            $target->parentRelationColumnName = $settings['parentRelationColumnName'];
         }
         if (!empty($settings['nodeColumnName'])) {
             $target->nodeColumnName = $settings['nodeColumnName'];
@@ -84,6 +88,11 @@ class EntityConfiguration
     public function getParentColumnName(): ?string
     {
         return $this->parentColumnName;
+    }
+
+    public function getParentRelationColumnName(): ?string
+    {
+        return $this->parentRelationColumnName;
     }
 
     public function getNodeColumnName(): ?string


### PR DESCRIPTION
Summary:
Implement support to model custom relations of one-to-many relations inside fixture yamls by adding a new config field inside `entitySettings` for each table called `parentRelationColumnName`. When set, the data-array structure passed to the core `DataHandler` receives the relations like expected. The field needs to be set on a child record with the name of the parent record column name of the relation as its value.

Resolves #619