### PR TITLE
[TASK] Add missing `composer.json` to testing-framework extensions

### DIFF
--- a/Resources/Core/Functional/Extensions/json_response/composer.json
+++ b/Resources/Core/Functional/Extensions/json_response/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "typo3/testing-json-response",
+    "type": "typo3-cms-extension",
+    "description": "Providing testing framework extension for functional testing.",
+    "keywords": [
+        "typo3",
+        "testing",
+        "tests"
+    ],
+    "homepage": "https://typo3.org/",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "TYPO3 CMS Core Team",
+            "role": "Developer",
+            "homepage": "https://forge.typo3.org/projects/typo3cms-core"
+        },
+        {
+            "name": "The TYPO3 Community",
+            "role": "Contributor",
+            "homepage": "https://typo3.org/community/"
+        }
+    ],
+    "support": {
+        "general": "https://typo3.org/support/",
+        "issues": "https://github.com/TYPO3/testing-framework/issues"
+    },
+    "require": {
+        "php": "^8.2",
+        "typo3/cms-core": "13.*.*@dev || 14.*.*@dev"
+    },
+    "autoload": {
+        "psr-4": {
+            "TYPO3\\JsonResponse\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "json_response"
+        }
+    }
+}

--- a/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
@@ -4,14 +4,14 @@ $EM_CONF[$_EXTKEY] = [
     'title' => 'JSON Response',
     'description' => 'JSON Response',
     'category' => 'example',
-    'version' => '9.4.0',
+    'version' => '1.0.0',
     'state' => 'beta',
     'author' => 'Oliver Hader',
     'author_email' => 'oliver@typo3.org',
     'author_company' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.4.0',
+            'typo3' => '13.0.0 - 14.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/Resources/Core/Functional/Extensions/private_container/composer.json
+++ b/Resources/Core/Functional/Extensions/private_container/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "typo3/testing-private-container",
+    "type": "typo3-cms-extension",
+    "description": "Providing testing framework extension for functional testing.",
+    "keywords": [
+        "typo3",
+        "testing",
+        "tests"
+    ],
+    "homepage": "https://typo3.org/",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "TYPO3 CMS Core Team",
+            "role": "Developer",
+            "homepage": "https://forge.typo3.org/projects/typo3cms-core"
+        },
+        {
+            "name": "The TYPO3 Community",
+            "role": "Contributor",
+            "homepage": "https://typo3.org/community/"
+        }
+    ],
+    "support": {
+        "general": "https://typo3.org/support/",
+        "issues": "https://github.com/TYPO3/testing-framework/issues"
+    },
+    "require": {
+        "php": "^8.2",
+        "typo3/cms-core": "13.*.*@dev || 14.*.*@dev"
+    },
+    "autoload": {
+        "psr-4": {
+            "TYPO3\\PrivateContainer\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "private_container"
+        }
+    }
+}

--- a/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.0.0-12.99.99',
+            'typo3' => '13.0.0-14.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
The typo3/testing-framework provides two TYPO3 extensions,
which are required and bound to every created functional
test instance.

Adding missing `composer.json` for these two extensions.

Releases: main, 8
