### PR TITLE
[TASK] Allow defining test instance files copy for acceptance tests

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -199,7 +199,7 @@ class Testbase
 
         $linksToSet = [];
         $coreExtensions = array_unique(array_merge($defaultCoreExtensionsToLoad, $coreExtensionsToLoad));
-        // @todo Fallback to all system extensions needed for TYPO3 acceptanceInstall tests.
+        // Fallback to all system extensions needed for TYPO3 acceptanceInstall tests.
         if ($coreExtensions === []) {
             $coreExtensions = $this->composerPackageManager->getSystemExtensionExtensionKeys();
         }
@@ -266,6 +266,46 @@ class Testbase
                 );
             }
             file_put_contents($target, $entryPointContent);
+        }
+    }
+
+    public function provideInstance(array $additionalHtaccessFiles = []): void
+    {
+        $copyFiles = [
+            // Create favicon.ico to suppress potential javascript errors in console
+            // which are caused by calling a non html in the browser, e.g. seo sitemap xml
+            'typo3/sysext/backend/Resources/Public/Icons/favicon.ico' => [
+                'favicon.ico',
+            ],
+            // Provide some files into the test instance normally added by installer
+            'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess' => [
+                '.htaccess',
+            ],
+            'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/resources-root-htaccess' => [
+                'fileadmin/.htaccess',
+            ],
+            'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-htaccess' => [
+                'fileadmin/_temp_/.htaccess',
+            ],
+            'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-index.html' => [
+                'fileadmin/_temp_/index.html',
+            ],
+            'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/typo3temp-var-htaccess' => [
+                'typo3temp/var/.htaccess',
+            ],
+        ];
+        foreach ($copyFiles as $sourceFile => $targetFiles) {
+            foreach ($targetFiles as $targetFile) {
+                $this->createDirectory(dirname(ltrim($targetFile, '/')));
+                $sourceFile = ltrim($sourceFile, '/');
+                $targetFile = ltrim($targetFile, '/');
+                if (!@copy($sourceFile, $targetFile)) {
+                    throw new \RuntimeException(
+                        sprintf('Could not copy "%s" to "%s".', $sourceFile, $targetFile),
+                        1733391799,
+                    );
+                }
+            }
         }
     }
 
@@ -977,5 +1017,111 @@ class Testbase
     {
         echo $message . chr(10);
         exit(1);
+    }
+
+    /**
+     * Copy files within the test instance path `$instancePath`.
+     *
+     * @param string $instancePath The test instance path.
+     * @param array<string, string[]> $files
+     * @throws Exception
+     */
+    public function copyInstanceFiles(string $instancePath, array $files, bool $createTargetFolder = true): void
+    {
+        if ($files === []) {
+            return;
+        }
+        foreach ($files as $sourceFile => $targetFiles) {
+            foreach ($targetFiles as $targetFile) {
+                $this->copyInstanceFile($instancePath, $sourceFile, $targetFile, $createTargetFolder);
+            }
+        }
+    }
+
+    /**
+     * Copy one file within the test instance with the option to create the target path.
+     *
+     * @param string $instancePath The test instance path.
+     * @param string $sourceFile Relative source file path within test instance.
+     * @param string $targetFile Target file path within test instance.
+     * @param bool $createTargetFolder True to create target folder it does not exists, otherwise exception is thrown.
+     * @throws Exception
+     */
+    public function copyInstanceFile(string $instancePath, string $sourceFile, string $targetFile, bool $createTargetFolder = true): void
+    {
+        if (str_starts_with($sourceFile, '/')) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Source "%s" must be relative from test instance path and must not start with "/".',
+                    $sourceFile,
+                ),
+                1733392183,
+            );
+        }
+        if (str_starts_with($targetFile, '/')) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Target "%s" must be relative from test instance path and must not start with "/".',
+                    $targetFile,
+                ),
+                1733392258,
+            );
+        }
+        if (trim($sourceFile, '/') === '') {
+            throw new \RuntimeException(
+                sprintf(
+                    'Source "%s" must not be empty or "/".',
+                    $sourceFile,
+                ),
+                1733392321,
+            );
+        }
+        if (trim($targetFile, '/') === '') {
+            throw new \RuntimeException(
+                sprintf(
+                    'Target "%s" must not be empty or "/".',
+                    $targetFile,
+                ),
+                1733392321,
+            );
+        }
+        $instancePath = rtrim($instancePath, '/');
+        $sourceFileFull = $instancePath . '/' . $sourceFile;
+        $targetFileFull = $instancePath . '/' . $targetFile;
+        $targetPath = rtrim(dirname($targetFile), '/');
+        $targetPathFull = $instancePath . '/' . $targetPath;
+        if (!is_dir($targetPathFull)) {
+            if (!$createTargetFolder) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Target instance path "%s" does not exists and should not be created, but is required.',
+                        $targetPath,
+                    ),
+                    1733392917,
+                );
+            }
+            $this->createDirectory($targetPathFull);
+        }
+        if (!file_exists($sourceFileFull)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Source file "%s" does not exists within test instance "%s" and could not be copied to "%s".',
+                    $sourceFile,
+                    $instancePath,
+                    $targetFile,
+                ),
+                1733393186,
+            );
+        }
+        if (!@copy($sourceFileFull, $targetFileFull)) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Could not copy "%s" to "%s".',
+                    $sourceFile,
+                    $targetFile,
+                ),
+                1733391799,
+            );
+        }
     }
 }


### PR DESCRIPTION
[TASK] Allow defining test instance files copy for acceptance tests

Running acceptance tests with codeception on a created
test instance with a real `Apache2` webserver requires
to have the `.htaccess` files in place, otherwise the
required rewriting to the endpoints will not work.

Since TYPO3 v13 with droppend backend entrypoint this
grows to a even higher requirement.

TYPO3 monorepo implemented that directly within the
extended `BackendEnvironment` class.

To make the live for developers easier using the
`typo3/testing-framework` for project or extension
acceptance testing a new tooling is now added based
on the direct monorepo implementation.

Following `BackendEnvironment::$config[]` options are
now available:

* `'copyInstanceFiles' => [],` (`array<string, string[]>`)
  to copy the soureFile to all listed target paths.        
* `'copyInstanceFilesCreateTargetPath' => true,` to
  configure if target folders should be created when
  missing or throw a excetion.

`BackendEnvironment` applies default files to copy based on
available core extensions:

* `EXT:backend`
  source.: 'typo3/sysext/backend/Resources/Public/Icons/favicon.ico'
  targets:
    - 'favicon.ico'

* `EXT:install`
  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess'
  targets: 
    - '.htaccess'

  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-htaccess'
  targets:
    - 'fileadmin/_temp_/.htaccess'

  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-index.html'
  targets:
   - 'fileadmin/_temp_/index.html'

  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/typo3temp-var-htaccess'
  targets:
    . 'typo3temp/var/.htaccess',

That way, additional files could be defined and configured
instead of implementing custom code in the extended class.

Note that files are always provided, which does not hurt
when not using `Apache2` as acceptance instance webserver.

Releases: main, 8