### PR TITLE
[TASK] Use simplier and working checkout ref determination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
       matrix:
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     steps:
-      - name: Checkout
+
+      - name: Checkout ${{ github.event_name == 'workflow_dispatch' && github.head_ref || '' }}
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.head_ref || '' }}
 
       - name: Composer install
         run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate


### PR DESCRIPTION
With the introduction of non-main branch scheduled workflow
execution a adjusted checkout part in the `ci.yml` workflow
file has been added to allow to define which branch should
be checked out.

That breaks pipeline execution for pull-requests opened from
repository forks.

This change replaces the old detection with a more simplified
implementation, only setting the custom ref in case of github
workflow_dispatch event execution using `''` as fallback which
allows custom branch selection for workflow dispatching while
keeping default repostiory and branch checkout intact.

Releases: main, 8, 7
