### PR TITLE
[TASK] composer req composer/class-map-generator:^1.3.4 (#621)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   },
   "require": {
     "php": "^8.1",
+    "composer/class-map-generator": "^1.3.4",
     "guzzlehttp/psr7": "^2.5.0",
     "phpunit/phpunit": "^10.1 || ^11.0",
     "psr/container": "^1.1.0 || ^2.0.0",


### PR DESCRIPTION
This has been merged to dev-main (to be TF 9) already. TF 8 needs this change to keep core v13 compat.

TF needs this since core monorepo removed the copy of ClassMapGenerator with [1] for functional test
legacy instances of extensions.

> composer req composer/class-map-generator:^1.3.4

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/86184