### PR TITLE
[BUGFIX] Ensure correct path calculation on system build

### DIFF
--- a/Classes/Core/SystemEnvironmentBuilder.php
+++ b/Classes/Core/SystemEnvironmentBuilder.php
@@ -40,13 +40,16 @@ use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder as CoreSystemEnvironmentBuilder
  */
 class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
 {
-    public static function run(int $entryPointLevel = 0, int $requestType = 0, bool $composerMode = false): void
+    private static ?bool $composerMode = null;
+
+    public static function run(int $entryPointLevel = 0, int $requestType = 0, ?bool $composerMode = null): void
     {
-        CoreSystemEnvironmentBuilder::run($entryPointLevel, $requestType);
+        self::$composerMode = $composerMode;
+        parent::run($entryPointLevel, $requestType);
         Environment::initialize(
             Environment::getContext(),
             Environment::isCli(),
-            $composerMode,
+            static::usesComposerClassLoading(),
             Environment::getProjectPath(),
             Environment::getPublicPath(),
             Environment::getVarPath(),
@@ -54,5 +57,17 @@ class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
             Environment::getCurrentScript(),
             Environment::isWindows() ? 'WINDOWS' : 'UNIX'
         );
+    }
+
+    /**
+     * Manage composer mode separated from TYPO3_COMPOSER_MODE define set by typo3/cms-composer-installers.
+     *
+     * Note that this will not with earlier TYPO3 versions than 13.4.
+     * @link https://review.typo3.org/c/Packages/TYPO3.CMS/+/86569
+     * @link https://github.com/TYPO3/testing-framework/issues/577
+     */
+    protected static function usesComposerClassLoading(): bool
+    {
+        return self::$composerMode ?? parent::usesComposerClassLoading();
     }
 }


### PR DESCRIPTION
TYPO3 core `SystemEnvironmentBuilder` has been implement
normal TYPO3 usages in mind respecting possible instance
setup scenarios, to build low level system environment
before taking configuration into account.

Path calculations are based on different indicators,
for example if TYPO3 is used in composer mode based
on the PHP define() TYPO3_COMPOSER_MODE set during
by the `typo3/cms-composer-installers` composer plugin
during `composer install` actions.

Per nature, PHP defines are immutable and cannot be
changed anymore during runtime.

As `typo3/testing-framework` is only installabe using
composer the TYPO3_COMPOSER_MODE define is always set
but is invalid for functional test instances build in
legacy mode and making invalid path calculations.
That was hidden quite some time now, and is related to
a chain of changes over a very long period of time and
finally popped up in early TYPO3 v13 development after
introducing the configurable backend url feature.

Functional tests building relative url for resources
or links could run into the issue not retrieving the
leading slash anymore due to path calculation errrors,
leading to follup issues in `NormalizedParams` create
method when using frontend requests.

Eventually more developers run into that issue, but
simply adjusted the test expectation instead analyzing
the root of the curse and thus not reported it, which
has been done recenently.

To fix this issue changes on two fronts have to be made,
in the TYPO3 core `SystemEnvironmentBuilder` [1] and
in the testing-framework implementation.

Note that only both changes together solves this issue,
as the testing-framework change alone would not be
executed due to using `self` for static method calls
in the TYPO3 implementation.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/86569

Resolves: #577
Releases: main, 8
