### PR TITLE
[BUGFIX] Add missing parameter for `SystemEnvironmentBuilder::run()` call

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -699,7 +699,7 @@ class Testbase
         GeneralUtility::purgeInstances();
 
         $classLoader = require $this->getPackagesPath() . '/autoload.php';
-        SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_CLI);
+        SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_CLI, false);
         $container = Bootstrap::init($classLoader);
         // Make sure output is not buffered, so command-line output can take place and
         // phpunit does not whine about changed output bufferings in tests.


### PR DESCRIPTION
Related: #577
Releases: main
