### PR TITLE
[TASK] composer req composer/class-map-generator:^1.3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   },
   "require": {
     "php": "^8.2",
+    "composer/class-map-generator": "^1.3.4",
     "guzzlehttp/psr7": "^2.5.0",
     "phpunit/phpunit": "^11.2.5",
     "psr/container": "^2.0",


### PR DESCRIPTION
TF needs this since core monorepo removed the copy of ClassMapGenerator with [1] for functional test
legacy instances of extensions.

> composer req composer/class-map-generator:^1.3.4

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/86184