### PR TITLE
[BUGFIX] Avoid TypeError for database port handling

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -453,7 +453,7 @@ class Testbase
                 $originalConfigurationArray['DB']['Connections']['Default']['password'] = $databasePasswordTrimmed;
             }
             if ($databasePort) {
-                $originalConfigurationArray['DB']['Connections']['Default']['port'] = $databasePort;
+                $originalConfigurationArray['DB']['Connections']['Default']['port'] = (int)$databasePort;
             }
             if ($databaseSocket) {
                 $originalConfigurationArray['DB']['Connections']['Default']['unix_socket'] = $databaseSocket;


### PR DESCRIPTION
Using the `typo3DatabasePort` environment variable to
define the database server port string-casts the value
to an string which is not compatible with the mysqli
method `mysqli::real_connect()` and fails with:

```
TypeError: mysqli::real_connect(): Argument #5 ($port)
must be of type ?int, string given
```

This change casts the database port to an integer in case
a port is provided to avoid PHP TypeError when passing to
`mysqli::real_connect()` to align with `ConnectionPool`,
which is not used to create the database for the functional
test instance.

Resolves: #631
Releases: main, 8
