### PR TITLE
[BUGFIX] Respect overridden properties in AbstractPageTree

### DIFF
--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -52,7 +52,7 @@ abstract class AbstractPageTree
         foreach ($path as $pageName) {
             $context = $this->ensureTreeNodeIsOpen($pageName, $context);
         }
-        $context->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(self::$treeItemAnchorSelector))->click();
+        $context->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(static::$treeItemAnchorSelector))->click();
     }
 
     /**
@@ -65,7 +65,7 @@ abstract class AbstractPageTree
         $I = $this->tester;
         $I->switchToIFrame();
         return $I->executeInSelenium(function (\Facebook\WebDriver\Remote\RemoteWebDriver $webdriver) {
-            return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(self::$pageTreeSelector));
+            return $webdriver->findElement(\Facebook\WebDriver\WebDriverBy::cssSelector(static::$pageTreeSelector));
         });
     }
 
@@ -79,7 +79,7 @@ abstract class AbstractPageTree
     protected function ensureTreeNodeIsOpen(string $nodeText, RemoteWebElement $context)
     {
         $I = $this->tester;
-        $I->see($nodeText, self::$treeItemSelector);
+        $I->see($nodeText, static::$treeItemSelector);
 
         /** @var RemoteWebElement $context */
         $context = $I->executeInSelenium(function () use (


### PR DESCRIPTION
This changes all property accesses within AbstractPageTree to use static instead of self. Since the class is abstract and therefore subject to class inheritance, its properties may also change in subclasses. Using self to access them would hide potentially overridden properties (late static binding).