### PR TITLE
[TASK] Do not enable feature `redirects.hitCount` for acceptance tests

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -281,7 +281,6 @@ abstract class BackendEnvironment extends Extension
         $localConfiguration['SYS']['errorHandlerErrors'] = E_ALL;
         $localConfiguration['SYS']['trustedHostsPattern'] = '.*';
         $localConfiguration['SYS']['encryptionKey'] = 'iAmInvalid';
-        $localConfiguration['SYS']['features']['redirects.hitCount'] = true;
         // @todo: This sql_mode should be enabled as soon as styleguide and dataHandler can cope with it
         //$localConfiguration['SYS']['setDBinit'] = 'SET SESSION sql_mode = \'STRICT_ALL_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY\';';
         $localConfiguration['GFX']['processor'] = 'GraphicsMagick';


### PR DESCRIPTION
This change removes the enabling of feature `redirects.hitCount`
within codeception acceptance test setups to stay on TYPO3 Core
defaults.

That has been preared with temporary solution for TYPO3 Core tests [1].

* [1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/87280

Resolves: https://github.com/TYPO3/testing-framework/issues/554
Releases: main
