### PR TITLE
[BUGFIX] Harden XPath query to limit search for page tree node

### DIFF
--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -86,7 +86,7 @@ abstract class AbstractPageTree
             $nodeText,
             $context
         ) {
-            return $context->findElement(\Facebook\WebDriver\WebDriverBy::xpath('//*[text()=\'' . $nodeText . '\']/..'));
+            return $context->findElement(\Facebook\WebDriver\WebDriverBy::xpath('.//following-sibling::*//*[text()=\'' . $nodeText . '\']/..'));
         });
 
         try {


### PR DESCRIPTION
Even if page tree nodes are queried from a given context node, the used XPath query searches for all elements in the document because of the `//` syntax. This may lead to possible test failures in case the queried node text appears multiple times in the document.

In order to avoid such behaviors and actually limit the XPath query to the given context, it is now prefixed with a dot (`.`). In addition, only following siblings of the current node are included since page tree nodes are presented as flat node structure. This way, the current context is now actually taken into account.