### PR TITLE
[BUGFIX] Respect `composer mode only` extension in `FunctionalTestCase`

### DIFF
--- a/Build/phpstan/phpstan.neon
+++ b/Build/phpstan/phpstan.neon
@@ -20,3 +20,5 @@ parameters:
     - ../../Classes/Core/Acceptance/*
     # Text fixtures extensions uses $_EXTKEY phpstan would be report as "might not defined"
     - ../../Tests/Unit/*/Fixtures/Extensions/*/ext_emconf.php
+    - ../../Tests/Unit/*/Fixtures/Packages/*/ext_emconf.php
+    - ../../Tests/Unit/Fixtures/Packages/*/ext_emconf.php

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -61,6 +61,7 @@ final class ComposerPackageManager
 
     public function __construct()
     {
+        // @todo Remove this from the constructor.
         $this->build();
     }
 
@@ -545,10 +546,19 @@ final class ComposerPackageManager
         ?array $info = null,
         ?array $extEmConf = null
     ): string {
-        $isExtension = in_array($info['type'] ?? '', ['typo3-cms-framework', 'typo3-cms-extension'], true)
-            || ($extEmConf !== null);
-        if (!$isExtension) {
+        $isComposerExtensionType = ($info !== null && array_key_exists('type', $info) && is_string($info['type']) && in_array($info['type'], ['typo3-cms-framework', 'typo3-cms-extension'], true));
+        $hasExtEmConf = $extEmConf !== null;
+        if (!($isComposerExtensionType || $hasExtEmConf)) {
             return '';
+        }
+        $hasComposerExtensionKey = (
+            is_array($info)
+            && isset($info['extra']['typo3/cms']['extension-key'])
+            && is_string($info['extra']['typo3/cms']['extension-key'])
+            && $info['extra']['typo3/cms']['extension-key'] !== ''
+        );
+        if ($hasComposerExtensionKey) {
+            return $info['extra']['typo3/cms']['extension-key'];
         }
         $baseName = basename($packagePath);
         if (($info['type'] ?? '') === 'typo3-csm-framework'

--- a/Classes/Core/PackageCollection.php
+++ b/Classes/Core/PackageCollection.php
@@ -26,10 +26,38 @@ use TYPO3\CMS\Core\Service\DependencyOrderingService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\TestingFramework\Composer\ComposerPackageManager;
+use TYPO3\TestingFramework\Composer\PackageInfo;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
- * Collection for extension packages to resolve their dependencies in a test-base.
- * Most of the code has been duplicated and adjusted from `\TYPO3\CMS\Core\Package\PackageManager`.
+ * Composer package collection to resolve extension dependencies for classic-mode based test instances.
+ *
+ * This class resolves extension dependencies for composer packages to sort classic-mode PackageStates,
+ * which only takes TYPO3 extensions into account with a fallback to read composer information when the
+ * `ext_emconf.php` file is missing.
+ *
+ * Most of the code has been duplicated and adjusted from {@see PackageManager}.
+ *
+ * Background:
+ * ===========
+ *
+ * TYPO3 has the two installation mode "composer" and "classic". For the "composer" mode the package dependency handling
+ * is mainly done by composer and dependency detection and sorting is purely based on composer.json information. "Classic"
+ * mode uses only "ext_emconf.php" information to do the same job, not mixing it with the composer.json information when
+ * available.
+ *
+ * Since TYPO3 v12 extensions installed in "composer" mode are not required to provide a "ext_emconf.php" anymore, which
+ * makes them only installable within a "composer" mode installation. Agencies used to drop that file from local path
+ * extensions in "composer" mode projects, because it is a not needed requirement for them and avoids maintenance of it.
+ *
+ * typo3/testing-framework builds "classic" mode functional test instances while used within composer installations only,
+ * and introduced an extension sorting with this class to ensure to have a deterministic extension sorting like a real
+ * "classic" mode installation would provide in case extensions are not manually provided in the correct order within
+ * {@see FunctionalTestCase::$testExtensionToLoad} property.
+ *
+ * {@see PackageCollection} is based on the TYPO3 core {@see PackageManager} to provide a sorting for functional test
+ * instances, falling back to use composer.json information in case no "ext_emconf.php" are given limiting it only to
+ * TYPO3 compatible extensions (typo3-cms-framework and typo3-cms-extension composer package types).
  *
  * @phpstan-type PackageKey non-empty-string
  * @phpstan-type PackageName non-empty-string
@@ -54,6 +82,10 @@ class PackageCollection
     {
         $packages = [];
         foreach ($packageStates as $packageKey => $packageStateConfiguration) {
+            // @todo Verify retrieving package information and throwing early exception after extension without
+            //       composer.json support has been dropped, even for simplified test fixture extensions. Think
+            //       about triggering deprecation for this case first, which may also breaking from a testing
+            //       perspective.
             $packagePath = PathUtility::sanitizeTrailingSeparator(
                 rtrim($basePath, '/') . '/' . $packageStateConfiguration['packagePath']
             );
@@ -157,8 +189,11 @@ class PackageCollection
             ];
             if (isset($allPackageConstraints[$packageKey]['dependencies'])) {
                 foreach ($allPackageConstraints[$packageKey]['dependencies'] as $dependentPackageKey) {
-                    if (!in_array($dependentPackageKey, $packageKeys, true)) {
-                        if ($this->isComposerDependency($dependentPackageKey)) {
+                    $extensionKey = $this->getPackageExtensionKey($dependentPackageKey);
+                    if (!in_array($dependentPackageKey, $packageKeys, true)
+                        && !in_array($extensionKey, $packageKeys, true)
+                    ) {
+                        if (!$this->isTypo3SystemOrCustomExtension($dependentPackageKey)) {
                             // The given package has a dependency to a Composer package that has no relation to TYPO3
                             // We can ignore those, when calculating the extension order
                             continue;
@@ -169,21 +204,30 @@ class PackageCollection
                             1519931815
                         );
                     }
-                    $dependencies[$packageKey]['after'][] = $dependentPackageKey;
+                    $dependencies[$packageKey]['after'][] = $extensionKey;
                 }
             }
             if (isset($allPackageConstraints[$packageKey]['suggestions'])) {
                 foreach ($allPackageConstraints[$packageKey]['suggestions'] as $suggestedPackageKey) {
+                    $extensionKey = $this->getPackageExtensionKey($suggestedPackageKey);
                     // skip suggestions on not existing packages
-                    if (in_array($suggestedPackageKey, $packageKeys, true)) {
-                        // Suggestions actually have never been meant to influence loading order.
-                        // We misuse this currently, as there is no other way to influence the loading order
-                        // for not-required packages (soft-dependency).
-                        // When considering suggestions for the loading order, we might create a cyclic dependency
-                        // if the suggested package already has a real dependency on this package, so the suggestion
-                        // has do be dropped in this case and must *not* be taken into account for loading order evaluation.
-                        $dependencies[$packageKey]['after-resilient'][] = $suggestedPackageKey;
+                    if (!in_array($suggestedPackageKey, $packageKeys, true)
+                        && !in_array($extensionKey, $packageKeys, true)
+                    ) {
+                        continue;
                     }
+                    if (!$this->isTypo3SystemOrCustomExtension($extensionKey ?: $suggestedPackageKey)) {
+                        // Ignore non TYPO3 extension packages for suggestion determination/ordering.
+                        continue;
+                    }
+
+                    // Suggestions actually have never been meant to influence loading order.
+                    // We misuse this currently, as there is no other way to influence the loading order
+                    // for not-required packages (soft-dependency).
+                    // When considering suggestions for the loading order, we might create a cyclic dependency
+                    // if the suggested package already has a real dependency on this package, so the suggestion
+                    // has do be dropped in this case and must *not* be taken into account for loading order evaluation.
+                    $dependencies[$packageKey]['after-resilient'][] = $extensionKey;
                 }
             }
         }
@@ -250,25 +294,28 @@ class PackageCollection
         foreach ($dependentPackageConstraints as $constraint) {
             if ($constraint instanceof PackageConstraint) {
                 $dependentPackageKey = $constraint->getValue();
-                if (!in_array($dependentPackageKey, $dependentPackageKeys, true) && !in_array($dependentPackageKey, $trace, true)) {
-                    $dependentPackageKeys[] = $dependentPackageKey;
+                $extensionKey = $this->getPackageExtensionKey($dependentPackageKey) ?: $dependentPackageKey;
+                if (!in_array($extensionKey, $dependentPackageKeys, true)) {
+                    $dependentPackageKeys[] = $extensionKey;
                 }
-                if (!isset($this->packages[$dependentPackageKey])) {
-                    if ($this->isComposerDependency($dependentPackageKey)) {
+
+                if (!isset($this->packages[$extensionKey])) {
+                    if (!$this->isTypo3SystemOrCustomExtension($extensionKey)) {
                         // The given package has a dependency to a Composer package that has no relation to TYPO3
                         // We can ignore those, when calculating the extension order
                         continue;
                     }
+
                     throw new Exception(
                         sprintf(
                             'Package "%s" depends on package "%s" which does not exist.',
                             $package->getPackageKey(),
-                            $dependentPackageKey
+                            $extensionKey
                         ),
                         1695119749
                     );
                 }
-                $this->getDependencyArrayForPackage($this->packages[$dependentPackageKey], $dependentPackageKeys, $trace);
+                $this->getDependencyArrayForPackage($this->packages[$extensionKey], $dependentPackageKeys, $trace);
             }
         }
         return array_reverse($dependentPackageKeys);
@@ -287,9 +334,17 @@ class PackageCollection
         foreach ($suggestedPackageConstraints as $constraint) {
             if ($constraint instanceof PackageConstraint) {
                 $suggestedPackageKey = $constraint->getValue();
-                if (isset($this->packages[$suggestedPackageKey])) {
-                    $suggestedPackageKeys[] = $suggestedPackageKey;
+                $extensionKey = $this->getPackageExtensionKey($suggestedPackageKey) ?: $suggestedPackageKey;
+                if (!$this->isTypo3SystemOrCustomExtension($suggestedPackageKey)) {
+                    // Suggested packages which are not installed or not a TYPO3 extension can be skipped for
+                    // sorting when not available.
+                    continue;
                 }
+                if (!isset($this->packages[$extensionKey])) {
+                    // Suggested extension is not available in test system installation (not symlinked), ignore it.
+                    continue;
+                }
+                $suggestedPackageKeys[] = $extensionKey;
             }
         }
         return array_reverse($suggestedPackageKeys);
@@ -303,15 +358,38 @@ class PackageCollection
         $frameworkKeys = [];
         foreach ($this->packages as $package) {
             if ($package->getPackageMetaData()->isFrameworkType()) {
-                $frameworkKeys[] = $package->getPackageKey();
+                $frameworkKeys[] = $this->getPackageExtensionKey($package->getPackageKey()) ?: $package->getPackageKey();
             }
         }
         return $frameworkKeys;
     }
 
-    protected function isComposerDependency(string $packageKey): bool
+    /**
+     * Determines if given composer package key is either a `typo3-cms-framework` or `typo3-cms-extension` package.
+     */
+    protected function isTypo3SystemOrCustomExtension(string $packageKey): bool
     {
-        $packageInfo = $this->composerPackageManager->getPackageInfo($packageKey);
-        return !(($packageInfo?->isSystemExtension() ?? false) || ($packageInfo?->isExtension()));
+        $packageInfo = $this->getPackageInfo($packageKey);
+        if ($packageInfo === null) {
+            return false;
+        }
+        return $packageInfo->isSystemExtension() || $packageInfo->isExtension();
+    }
+
+    /**
+     * Returns package extension key. Returns empty string if not available.
+     */
+    protected function getPackageExtensionKey(string $packageKey): string
+    {
+        $packageInfo = $this->getPackageInfo($packageKey);
+        if ($packageInfo === null) {
+            return '';
+        }
+        return $packageInfo->getExtensionKey();
+    }
+
+    protected function getPackageInfo(string $packageKey): ?PackageInfo
+    {
+        return $this->composerPackageManager->getPackageInfo($packageKey);
     }
 }

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -295,4 +295,67 @@ final class ComposerPackageManagerTest extends UnitTestCase
         self::assertNotNull($packageInfo->getInfo());
         self::assertNotNull($packageInfo->getExtEmConf());
     }
+
+    public static function packagesWithoutExtEmConfFileDataProvider(): \Generator
+    {
+        yield 'package0 => package0' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package0',
+            'expectedExtensionKey' => 'package0',
+            'expectedPackageName' => 'typo3/testing-framework-package-0',
+        ];
+        yield 'package0 => package1' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package1',
+            'expectedExtensionKey' => 'package1',
+            'expectedPackageName' => 'typo3/testing-framework-package-1',
+        ];
+        yield 'package0 => package2' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package2',
+            'expectedExtensionKey' => 'package2',
+            'expectedPackageName' => 'typo3/testing-framework-package-2',
+        ];
+        yield 'package-identifier => some_test_extension' => [
+            'path' => __DIR__ . '/../Fixtures/Packages/package-identifier',
+            'expectedExtensionKey' => 'some_test_extension',
+            'expectedPackageName' => 'typo3/testing-framework-package-identifier',
+        ];
+    }
+
+    #[DataProvider('packagesWithoutExtEmConfFileDataProvider')]
+    #[Test]
+    public function getPackageInfoWithFallbackReturnsExtensionInfoWithCorrectExtensionKeyWhenNotHavingAnExtEmConfFile(
+        string $path,
+        string $expectedExtensionKey,
+        string $expectedPackageName,
+    ): void {
+        $packageInfo = (new ComposerPackageManager())->getPackageInfoWithFallback($path);
+        self::assertInstanceOf(PackageInfo::class, $packageInfo, 'PackageInfo retrieved for ' . $path);
+        self::assertNull($packageInfo->getExtEmConf(), 'Package provides ext_emconf.php');
+        self::assertNotNull($packageInfo->getInfo(), 'Package has no composer info (composer.json)');
+        self::assertNotEmpty($packageInfo->getInfo(), 'Package composer info is empty');
+        self::assertTrue($packageInfo->isExtension(), 'Package is not a extension');
+        self::assertFalse($packageInfo->isSystemExtension(), 'Package is a system extension');
+        self::assertTrue($packageInfo->isComposerPackage(), 'Package is not a composer package');
+        self::assertFalse($packageInfo->isMonoRepository(), 'Package is mono repository');
+        self::assertSame($expectedPackageName, $packageInfo->getName());
+        self::assertSame($expectedExtensionKey, $packageInfo->getExtensionKey());
+    }
+
+    #[Test]
+    public function getPackageInfoWithFallbackReturnsExtensionInfoWithCorrectExtensionKeyAndHavingAnExtEmConfFile(): void
+    {
+        $path = __DIR__ . '/../Fixtures/Packages/package-with-extemconf';
+        $expectedExtensionKey = 'extension_with_extemconf';
+        $expectedPackageName = 'typo3/testing-framework-package-with-extemconf';
+        $packageInfo = (new ComposerPackageManager())->getPackageInfoWithFallback($path);
+        self::assertInstanceOf(PackageInfo::class, $packageInfo, 'PackageInfo retrieved for ' . $path);
+        self::assertNotNull($packageInfo->getExtEmConf(), 'Package has ext_emconf.php file');
+        self::assertNotNull($packageInfo->getInfo(), 'Package has composer info');
+        self::assertNotEmpty($packageInfo->getInfo(), 'Package composer info is not empty');
+        self::assertTrue($packageInfo->isExtension(), 'Package is a extension');
+        self::assertFalse($packageInfo->isSystemExtension(), 'Package is not a system extension');
+        self::assertTrue($packageInfo->isComposerPackage(), 'Package is a composer package');
+        self::assertFalse($packageInfo->isMonoRepository(), 'Package is not mono repository root');
+        self::assertSame($expectedPackageName, $packageInfo->getName());
+        self::assertSame($expectedExtensionKey, $packageInfo->getExtensionKey());
+    }
 }

--- a/Tests/Unit/Core/PackageCollectionTest.php
+++ b/Tests/Unit/Core/PackageCollectionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2024 Daniel Siepmann <coding@daniel-siepmann.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace Typo3\TestingFramework\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\TestingFramework\Composer\ComposerPackageManager;
+use TYPO3\TestingFramework\Core\PackageCollection;
+
+final class PackageCollectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function sortsComposerPackages(): void
+    {
+        $packageStates = require __DIR__ . '/../Fixtures/Packages/PackageStates.php';
+        $expectedPackageStates = require __DIR__ . '/../Fixtures/Packages/PackageStates_sorted.php';
+        $packageStates = $packageStates['packages'];
+        $basePath = realpath(__DIR__ . '/../../../');
+
+        $composerPackageManager = new ComposerPackageManager();
+        // That way it knows about the extensions, this is done by TestBase upfront.
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package0');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package1');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package2');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package-with-extemconf');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package-unsynced-extemconf');
+        $composerPackageManager->getPackageInfoWithFallback(__DIR__ . '/../Fixtures/Packages/package2-unsynced-extemconf');
+
+        $subject = PackageCollection::fromPackageStates(
+            $composerPackageManager,
+            new PackageManager(
+                new DependencyOrderingService(),
+                __DIR__ . '/../Fixtures/Packages/PackageStates.php',
+                $basePath
+            ),
+            $basePath,
+            $packageStates
+        );
+
+        $result = $subject->sortPackageStates(
+            $packageStates,
+            new DependencyOrderingService()
+        );
+
+        self::assertSame(5, array_search('package0', array_keys($result)), 'Package 0 is not stored at loading order 5.');
+        self::assertSame(6, array_search('package1', array_keys($result)), 'Package 1 is not stored at loading order 6.');
+        self::assertSame(7, array_search('extension_unsynced_extemconf', array_keys($result)), 'extension_unsynced_extemconf is not stored at loading order 7.');
+        self::assertSame(8, array_search('extension_with_extemconf', array_keys($result)), 'extension_with_extemconf is not stored at loading order 8.');
+        self::assertSame(9, array_search('extension2_unsynced_extemconf', array_keys($result)), 'extension2_unsynced_extemconf is not stored at loading order 9.');
+        self::assertSame(10, array_search('package2', array_keys($result)), 'Package 2 is not stored at loading order 10.');
+        self::assertSame($expectedPackageStates['packages'], $result, 'Sorted packages does not match expected order');
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/PackageStates.php
+++ b/Tests/Unit/Fixtures/Packages/PackageStates.php
@@ -1,0 +1,41 @@
+<?php
+
+// This is a fixture file and is intended to be not in sorted state to verify that sorting works correctly.
+return [
+    'packages' => [
+        'package2' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2/',
+        ],
+        'extbase' => [
+            'packagePath' => '.Build/vendor/typo3/cms-extbase/',
+        ],
+        'extension2_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/',
+        ],
+        'extension_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/',
+        ],
+        'extension_with_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-with-extemconf/',
+        ],
+        'package1' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package1/',
+        ],
+        'fluid' => [
+            'packagePath' => '.Build/vendor/typo3/cms-fluid/',
+        ],
+        'package0' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package0/',
+        ],
+        'backend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-backend/',
+        ],
+        'frontend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-frontend/',
+        ],
+        'core' => [
+            'packagePath' => '.Build/vendor/typo3/cms-core/',
+        ],
+    ],
+    'version' => 5,
+];

--- a/Tests/Unit/Fixtures/Packages/PackageStates_sorted.php
+++ b/Tests/Unit/Fixtures/Packages/PackageStates_sorted.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'packages' => [
+        'core' => [
+            'packagePath' => '.Build/vendor/typo3/cms-core/',
+        ],
+        'extbase' => [
+            'packagePath' => '.Build/vendor/typo3/cms-extbase/',
+        ],
+        'fluid' => [
+            'packagePath' => '.Build/vendor/typo3/cms-fluid/',
+        ],
+        'backend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-backend/',
+        ],
+        'frontend' => [
+            'packagePath' => '.Build/vendor/typo3/cms-frontend/',
+        ],
+        'package0' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package0/',
+        ],
+        'package1' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package1/',
+        ],
+        'extension_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/',
+        ],
+        'extension_with_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-with-extemconf/',
+        ],
+        'extension2_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/',
+        ],
+        'package2' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2/',
+        ],
+    ],
+    'version' => 5,
+];

--- a/Tests/Unit/Fixtures/Packages/package-identifier/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-identifier/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "typo3/testing-framework-package-identifier",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "some_test_extension"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "typo3/testing-framework-package-unsynced-extemconf",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "extension_unsynced_extemconf"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/ext_emconf.php
+++ b/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/ext_emconf.php
@@ -1,0 +1,20 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'typo3/testing-framework package test extension',
+    'description' => '',
+    'category' => 'be',
+    'state' => 'stable',
+    'author' => 'TYPO3 Core Team',
+    'author_email' => 'typo3cms@typo3.org',
+    'author_company' => '',
+    'version' => '13.4.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0',
+            'package1' => '0.0.0-9.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Fixtures/Packages/package-with-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-with-extemconf/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "typo3/testing-framework-package-with-extemconf",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*",
+        "typo3/testing-framework-package-1": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "extension_with_extemconf"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package-with-extemconf/ext_emconf.php
+++ b/Tests/Unit/Fixtures/Packages/package-with-extemconf/ext_emconf.php
@@ -1,0 +1,20 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'typo3/testing-framework package test extension',
+    'description' => '',
+    'category' => 'be',
+    'state' => 'stable',
+    'author' => 'TYPO3 Core Team',
+    'author_email' => 'typo3cms@typo3.org',
+    'author_company' => '',
+    'version' => '13.4.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0',
+            'package1' => '0.0.0-9.99.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Fixtures/Packages/package0/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package0/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "typo3/testing-framework-package-0",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "package0"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package1/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package1/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "typo3/testing-framework-package-1",
+    "description": "Package 1, with replace entry",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*",
+        "typo3/testing-framework-package-0": "*"
+    },
+    "replace": {
+        "typo3-ter/package1": "self.version"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "package1"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "typo3/testing-framework-package2-unsynced-extemconf",
+    "description": "Package 0",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/cms-core": "*",
+        "typo3/testing-framework-package-1": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "extension2_unsynced_extemconf"
+        }
+    }
+}

--- a/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/ext_emconf.php
+++ b/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/ext_emconf.php
@@ -1,0 +1,19 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'typo3/testing-framework package test extension',
+    'description' => '',
+    'category' => 'be',
+    'state' => 'stable',
+    'author' => 'TYPO3 Core Team',
+    'author_email' => 'typo3cms@typo3.org',
+    'author_company' => '',
+    'version' => '13.4.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '13.4.0',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/Tests/Unit/Fixtures/Packages/package2/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package2/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "typo3/testing-framework-package-2",
+    "description": "Package 2 depending on package 1",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*",
+        "typo3/testing-framework-package-1": "*",
+        "typo3/testing-framework-package-0": "*",
+        "typo3/testing-framework-package-with-extemconf": "*",
+        "typo3/testing-framework-package-with-extemconf": "*",
+        "typo3/testing-framework-package-unsynced-extemconf": "*",
+        "typo3/testing-framework-package2-unsynced-extemconf": "*",
+        "typo3/cms-core": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "package2"
+        }
+    }
+}


### PR DESCRIPTION
The `typo3/testing-framework` creates functional test instances
as "classic" mode instances, writing a `PackageStates.php` file
composed using composer information, provided and handled by the
internal `ComposerPackageManager` class. Extensions in the state
file are not sorted based on their dependencies and suggestions.

To mitigate this and having a correctly sorted extension state
file, the `PackageCollection` service has been introduced with
the goal to resort the extension state file after the initial
write to provide the correct sorted extension state.

The extension sorting within the state file is important, as the
TYPO3 Core uses this sorting to loop over extensions to collect
information from the extensions, for example TCA, TCAOverrides,
ext_localconf.php and other things. Package sorting is here very
important to allow extensions to reconfigure or change the stuff
from other extensions, which is guaranteed in normal "composer"
and "classic" mode instances.

For "classic" mode instances, only the `ext_emconf.php` file is 
taken into account and "composer.json" as the source of thruth
for "composer" mode instances since TYPO3 v12, which made the
`ext_emconf.php` file obsolete for extensions only installed
with composer.

Many agencies removed the optional `ext_emconf.php` file for
project local path extensions like a sitepackage to remove
the maintenance burden, which is a valid case.

Sadly, the `PackageCollection` adopted from the TYPO3 Core
`PackageManager` did not reflected this case and failed for
extensions to properly sort only on extension dependencies
and keys due the mix of extension key and composer package
name handling. Extension depending on another extension
failed to be sorted correctly with following exception:

    UnexpectedValueException: The package "extension_key"
    depends on "composer/package-key" which is not present
    in the system.

This change modifies the `PackageCollection` implementation
to take only TYPO3 extension and system extension into account
for dependency resolving and sorting, using `ext_emconf.php`
depends/suggest information as first source and falling back
to `composer` require and suggestion information.

Resolves: #541
Releases: main, 8