### PR TITLE
[TASK] Collection of backports

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -20,3 +20,5 @@ parameters:
     - ../../Classes/Core/Acceptance/*
     # Text fixtures extensions uses $_EXTKEY phpstan would be report as "might not defined"
     - ../../Tests/Unit/*/Fixtures/Extensions/*/ext_emconf.php
+    - ../../Tests/Unit/*/Fixtures/Packages/*/ext_emconf.php
+    - ../../Tests/Unit/Fixtures/Packages/*/ext_emconf.php

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -61,6 +61,7 @@ final class ComposerPackageManager
 
     public function __construct()
     {
+        // @todo Remove this from the constructor.
         $this->build();
     }
 
@@ -545,10 +546,19 @@ final class ComposerPackageManager
         ?array $info = null,
         ?array $extEmConf = null
     ): string {
-        $isExtension = in_array($info['type'] ?? '', ['typo3-cms-framework', 'typo3-cms-extension'], true)
-            || ($extEmConf !== null);
-        if (!$isExtension) {
+        $isComposerExtensionType = ($info !== null && array_key_exists('type', $info) && is_string($info['type']) && in_array($info['type'], ['typo3-cms-framework', 'typo3-cms-extension'], true));
+        $hasExtEmConf = $extEmConf !== null;
+        if (!($isComposerExtensionType || $hasExtEmConf)) {
             return '';
+        }
+        $hasComposerExtensionKey = (
+            is_array($info)
+            && isset($info['extra']['typo3/cms']['extension-key'])
+            && is_string($info['extra']['typo3/cms']['extension-key'])
+            && $info['extra']['typo3/cms']['extension-key'] !== ''
+        );
+        if ($hasComposerExtensionKey) {
+            return $info['extra']['typo3/cms']['extension-key'];
         }
         $baseName = basename($packagePath);
         if (($info['type'] ?? '') === 'typo3-csm-framework'

--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -21,6 +21,7 @@ use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Extension;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
 use TYPO3\TestingFramework\Core\Testbase;
@@ -261,8 +262,15 @@ abstract class BackendEnvironment extends Extension
             $testbase->testDatabaseNameIsNotTooLong($originalDatabaseName, $localConfiguration);
             if ($dbDriver === 'mysqli' || $dbDriver === 'pdo_mysql') {
                 $localConfiguration['DB']['Connections']['Default']['charset'] = 'utf8mb4';
-                $localConfiguration['DB']['Connections']['Default']['tableoptions']['charset'] = 'utf8mb4';
-                $localConfiguration['DB']['Connections']['Default']['tableoptions']['collate'] = 'utf8mb4_unicode_ci';
+                if ((new Typo3Version())->getMajorVersion() >= 12) {
+                    // @todo Use this as default when TYPO3 v11 support is dropped.
+                    $localConfiguration['DB']['Connections']['Default']['defaultTableOptions']['charset'] = 'utf8mb4';
+                    $localConfiguration['DB']['Connections']['Default']['defaultTableOptions']['collation'] = 'utf8mb4_unicode_ci';
+                } else {
+                    // @todo Remove this when TYPO3 v11 support is dropped.
+                    $localConfiguration['DB']['Connections']['Default']['tableoptions']['charset'] = 'utf8mb4';
+                    $localConfiguration['DB']['Connections']['Default']['tableoptions']['collate'] = 'utf8mb4_unicode_ci';
+                }
             }
         } else {
             // sqlite dbs of all tests are stored in a dir parallel to instance roots. Allows defining this path as tmpfs.

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -111,6 +111,23 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      *
      * A default list of core extensions is always loaded.
      *
+     * System extension can be provided by their extension key or composer package name,
+     * and also as classic mode relative path
+     *
+     * ```
+     * protected array $coreExensionToLoad = [
+     *   // As composer package name
+     *   'typo3/cms-core',
+     *   // As extension-key
+     *   'core',
+     *   // As relative classic mode system installation path
+     *   'typo3/sysext/core',
+     * ];
+     * ```
+     *
+     * Note that system extensions must be available, which means either added as require or
+     * require-dev to the root composer.json or required and installed by a required package.
+     *
      * @see FunctionalTestCaseUtility $defaultActivatedCoreExtensions
      *
      * @var non-empty-string[]
@@ -121,16 +138,32 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * Array of test/fixture extensions paths that should be loaded for a test.
      *
      * This property will stay empty in this abstract, so it is possible
-     * to just overwrite it in extending classes. Extensions noted here will
-     * be loaded for every test of a test case, and it is not possible to change
-     * the list of loaded extensions between single tests of a test case.
+     * to just overwrite it in extending classes.
+     *
+     * IMPORTANT:   Extension list is concrete and used to create the test instance on first
+     *              test execution and is **NOT** changeable between single test permutations.
      *
      * Given path is expected to be relative to your document root, example:
      *
-     * array(
-     *   'typo3conf/ext/some_extension/Tests/Functional/Fixtures/Extensions/test_extension',
+     * ```
+     * protected array $testExtensionToLoad = [
+     *
+     *   // Virtual relative classic mode installation path
      *   'typo3conf/ext/base_extension',
-     * );
+     *
+     *   // Virtual relative classic mode installation path subfolder test fixture
+     *   'typo3conf/ext/some_extension/Tests/Functional/Fixtures/Extensions/test_extension',
+     *
+     *   // Relative to current test case (recommended for test fixture extension)
+     *   __DIR__ . '/../Fixtures/Extensions/another_test_extension',
+     *
+     *   // composer package name when available as `require` or `require-dev` in root composer.json
+     *   'vendor/some-extension',
+     *
+     *   // extension key when available as package loaded as `require` or `require-dev` in root composer.json
+     *   'my_extension_key',
+     * ];
+     * ```
      *
      * Extensions in this array are linked to the test instance, loaded
      * and their ext_tables.sql will be applied.
@@ -147,18 +180,22 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * be linked for every test of a test case, and it is not possible to change
      * the list of folders between single tests of a test case.
      *
-     * array(
+     * ```
+     * protected array $pathsToLinkInTestInstance = [
      *   'link-source' => 'link-destination'
-     * );
+     * ];
+     * ```
      *
      * Given paths are expected to be relative to the test instance root.
      * The array keys are the source paths and the array values are the destination
      * paths, example:
      *
-     * [
+     * ```
+     * protected array $pathsToLinkInTestInstance = [
      *   'typo3/sysext/impext/Tests/Functional/Fixtures/Folders/fileadmin/user_upload' =>
      *   'fileadmin/user_upload',
-     * ]
+     * ];
+     * ```
      *
      * To be able to link from my_own_ext the extension path needs also to be registered in
      * property $testExtensionsToLoad
@@ -172,12 +209,14 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * paths are really duplicated and provided in the instance - instead of
      * using symbolic links. Examples:
      *
-     * [
+     * ```
+     * protected array $pathsToProvideInTestInstance = [
      *   // Copy an entire directory recursive to fileadmin
      *   'typo3/sysext/lowlevel/Tests/Functional/Fixtures/testImages/' => 'fileadmin/',
      *   // Copy a single file into some deep destination directory
      *   'typo3/sysext/lowlevel/Tests/Functional/Fixtures/testImage/someImage.jpg' => 'fileadmin/_processed_/0/a/someImage.jpg',
-     * ]
+     * ];
+     * ```
      *
      * @var array<string, non-empty-string>
      */
@@ -208,9 +247,11 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
      * To create additional folders add the paths to this array. Given paths are expected to be
      * relative to the test instance root and have to begin with a slash. Example:
      *
-     * [
+     * ```
+     * protected array $additionalFoldersToCreate = [
      *   'fileadmin/user_upload'
-     * ]
+     * ];
+     * ```
      *
      * @var non-empty-string[]
      */

--- a/Classes/Core/SystemEnvironmentBuilder.php
+++ b/Classes/Core/SystemEnvironmentBuilder.php
@@ -40,16 +40,19 @@ use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder as CoreSystemEnvironmentBuilder
  */
 class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
 {
+    private static ?bool $composerMode = null;
+
     /**
      * @todo: Change default $requestType to 0 when dropping support for TYPO3 v12
      */
-    public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE, bool $composerMode = false)
+    public static function run(int $entryPointLevel = 0, int $requestType = CoreSystemEnvironmentBuilder::REQUESTTYPE_FE, ?bool $composerMode = null): void
     {
-        CoreSystemEnvironmentBuilder::run($entryPointLevel, $requestType);
+        self::$composerMode = $composerMode;
+        parent::run($entryPointLevel, $requestType);
         Environment::initialize(
             Environment::getContext(),
             Environment::isCli(),
-            $composerMode,
+            static::usesComposerClassLoading(),
             Environment::getProjectPath(),
             Environment::getPublicPath(),
             Environment::getVarPath(),
@@ -57,5 +60,17 @@ class SystemEnvironmentBuilder extends CoreSystemEnvironmentBuilder
             Environment::getCurrentScript(),
             Environment::isWindows() ? 'WINDOWS' : 'UNIX'
         );
+    }
+
+    /**
+     * Manage composer mode separated from TYPO3_COMPOSER_MODE define set by typo3/cms-composer-installers.
+     *
+     * Note that this will not with earlier TYPO3 versions than 13.4.
+     * @link https://review.typo3.org/c/Packages/TYPO3.CMS/+/86569
+     * @link https://github.com/TYPO3/testing-framework/issues/577
+     */
+    protected static function usesComposerClassLoading(): bool
+    {
+        return self::$composerMode ?? parent::usesComposerClassLoading();
     }
 }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -745,7 +745,7 @@ class Testbase
         $classLoader = require $this->getPackagesPath() . '/autoload.php';
         // @todo: Remove else branch when dropping support for v12
         if ($hasConsolidatedHttpEntryPoint) {
-            SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_CLI);
+            SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_CLI, false);
         } else {
             SystemEnvironmentBuilder::run(1, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);
         }

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -473,7 +473,7 @@ class Testbase
                 $originalConfigurationArray['DB']['Connections']['Default']['password'] = $databasePasswordTrimmed;
             }
             if ($databasePort) {
-                $originalConfigurationArray['DB']['Connections']['Default']['port'] = $databasePort;
+                $originalConfigurationArray['DB']['Connections']['Default']['port'] = (int)$databasePort;
             }
             if ($databaseSocket) {
                 $originalConfigurationArray['DB']['Connections']['Default']['unix_socket'] = $databaseSocket;

--- a/Resources/Core/Functional/Extensions/json_response/composer.json
+++ b/Resources/Core/Functional/Extensions/json_response/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "typo3/testing-json-response",
+    "type": "typo3-cms-extension",
+    "description": "Providing testing framework extension for functional testing.",
+    "keywords": [
+        "typo3",
+        "testing",
+        "tests"
+    ],
+    "homepage": "https://typo3.org/",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "TYPO3 CMS Core Team",
+            "role": "Developer",
+            "homepage": "https://forge.typo3.org/projects/typo3cms-core"
+        },
+        {
+            "name": "The TYPO3 Community",
+            "role": "Contributor",
+            "homepage": "https://typo3.org/community/"
+        }
+    ],
+    "support": {
+        "general": "https://typo3.org/support/",
+        "issues": "https://github.com/TYPO3/testing-framework/issues"
+    },
+    "require": {
+        "php": "^8.1",
+        "typo3/cms-core": "12.*.*@dev || 13.*.*@dev"
+    },
+    "autoload": {
+        "psr-4": {
+            "TYPO3\\JsonResponse\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "json_response"
+        }
+    }
+}

--- a/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
@@ -4,14 +4,14 @@ $EM_CONF[$_EXTKEY] = [
     'title' => 'JSON Response',
     'description' => 'JSON Response',
     'category' => 'example',
-    'version' => '9.4.0',
+    'version' => '1.0.0',
     'state' => 'beta',
     'author' => 'Oliver Hader',
     'author_email' => 'oliver@typo3.org',
     'author_company' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.4.0',
+            'typo3' => '12.0.0 - 13.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/Resources/Core/Functional/Extensions/private_container/composer.json
+++ b/Resources/Core/Functional/Extensions/private_container/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "typo3/testing-private-container",
+    "type": "typo3-cms-extension",
+    "description": "Providing testing framework extension for functional testing.",
+    "keywords": [
+        "typo3",
+        "testing",
+        "tests"
+    ],
+    "homepage": "https://typo3.org/",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "TYPO3 CMS Core Team",
+            "role": "Developer",
+            "homepage": "https://forge.typo3.org/projects/typo3cms-core"
+        },
+        {
+            "name": "The TYPO3 Community",
+            "role": "Contributor",
+            "homepage": "https://typo3.org/community/"
+        }
+    ],
+    "support": {
+        "general": "https://typo3.org/support/",
+        "issues": "https://github.com/TYPO3/testing-framework/issues"
+    },
+    "require": {
+        "php": "^8.1",
+        "typo3/cms-core": "12.*.*@dev || 13.*.*@dev"
+    },
+    "autoload": {
+        "psr-4": {
+            "TYPO3\\PrivateContainer\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "private_container"
+        }
+    }
+}

--- a/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.0.0-12.99.99',
+            'typo3' => '12.0.0-13.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -201,8 +201,15 @@ final class ComposerPackageManagerTest extends UnitTestCase
     public function extensionWithoutJsonCanBeResolvedByAbsolutePath(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $packageInfo = $subject->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Extensions/ext_without_composerjson_absolute');
 
+        // Extension without composer.json registers basefolder as extension key
+        self::assertArrayHasKey('ext_without_composerjson_absolute', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('unknown-vendor/ext-without-composerjson-absolute', $extensionMapPropertyReflection->getValue($subject)['ext_without_composerjson_absolute']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('ext_without_composerjson_absolute', $packageInfo->getExtensionKey());
         self::assertSame('unknown-vendor/ext-without-composerjson-absolute', $packageInfo->getName());
@@ -215,8 +222,15 @@ final class ComposerPackageManagerTest extends UnitTestCase
     public function extensionWithoutJsonCanBeResolvedRelativeFromRoot(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $packageInfo = $subject->getPackageInfoWithFallback('Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_relativefromroot');
 
+        // Extension without composer.json registers basefolder as extension key
+        self::assertArrayHasKey('ext_without_composerjson_relativefromroot', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('unknown-vendor/ext-without-composerjson-relativefromroot', $extensionMapPropertyReflection->getValue($subject)['ext_without_composerjson_relativefromroot']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('ext_without_composerjson_relativefromroot', $packageInfo->getExtensionKey());
         self::assertSame('unknown-vendor/ext-without-composerjson-relativefromroot', $packageInfo->getName());
@@ -229,22 +243,40 @@ final class ComposerPackageManagerTest extends UnitTestCase
     public function extensionWithoutJsonCanBeResolvedByLegacyPath(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $packageInfo = $subject->getPackageInfoWithFallback('typo3conf/ext/testing_framework/Tests/Unit/Composer/Fixtures/Extensions/ext_without_composerjson_fallbackroot');
 
+        // Extension without composer.json registers basefolder as extension key
+        self::assertArrayHasKey('ext_without_composerjson_fallbackroot', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('unknown-vendor/ext-without-composerjson-fallbackroot', $extensionMapPropertyReflection->getValue($subject)['ext_without_composerjson_fallbackroot']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('ext_without_composerjson_fallbackroot', $packageInfo->getExtensionKey());
         self::assertSame('unknown-vendor/ext-without-composerjson-fallbackroot', $packageInfo->getName());
         self::assertSame('typo3-cms-extension', $packageInfo->getType());
         self::assertNull($packageInfo->getInfo());
         self::assertNotNull($packageInfo->getExtEmConf());
+
     }
 
     #[Test]
     public function extensionWithJsonCanBeResolvedByAbsolutePath(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $packageInfo = $subject->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Extensions/ext_absolute');
 
+        // Extension with composer.json and extension key does not register basepath as extension key
+        self::assertArrayNotHasKey('ext_absolute', $extensionMapPropertyReflection->getValue($subject));
+
+        // Extension with composer.json and extension key register extension key as composer package alias
+        self::assertArrayHasKey('absolute_real', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('testing-framework/extension-absolute', $extensionMapPropertyReflection->getValue($subject)['absolute_real']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('absolute_real', $packageInfo->getExtensionKey());
         self::assertSame('testing-framework/extension-absolute', $packageInfo->getName());
@@ -257,8 +289,18 @@ final class ComposerPackageManagerTest extends UnitTestCase
     public function extensionWithJsonCanBeResolvedRelativeFromRoot(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $packageInfo = $subject->getPackageInfoWithFallback('Tests/Unit/Composer/Fixtures/Extensions/ext_relativefromroot');
 
+        // Extension with composer.json and extension key does not register basepath as extension key
+        self::assertArrayNotHasKey('ext_relativefromroot', $extensionMapPropertyReflection->getValue($subject));
+
+        // Extension with composer.json and extension key register extension key as composer package alias
+        self::assertArrayHasKey('relativefromroot_real', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('testing-framework/extension-relativefromroot', $extensionMapPropertyReflection->getValue($subject)['relativefromroot_real']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('relativefromroot_real', $packageInfo->getExtensionKey());
         self::assertSame('testing-framework/extension-relativefromroot', $packageInfo->getName());
@@ -271,8 +313,18 @@ final class ComposerPackageManagerTest extends UnitTestCase
     public function extensionWithJsonCanBeResolvedByLegacyPath(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $packageInfo = $subject->getPackageInfoWithFallback('typo3conf/ext/testing_framework/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot');
 
+        // Extension with composer.json and extension key does not register basepath as extension key
+        self::assertArrayNotHasKey('ext_fallbackroot', $extensionMapPropertyReflection->getValue($subject));
+
+        // Extension with composer.json and extension key register extension key as composer package alias
+        self::assertArrayHasKey('fallbackroot_real', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('testing-framework/extension-fallbackroot', $extensionMapPropertyReflection->getValue($subject)['fallbackroot_real']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('fallbackroot_real', $packageInfo->getExtensionKey());
         self::assertSame('testing-framework/extension-fallbackroot', $packageInfo->getName());
@@ -285,9 +337,19 @@ final class ComposerPackageManagerTest extends UnitTestCase
     public function extensionWithJsonCanBeResolvedByRelativeLegacyPath(): void
     {
         $subject = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($subject, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($subject));
         $projectFolderName = basename($subject->getRootPath());
         $packageInfo = $subject->getPackageInfoWithFallback('../' . $projectFolderName . '/typo3conf/ext/testing_framework/Tests/Unit/Composer/Fixtures/Extensions/ext_fallbackroot');
 
+        // Extension with composer.json and extension key does not register basepath as extension key
+        self::assertArrayNotHasKey('ext_fallbackroot', $extensionMapPropertyReflection->getValue($subject));
+
+        // Extension with composer.json and extension key register extension key as composer package alias
+        self::assertArrayHasKey('fallbackroot_real', $extensionMapPropertyReflection->getValue($subject));
+        self::assertSame('testing-framework/extension-fallbackroot', $extensionMapPropertyReflection->getValue($subject)['fallbackroot_real']);
+
+        // Verify package info
         self::assertInstanceOf(PackageInfo::class, $packageInfo);
         self::assertSame('fallbackroot_real', $packageInfo->getExtensionKey());
         self::assertSame('testing-framework/extension-fallbackroot', $packageInfo->getName());
@@ -357,5 +419,200 @@ final class ComposerPackageManagerTest extends UnitTestCase
         self::assertFalse($packageInfo->isMonoRepository(), 'Package is not mono repository root');
         self::assertSame($expectedPackageName, $packageInfo->getName());
         self::assertSame($expectedExtensionKey, $packageInfo->getExtensionKey());
+    }
+
+    public static function prepareResolvePackageNameReturnsExpectedValuesDataProvider(): \Generator
+    {
+        yield 'Composer package name returns unchanged (not checked for existence)' => [
+            'name' => 'typo3/cms-core',
+            'expected' => 'typo3/cms-core',
+        ];
+        yield 'Extension key returns unchanged (not checked for existence)' => [
+            'name' => 'core',
+            'expected' => 'core',
+        ];
+        yield 'Classic mode system path returns extension key (not checked for existence)' => [
+            'name' => 'typo3/sysext/core',
+            'expected' => 'core',
+        ];
+        yield 'Classic mode extension path returns extension key (not checked for existence)' => [
+            'name' => 'typo3conf/ext/some_ext',
+            'expected' => 'some_ext',
+        ];
+        yield 'Not existing full path to classic system extension path resolves to extension key (not checked for existence)' => [
+            'name' => 'ROOT:/typo3/sysext/core',
+            'expected' => 'core',
+        ];
+        yield 'Not existing full path to classic extension path resolves to extension key (not checked for existence)' => [
+            'name' => 'ROOT:/typo3conf/ext/some_ext',
+            'expected' => 'some_ext',
+        ];
+        yield 'Vendor path returns vendor with package subfolder' => [
+            'name' => 'VENDOR:/typo3/cms-core',
+            'expected' => 'typo3/cms-core',
+        ];
+    }
+
+    #[DataProvider('prepareResolvePackageNameReturnsExpectedValuesDataProvider')]
+    #[Test]
+    public function prepareResolvePackageNameReturnsExpectedValues(string $name, string $expected): void
+    {
+        $composerPackageManager = new ComposerPackageManager();
+        $replaceMap = [
+            'ROOT:/' => rtrim($composerPackageManager->getRootPath(), '/') . '/',
+            'VENDOR:/' => rtrim($composerPackageManager->getVendorPath(), '/') . '/',
+        ];
+        $name = str_replace(array_keys($replaceMap), array_values($replaceMap), $name);
+        foreach (array_keys($replaceMap) as $replaceKey) {
+            self::assertStringNotContainsString($replaceKey, $name, 'Key "%s" is replaced in name "%s"');
+        }
+        $prepareResolvePackageNameReflectionMethod = new \ReflectionMethod($composerPackageManager, 'prepareResolvePackageName');
+        $resolved = $prepareResolvePackageNameReflectionMethod->invoke($composerPackageManager, $name);
+        self::assertSame($expected, $resolved, sprintf('"%s" resolved to "%s"', $name, $expected));
+    }
+
+    public static function resolvePackageNameReturnsExpectedPackageNameDataProvider(): \Generator
+    {
+        yield 'Composer package name returns unchanged (not checked for existence)' => [
+            'name' => 'typo3/cms-core',
+            'expected' => 'typo3/cms-core',
+        ];
+        yield 'Extension key returns unchanged (not checked for existence)' => [
+            'name' => 'core',
+            'expected' => 'typo3/cms-core',
+        ];
+        yield 'Classic mode system path returns extension key (not checked for existence)' => [
+            'name' => 'typo3/sysext/core',
+            'expected' => 'typo3/cms-core',
+        ];
+        yield 'Not existing full path to classic system extension path resolves to extension key (not checked for existence)' => [
+            'name' => 'ROOT:/typo3/sysext/core',
+            'expected' => 'typo3/cms-core',
+        ];
+        yield 'Vendor path returns vendor with package subfolder' => [
+            'name' => 'VENDOR:/typo3/cms-core',
+            'expected' => 'typo3/cms-core',
+        ];
+        // Not loaded/known extension resolves only extension key and not to a composer package name.
+        yield 'Not existing full path to classic extension path resolves to extension key for unknown extension' => [
+            'name' => 'ROOT:/typo3conf/ext/some_ext',
+            'expected' => 'some_ext',
+        ];
+        // Not loaded/known extension resolves only extension key and not to a composer package name.
+        yield 'Classic mode extension path returns extension key for unknown extension' => [
+            'name' => 'typo3conf/ext/some_ext',
+            'expected' => 'some_ext',
+        ];
+    }
+
+    #[DataProvider('resolvePackageNameReturnsExpectedPackageNameDataProvider')]
+    #[Test]
+    public function resolvePackageNameReturnsExpectedPackageName(string $name, string $expected): void
+    {
+        $composerPackageManager = new ComposerPackageManager();
+        $replaceMap = [
+            'ROOT:/' => rtrim($composerPackageManager->getRootPath(), '/') . '/',
+            'VENDOR:/' => rtrim($composerPackageManager->getVendorPath(), '/') . '/',
+        ];
+        $name = str_replace(array_keys($replaceMap), array_values($replaceMap), $name);
+        foreach (array_keys($replaceMap) as $replaceKey) {
+            self::assertStringNotContainsString($replaceKey, $name, 'Key "%s" is replaced in name "%s"');
+        }
+        $resolvePackageNameReflectionMethod = new \ReflectionMethod($composerPackageManager, 'resolvePackageName');
+        $resolved = $resolvePackageNameReflectionMethod->invoke($composerPackageManager, $name);
+        self::assertSame($expected, $resolved, sprintf('"%s" resolved to "%s"', $name, $expected));
+    }
+
+    #[Test]
+    public function ensureEndingComposerPackageNameAndTypoExtensionPackageExtensionKeyResolvesCorrectPackage(): void
+    {
+        $composerManager = new ComposerPackageManager();
+        $extensionMapPropertyReflection = new \ReflectionProperty($composerManager, 'extensionKeyToPackageNameMap');
+        self::assertIsArray($extensionMapPropertyReflection->getValue($composerManager));
+
+        // verify initial composer package information
+        $initComposerPackage = $composerManager->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Packages/sharedextensionkey');
+        self::assertArrayNotHasKey('sharedextensionkey', $extensionMapPropertyReflection->getValue($composerManager));
+        self::assertInstanceOf(PackageInfo::class, $initComposerPackage);
+        self::assertSame('testing-framework/sharedextensionkey', $initComposerPackage->getName(), 'PackageInfo->name is "testing-framework/sharedextensionkey"');
+        self::assertFalse($initComposerPackage->isSystemExtension(), '"testing-framework/sharedextensionkey" is not a TYPO3 system extension');
+        self::assertFalse($initComposerPackage->isExtension(), '"testing-framework/sharedextensionkey" is not a TYPO3 extension');
+        self::assertTrue($initComposerPackage->isComposerPackage(), '"testing-framework/sharedextensionkey" is a composer package');
+        self::assertSame('', $initComposerPackage->getExtensionKey());
+
+        // verify initial extension package information
+        $initExtensionPackage = $composerManager->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Extensions/extension-key-shared-with-composer-package');
+        self::assertArrayHasKey('sharedextensionkey', $extensionMapPropertyReflection->getValue($composerManager));
+        self::assertSame('testing-framework/extension-key-shared-with-composer-package', $extensionMapPropertyReflection->getValue($composerManager)['sharedextensionkey']);
+        self::assertInstanceOf(PackageInfo::class, $initExtensionPackage);
+        self::assertSame('testing-framework/extension-key-shared-with-composer-package', $initExtensionPackage->getName(), 'PackageInfo->name is "testing-framework/extension-key-shared-with-composer-package"');
+        self::assertFalse($initExtensionPackage->isSystemExtension(), '"testing-framework/extension-key-shared-with-composer-package" is not a TYPO3 system extension');
+        self::assertTrue($initExtensionPackage->isExtension(), '"testing-framework/extension-key-shared-with-composer-package" is not a TYPO3 extension');
+        self::assertTrue($initExtensionPackage->isComposerPackage(), '"testing-framework/extension-key-shared-with-composer-package" is a composer package');
+        self::assertSame('sharedextensionkey', $initExtensionPackage->getExtensionKey());
+
+        // verify shared extension key retrieval returns the extension package
+        $extensionPackage = $composerManager->getPackageInfo('sharedextensionkey');
+        self::assertInstanceOf(PackageInfo::class, $extensionPackage);
+        self::assertSame('testing-framework/extension-key-shared-with-composer-package', $extensionPackage->getName(), 'PackageInfo->name is "testing-framework/extension-key-shared-with-composer-package"');
+        self::assertFalse($extensionPackage->isSystemExtension(), '"testing-framework/extension-key-shared-with-composer-package" is not a TYPO3 system extension');
+        self::assertTrue($extensionPackage->isExtension(), '"testing-framework/extension-key-shared-with-composer-package" is not a TYPO3 extension');
+        self::assertTrue($extensionPackage->isComposerPackage(), '"testing-framework/extension-key-shared-with-composer-package" is a composer package');
+        self::assertSame('sharedextensionkey', $extensionPackage->getExtensionKey());
+
+        // verify shared extension key with classic mode prefix retrieval returns the extension package
+        $classicModeExtensionPackage = $composerManager->getPackageInfo('typo3conf/ext/sharedextensionkey');
+        self::assertInstanceOf(PackageInfo::class, $classicModeExtensionPackage);
+        self::assertSame('testing-framework/extension-key-shared-with-composer-package', $classicModeExtensionPackage->getName(), 'PackageInfo->name is "testing-framework/extension-key-shared-with-composer-package"');
+        self::assertFalse($classicModeExtensionPackage->isSystemExtension(), '"testing-framework/extension-key-shared-with-composer-package" is not a TYPO3 system extension');
+        self::assertTrue($classicModeExtensionPackage->isExtension(), '"testing-framework/extension-key-shared-with-composer-package" is not a TYPO3 extension');
+        self::assertTrue($classicModeExtensionPackage->isComposerPackage(), '"testing-framework/extension-key-shared-with-composer-package" is a composer package');
+        self::assertSame('sharedextensionkey', $classicModeExtensionPackage->getExtensionKey());
+    }
+
+    /**
+     * @todo Remove this when fluid/standalone fluid is no longer available by default due to core dependencies.
+     * {@see ensureEndingComposerPackageNameAndTypoExtensionPackageExtensionKeyResolvesCorrectPackage}
+     */
+    #[Test]
+    public function ensureStandaloneFluidDoesNotBreakCoreFluidExtension(): void
+    {
+        $composerManager = new ComposerPackageManager();
+
+        // Verify standalone fluid composer package
+        $standaloneFluid = $composerManager->getPackageInfo('typo3fluid/fluid');
+        self::assertInstanceOf(PackageInfo::class, $standaloneFluid);
+        self::assertSame('typo3fluid/fluid', $standaloneFluid->getName(), 'PackageInfo->name is not "typo3fluid/fluid"');
+        self::assertFalse($standaloneFluid->isSystemExtension(), '"typo3fluid/fluid" is not a TYPO3 system extension');
+        self::assertFalse($standaloneFluid->isExtension(), '"typo3fluid/fluid" is not a TYPO3 extension');
+        self::assertTrue($standaloneFluid->isComposerPackage(), '"typo3fluid/fluid" is a composer package');
+        self::assertSame('', $standaloneFluid->getExtensionKey());
+
+        // Verify TYPO3 system extension fluid.
+        $coreFluid = $composerManager->getPackageInfo('typo3/cms-fluid');
+        self::assertInstanceOf(PackageInfo::class, $coreFluid);
+        self::assertSame('typo3/cms-fluid', $coreFluid->getName(), 'PackageInfo->name is not "typo3/cms-fluid"');
+        self::assertTrue($coreFluid->isSystemExtension(), '"typo3/cms-fluid" is a TYPO3 system extension');
+        self::assertFalse($coreFluid->isExtension(), '"typo3/cms-fluid" is not a TYPO3 extension');
+        self::assertTrue($coreFluid->isComposerPackage(), '"typo3/cms-fluid" is a composer package');
+        self::assertSame('fluid', $coreFluid->getExtensionKey());
+
+        // Verify TYPO3 system extension fluid resolved using extension key.
+        $extensionKeyRetrievesCoreFluid = $composerManager->getPackageInfo('fluid');
+        self::assertInstanceOf(PackageInfo::class, $extensionKeyRetrievesCoreFluid);
+        self::assertSame('typo3/cms-fluid', $extensionKeyRetrievesCoreFluid->getName(), 'PackageInfo->name is not "typo3/cms-fluid"');
+        self::assertTrue($extensionKeyRetrievesCoreFluid->isSystemExtension(), '"typo3/cms-fluid" is a TYPO3 system extension');
+        self::assertFalse($extensionKeyRetrievesCoreFluid->isExtension(), '"typo3/cms-fluid" is not a TYPO3 extension');
+        self::assertTrue($extensionKeyRetrievesCoreFluid->isComposerPackage(), '"typo3/cms-fluid" is a composer package');
+        self::assertSame('fluid', $extensionKeyRetrievesCoreFluid->getExtensionKey());
+
+        // Verify TYPO3 system extension fluid resolved using relative classic mode path.
+        $extensionRelativeSystemExtensionPath = $composerManager->getPackageInfo('typo3/sysext/fluid');
+        self::assertInstanceOf(PackageInfo::class, $extensionRelativeSystemExtensionPath);
+        self::assertSame('typo3/cms-fluid', $extensionRelativeSystemExtensionPath->getName(), 'PackageInfo->name is not "typo3/cms-fluid"');
+        self::assertTrue($extensionRelativeSystemExtensionPath->isSystemExtension(), '"typo3/cms-fluid" is a TYPO3 system extension');
+        self::assertFalse($extensionRelativeSystemExtensionPath->isExtension(), '"typo3/cms-fluid" is not a TYPO3 extension');
+        self::assertTrue($extensionRelativeSystemExtensionPath->isComposerPackage(), '"typo3/cms-fluid" is a composer package');
+        self::assertSame('fluid', $extensionRelativeSystemExtensionPath->getExtensionKey());
     }
 }

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -295,4 +295,67 @@ final class ComposerPackageManagerTest extends UnitTestCase
         self::assertNotNull($packageInfo->getInfo());
         self::assertNotNull($packageInfo->getExtEmConf());
     }
+
+    public static function packagesWithoutExtEmConfFileDataProvider(): \Generator
+    {
+        yield 'package0 => package0' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package0',
+            'expectedExtensionKey' => 'package0',
+            'expectedPackageName' => 'typo3/testing-framework-package-0',
+        ];
+        yield 'package0 => package1' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package1',
+            'expectedExtensionKey' => 'package1',
+            'expectedPackageName' => 'typo3/testing-framework-package-1',
+        ];
+        yield 'package0 => package2' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package2',
+            'expectedExtensionKey' => 'package2',
+            'expectedPackageName' => 'typo3/testing-framework-package-2',
+        ];
+        yield 'package-identifier => some_test_extension' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package-identifier',
+            'expectedExtensionKey' => 'some_test_extension',
+            'expectedPackageName' => 'typo3/testing-framework-package-identifier',
+        ];
+    }
+
+    #[DataProvider('packagesWithoutExtEmConfFileDataProvider')]
+    #[Test]
+    public function getPackageInfoWithFallbackReturnsExtensionInfoWithCorrectExtensionKeyWhenNotHavingAnExtEmConfFile(
+        string $path,
+        string $expectedExtensionKey,
+        string $expectedPackageName,
+    ): void {
+        $packageInfo = (new ComposerPackageManager())->getPackageInfoWithFallback($path);
+        self::assertInstanceOf(PackageInfo::class, $packageInfo, 'PackageInfo retrieved for ' . $path);
+        self::assertNull($packageInfo->getExtEmConf(), 'Package provides ext_emconf.php');
+        self::assertNotNull($packageInfo->getInfo(), 'Package has no composer info (composer.json)');
+        self::assertNotEmpty($packageInfo->getInfo(), 'Package composer info is empty');
+        self::assertTrue($packageInfo->isExtension(), 'Package is not a extension');
+        self::assertFalse($packageInfo->isSystemExtension(), 'Package is a system extension');
+        self::assertTrue($packageInfo->isComposerPackage(), 'Package is not a composer package');
+        self::assertFalse($packageInfo->isMonoRepository(), 'Package is mono repository');
+        self::assertSame($expectedPackageName, $packageInfo->getName());
+        self::assertSame($expectedExtensionKey, $packageInfo->getExtensionKey());
+    }
+
+    #[Test]
+    public function getPackageInfoWithFallbackReturnsExtensionInfoWithCorrectExtensionKeyAndHavingAnExtEmConfFile(): void
+    {
+        $path = __DIR__ . '/../Fixtures/Packages/package-with-extemconf';
+        $expectedExtensionKey = 'extension_with_extemconf';
+        $expectedPackageName = 'typo3/testing-framework-package-with-extemconf';
+        $packageInfo = (new ComposerPackageManager())->getPackageInfoWithFallback($path);
+        self::assertInstanceOf(PackageInfo::class, $packageInfo, 'PackageInfo retrieved for ' . $path);
+        self::assertNotNull($packageInfo->getExtEmConf(), 'Package has ext_emconf.php file');
+        self::assertNotNull($packageInfo->getInfo(), 'Package has composer info');
+        self::assertNotEmpty($packageInfo->getInfo(), 'Package composer info is not empty');
+        self::assertTrue($packageInfo->isExtension(), 'Package is a extension');
+        self::assertFalse($packageInfo->isSystemExtension(), 'Package is not a system extension');
+        self::assertTrue($packageInfo->isComposerPackage(), 'Package is a composer package');
+        self::assertFalse($packageInfo->isMonoRepository(), 'Package is not mono repository root');
+        self::assertSame($expectedPackageName, $packageInfo->getName());
+        self::assertSame($expectedExtensionKey, $packageInfo->getExtensionKey());
+    }
 }

--- a/Tests/Unit/Composer/Fixtures/Extensions/extension-key-shared-with-composer-package/composer.json
+++ b/Tests/Unit/Composer/Fixtures/Extensions/extension-key-shared-with-composer-package/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "testing-framework/extension-key-shared-with-composer-package",
+    "description": "TYPO3 extension shareing extension-key with last part of composer package ",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech"
+        }
+    ],
+    "require": {},
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "sharedextensionkey"
+        }
+    }
+}

--- a/Tests/Unit/Composer/Fixtures/Packages/sharedextensionkey/composer.json
+++ b/Tests/Unit/Composer/Fixtures/Packages/sharedextensionkey/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "testing-framework/sharedextensionkey",
+    "description": "TYPO3 extension shareing extension-key with last part of composer package ",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Stefan Bürk",
+            "email": "stefan@buerk.tech"
+        }
+    ],
+    "require": {}
+}

--- a/Tests/Unit/Core/PackageCollectionTest.php
+++ b/Tests/Unit/Core/PackageCollectionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2024 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace Typo3\TestingFramework\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\TestingFramework\Composer\ComposerPackageManager;
+use TYPO3\TestingFramework\Core\PackageCollection;
+
+final class PackageCollectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function sortsComposerPackages(): void
+    {
+        $packageStates = require __DIR__ . '/../Fixtures/Packages/PackageStates.php';
+        $expectedPackageStates = require __DIR__ . '/../Fixtures/Packages/PackageStates_sorted.php';
+        $packageStates = $packageStates['packages'];
+        $basePath = realpath(__DIR__ . '/../../../');
+
+        $composerPackageManager = new ComposerPackageManager();
+        // That way it knows about the extensions, this is done by TestBase upfront.
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package0');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package1');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package2');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package-with-extemconf');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package-unsynced-extemconf');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package2-unsynced-extemconf');
+
+        $subject = PackageCollection::fromPackageStates(
+            $composerPackageManager,
+            new PackageManager(
+                new DependencyOrderingService(),
+                __DIR__ . '/../Fixtures/Packages/PackageStates.php',
+                $basePath
+            ),
+            $basePath,
+            $packageStates
+        );
+
+        $result = $subject->sortPackageStates(
+            $packageStates,
+            new DependencyOrderingService()
+        );
+
+        self::assertSame(5, array_search('package0', array_keys($result)), 'Package 0 is not stored at loading order 5.');
+        self::assertSame(6, array_search('package1', array_keys($result)), 'Package 1 is not stored at loading order 6.');
+        self::assertSame(7, array_search('extension_unsynced_extemconf', array_keys($result)), 'extension_unsynced_extemconf is not stored at loading order 7.');
+        self::assertSame(8, array_search('extension_with_extemconf', array_keys($result)), 'extension_with_extemconf is not stored at loading order 8.');
+        self::assertSame(9, array_search('extension2_unsynced_extemconf', array_keys($result)), 'extension2_unsynced_extemconf is not stored at loading order 9.');
+        self::assertSame(10, array_search('package2', array_keys($result)), 'Package 2 is not stored at loading order 10.');
+        self::assertSame($expectedPackageStates['packages'], $result, 'Sorted packages does not match expected order');
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/PackageStates.php
+++ b/Tests/Unit/Fixtures/Packages/PackageStates.php
@@ -1,0 +1,41 @@
+<?php
+
+// This is a fixture file and is intended to be not in sorted state to verify that sorting works correctly.
+return [
+    'packages' => [
+        'package2' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2/',
+        ],
+        'extbase' => [
+            'packagePath' => '.Build/vendor/typo3/cms-extbase/',
+        ],
+        'extension2_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/',
+        ],
+        'extension_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/',
+        ],
+        'extension_with_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-with-extemconf/',
+        ],
+        'package1' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package1/',
+        ],
+        'fluid' => [
+            'packagePath' => '.Build/vendor/typo3/cms-fluid/',
+        ],
+        'package0' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package0/',
+        ],
+        'backend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-backend/',
+        ],
+        'frontend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-frontend/',
+        ],
+        'core' => [
+            'packagePath' => '.Build/vendor/typo3/cms-core/',
+        ],
+    ],
+    'version' => 5,
+];

--- a/Tests/Unit/Fixtures/Packages/PackageStates_sorted.php
+++ b/Tests/Unit/Fixtures/Packages/PackageStates_sorted.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'packages' => [
+        'core' => [
+            'packagePath' => '.Build/vendor/typo3/cms-core/',
+        ],
+        'extbase' => [
+            'packagePath' => '.Build/vendor/typo3/cms-extbase/',
+        ],
+        'fluid' => [
+            'packagePath' => '.Build/vendor/typo3/cms-fluid/',
+        ],
+        'backend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-backend/',
+        ],
+        'frontend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-frontend/',
+        ],
+        'package0' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package0/',
+        ],
+        'package1' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package1/',
+        ],
+        'extension_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/',
+        ],
+        'extension_with_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-with-extemconf/',
+        ],
+        'extension2_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/',
+        ],
+        'package2' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2/',
+        ],
+    ],
+    'version' => 5,
+];

--- a/Tests/Unit/Fixtures/Packages/package-identifier/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-identifier/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "typo3/testing-framework-package-identifier",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "some_test_extension"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "typo3/testing-framework-package-unsynced-extemconf",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "extension_unsynced_extemconf"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/ext_emconf.php
+++ b/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/ext_emconf.php
@@ -1,0 +1,20 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'typo3/testing-framework package test extension',
+    'description' => '',
+    'category' => 'be',
+    'state' => 'stable',
+    'author' => 'TYPO3 Core Team',
+    'author_email' => 'typo3cms@typo3.org',
+    'author_company' => '',
+    'version' => '13.4.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0',
+            'package1' => '0.0.0-9.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Fixtures/Packages/package-with-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-with-extemconf/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "typo3/testing-framework-package-with-extemconf",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*",
+        "typo3/testing-framework-package-1": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "extension_with_extemconf"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package-with-extemconf/ext_emconf.php
+++ b/Tests/Unit/Fixtures/Packages/package-with-extemconf/ext_emconf.php
@@ -1,0 +1,20 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'typo3/testing-framework package test extension',
+    'description' => '',
+    'category' => 'be',
+    'state' => 'stable',
+    'author' => 'TYPO3 Core Team',
+    'author_email' => 'typo3cms@typo3.org',
+    'author_company' => '',
+    'version' => '13.4.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0',
+            'package1' => '0.0.0-9.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Fixtures/Packages/package0/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package0/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "typo3/testing-framework-package-0",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "package0"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package1/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package1/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "typo3/testing-framework-package-1",
+    "description": "Package 1, with replace entry",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*",
+        "typo3/testing-framework-package-0": "*"
+    },
+    "replace": {
+        "typo3-ter/package1": "self.version"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "package1"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "typo3/testing-framework-package2-unsynced-extemconf",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*",
+        "typo3/testing-framework-package-1": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "extension2_unsynced_extemconf"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/ext_emconf.php
+++ b/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'typo3/testing-framework package test extension',
+    'description' => '',
+    'category' => 'be',
+    'state' => 'stable',
+    'author' => 'TYPO3 Core Team',
+    'author_email' => 'typo3cms@typo3.org',
+    'author_company' => '',
+    'version' => '13.4.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Fixtures/Packages/package2/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package2/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "typo3/testing-framework-package-2",
+    "description": "Package 2 depending on package 1",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/testing-framework-package-1": "*",
+        "typo3/testing-framework-package-0": "*",
+        "typo3/testing-framework-package-with-extemconf": "*",
+        "typo3/testing-framework-package-with-extemconf": "*",
+        "typo3/testing-framework-package-unsynced-extemconf": "*",
+        "typo3/testing-framework-package2-unsynced-extemconf": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "package2"
+        }
+    }
+}


### PR DESCRIPTION
### **Collected backports from main to v8**

### :point_right: Backports tested 

* against TYPO3 Core v12 with [87276: [WIP][TASK] test collected tf backport](https://review.typo3.org/c/Packages/TYPO3.CMS/+/87276)

### Contained backports

:memo: [[TASK] Use non deprecated database connection options (tableoptions, collate)](https://github.com/TYPO3/testing-framework/pull/628)

* https://github.com/TYPO3/testing-framework/pull/640

:memo: [**[BUGFIX] Ensure correct path calculation on system build**](https://github.com/TYPO3/testing-framework/issues/577) 

Combined backport of:

* https://github.com/TYPO3/testing-framework/pull/630
* https://github.com/TYPO3/testing-framework/pull/632

:memo: [[TASK] Add missing composer.json to testing-framework extensions](https://github.com/TYPO3/testing-framework/pull/654)

* https://github.com/TYPO3/testing-framework/pull/654

:memo: [[BUGFIX] Respect composer mode only extension in FunctionalTestCase](https://github.com/TYPO3/testing-framework/issues/541)

* https://github.com/TYPO3/testing-framework/pull/542

:memo: [[BUGFIX] Avoid resolving invalid TYPO3 extensions in `ComposerPackageManager`](https://github.com/TYPO3/testing-framework/pull/553)

* https://github.com/TYPO3/testing-framework/pull/655

:memo: [[BUGFIX] Avoid TypeError for database port handling](https://github.com/TYPO3/testing-framework/issues/631)

* https://github.com/TYPO3/testing-framework/pull/656