### PR TITLE
[TASK] Use simplier and working checkout ref determination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,10 @@ jobs:
         php: [ '8.1' , '8.2', '8.3', '8.4']
     steps:
 
-      - name: Extract branch name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: extract_branch
-
-      - name: Checkout ${{ steps.extract_branch.outputs.branch }}
+      - name: Checkout ${{ github.event_name == 'workflow_dispatch' && github.head_ref || '' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.extract_branch.outputs.branch }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.head_ref || '' }}
 
       - name: Composer install
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate


### PR DESCRIPTION
With the introduction of non-main branch scheduled workflow
execution a adjusted checkout part in the `ci.yml` workflow
file has been added to allow to define which branch should
be checked out.

That breaks pipeline execution for pull-requests opened from
repository forks.

This change replaces the old detection with a more simplified
implementation, only setting the custom ref in case of github
workflow_dispatch event execution using `''` as fallback which
allows custom branch selection for workflow dispatching while
keeping default repostiory and branch checkout intact.

Releases: main, 8, 7
