### PR TITLE
[BUGFIX] Ensure to take test instance as class mode instance

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -747,7 +747,7 @@ class Testbase
         if ($hasConsolidatedHttpEntryPoint) {
             SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_CLI, false);
         } else {
-            SystemEnvironmentBuilder::run(1, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI);
+            SystemEnvironmentBuilder::run(1, SystemEnvironmentBuilder::REQUESTTYPE_BE | SystemEnvironmentBuilder::REQUESTTYPE_CLI, false);
         }
         $container = Bootstrap::init($classLoader);
         // Make sure output is not buffered, so command-line output can take place and


### PR DESCRIPTION
The bugfix backport to ensure correct system environment path
building to fix issue #577 missed to correctly set the flag
for non-composer mode for TYPO3 v12 and lead to wrong path
calculations and followup issues within functional tests.

This is fixed by handing over a correct override value within
the functional test bootstrap.

[1] https://github.com/TYPO3/testing-framework/issues/577
[2] https://github.com/TYPO3/testing-framework/pull/633

Resolves: #658
Related: #633
Related: https://github.com/TYPO3/testing-framework/pull/633/commits/409c2b8e4551a9bdb40703e09c48ffcea2d74c42
Releases: 8
