### PR TITLE
[BUGFIX] Avoid TYPO3\CMS\Backend\FrontendBackendUserAuthentication

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/BackendUserHandler.php
+++ b/Resources/Core/Functional/Extensions/json_response/Classes/Middleware/BackendUserHandler.php
@@ -19,13 +19,13 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Backend\FrontendBackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Context\WorkspaceAspect;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Authentication\FrontendBackendUserAuthentication;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext;
 
 /**


### PR DESCRIPTION
Use TYPO3\CMS\Frontend\FrontendBackendUserAuthentication instead, the class has been moved from ext:backend to ext:frontend in TYPO3 v13, the old name has been established as alias and is removed with TYPO3 v14.