### PR TITLE
[TASK] Trigger assertion in assertCSVDataSet() on empty table

### DIFF
--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
-         beStrictAboutTestsThatDoNotTestAnything="false"
          cacheDirectory=".phpunit.cache"
          cacheResult="false"
          colors="true"

--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -615,6 +615,10 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             $hasHashField = ($dataSet->getHashIndex($tableName) !== null);
             $records = $this->getAllRecords($tableName, $hasUidField, $hasHashField);
             $assertions = $dataSet->getElements($tableName);
+            if (count($assertions) === 0) {
+                // Increase assertion counter to avoid "test did not perform any assertions" if testing for an empty table
+                self::assertThat(true, self::isTrue());
+            }
             foreach ($assertions as $assertion) {
                 $result = $this->assertInRecords($assertion, $records);
                 if ($result === false) {

--- a/Resources/Core/Build/FunctionalTests.xml
+++ b/Resources/Core/Build/FunctionalTests.xml
@@ -16,7 +16,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
          backupGlobals="true"
-         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="FunctionalTestsBootstrap.php"
          cacheDirectory=".phpunit.cache"
          cacheResult="false"

--- a/Resources/Core/Build/UnitTests.xml
+++ b/Resources/Core/Build/UnitTests.xml
@@ -16,7 +16,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd"
          backupGlobals="true"
-         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="UnitTestsBootstrap.php"
          cacheDirectory=".phpunit.cache"
          cacheResult="false"


### PR DESCRIPTION
When comparing with a csv fixture that contains a table with no rows, which is a legit case, no assertion is raised. This makes phpunit emit a risky test: "This test did not perform any assertions". The patch adds an assertion in this case as well.

Note phpunit nowadays has attribute #[DoesNotPerformAssertions] to mark tests that do not assert anything. This can be used for tests that for instance just call a subject method to verify no exception is raised. It is good to follow this path, the patch removes "beStrictAboutTestsThatDoNotTestAnything=false" from the example phpunit xml files, which makes this setting implicitly true.

Releases: main
Resolves: #647