### PR TITLE
Revert "[TASK] Increase git fetch depth for pull-requests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
-          fetch-depth: 0
 
       - name: Composer install
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate


### PR DESCRIPTION
This reverts commit cd23e9f5fdad88ca3e99b49684f031498a320e8f,
which was a experimental try to mitigate an issue with scheduled
execution breaking external fork pull-requests. It's not needed
and removed again.
