### PR TITLE
[TASK] Explicitly provide all `fgetcsv()` arguments

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -31,8 +31,13 @@ parameters:
 			path: ../../Classes/Composer/ExtensionTestEnvironment.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<T of object\\> and '' will always evaluate to false\\.$#"
-			count: 2
+			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<T of object \\(method TYPO3\\\\TestingFramework\\\\Core\\\\BaseTestCase\\:\\:getAccessibleMock\\(\\), argument\\)\\> and '' will always evaluate to false\\.$#"
+			count: 1
+			path: ../../Classes/Core/BaseTestCase.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<T of object \\(method TYPO3\\\\TestingFramework\\\\Core\\\\BaseTestCase\\:\\:getAccessibleMockForAbstractClass\\(\\), argument\\)\\> and '' will always evaluate to false\\.$#"
+			count: 1
 			path: ../../Classes/Core/BaseTestCase.php
 
 		-

--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -63,7 +63,7 @@ class DataSet
             // BOM not found - rewind pointer to start of file.
             rewind($fileHandle);
         }
-        while (!feof($fileHandle) && ($values = fgetcsv($fileHandle, 0)) !== false) {
+        while (!feof($fileHandle) && ($values = fgetcsv($fileHandle, 0, ',', '"', '\\')) !== false) {
             $rawData[] = $values;
         }
         fclose($fileHandle);

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.4.0",
-    "phpstan/phpstan": "^1.8.0",
-    "phpstan/phpstan-phpunit": "^1.1.1",
+    "phpstan/phpstan": "^1.12.5",
+    "phpstan/phpstan-phpunit": "^1.4.0",
     "typo3/cms-workspaces": "10.*.*@dev || 11.*.*@dev"
   }
 }


### PR DESCRIPTION
With [1] the 5th parameter `$escape` of `fgetcsv()` must
be provided either positional or using named arguments or a
E_DEPRECATED will be emitted since `PHP 8.4.0 RC1` [2].

This change provide now all five parameter for `fgetcsv()`
calls and thus using the positional approach to allow easier
backporting to older TYPO3 version where named arguements are
not usable.

[1] https://github.com/php/php-src/pull/15569
[2] https://github.com/php/php-src/blob/ebee8df27ed/UPGRADING#L617-L622

Releases: main, 8, 7, 6
