### PR TITLE
[TASK] Allow defining test instance files copy for acceptance tests

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -22,7 +22,9 @@ use Codeception\Events;
 use Codeception\Extension;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Composer\ComposerPackageManager;
 use TYPO3\TestingFramework\Core\Functional\Framework\DataHandling\DataSet;
 use TYPO3\TestingFramework\Core\Testbase;
 
@@ -148,6 +150,19 @@ abstract class BackendEnvironment extends Extension
          * Example: [ __DIR__ . '/../../Fixtures/BackendEnvironment.csv' ]
          */
         'csvDatabaseFixtures' => [],
+
+        /**
+         * Copy files within created test instance.
+         *
+         * @var array<string, string[]>
+         */
+        'copyInstanceFiles' => [],
+
+        /**
+         * Should target paths for self::$config['copyInstanceFiles'] be created.
+         * Will throw an exception if folder does not exists and set to `false`.
+         */
+        'copyInstanceFilesCreateTargetPath' => true,
     ];
 
     /**
@@ -170,6 +185,11 @@ abstract class BackendEnvironment extends Extension
         Events::SUITE_BEFORE => 'bootstrapTypo3Environment',
         Events::TEST_BEFORE => 'cleanupTypo3Environment',
     ];
+
+    /**
+     * @var string|null Test instance path when created.
+     */
+    protected ?string $instancePath = null;
 
     /**
      * Initialize config array, called before events.
@@ -231,7 +251,7 @@ abstract class BackendEnvironment extends Extension
         $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance');
         $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
 
-        $instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
+        $instancePath = $this->instancePath = ORIGINAL_ROOT . 'typo3temp/var/tests/acceptance';
         putenv('TYPO3_PATH_ROOT=' . $instancePath);
         putenv('TYPO3_PATH_APP=' . $instancePath);
         $testbase->setTypo3TestingContext();
@@ -312,6 +332,13 @@ abstract class BackendEnvironment extends Extension
         // @todo: See which other possible state should be dropped here again (singletons, ...?)
         restore_error_handler();
 
+        $this->applyDefaultCopyInstanceFilesConfiguration();
+        $copyInstanceFilesCreateTargetPaths = (bool)($this->config['copyInstanceFilesCreateTargetPath'] ?? true);
+        $copyInstanceFiles = $this->config['copyInstanceFiles'] ?? [];
+        if (is_array($copyInstanceFiles) && $copyInstanceFiles !== []) {
+            $testbase->copyInstanceFiles($instancePath, $copyInstanceFiles, $copyInstanceFilesCreateTargetPaths);
+        }
+
         // Unset a closure or phpunit kicks in with a 'serialization of \Closure is not allowed'
         // Alternative solution:
         // unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['cliKeys']['extbase']);
@@ -336,5 +363,95 @@ abstract class BackendEnvironment extends Extension
         GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable('be_users')
             ->update('be_users', ['uc' => null], ['uid' => 1]);
+    }
+
+    private function applyDefaultCopyInstanceFilesConfiguration(): void
+    {
+        if ($this->hasExtension('typo3/cms-backend')) {
+            ArrayUtility::mergeRecursiveWithOverrule(
+                $this->config,
+                [
+                    'copyInstanceFiles' => [
+                        // Create favicon.ico to suppress potential javascript errors in console
+                        // which are caused by calling a non html in the browser, e.g. seo sitemap xml
+                        'typo3/sysext/backend/Resources/Public/Icons/favicon.ico' => [
+                            'favicon.ico',
+                        ],
+                    ],
+                ]
+            );
+        }
+        if ($this->hasExtension('typo3/cms-install')) {
+            ArrayUtility::mergeRecursiveWithOverrule(
+                $this->config,
+                [
+                    'copyInstanceFiles' => [
+                        // Provide some files into the test instance normally added by installer
+                        'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess' => [
+                            '.htaccess',
+                        ],
+                        'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/resources-root-htaccess' => [
+                            'fileadmin/.htaccess',
+                        ],
+                        'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-htaccess' => [
+                            'fileadmin/_temp_/.htaccess',
+                        ],
+                        'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-index.html' => [
+                            'fileadmin/_temp_/index.html',
+                        ],
+                        'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/typo3temp-var-htaccess' => [
+                            'typo3temp/var/.htaccess',
+                        ],
+                    ],
+                ]
+            );
+        }
+    }
+
+    /**
+     * Verify if extension is available in the system and within the acceptance test instance.
+     */
+    protected function hasExtension(string $extensionKeyOrComposerPackageName): bool
+    {
+        $instanceExtensions = $this->getInstanceExtensionKeys(
+            $this->config['coreExtensionsToLoad'],
+            $this->config['testExtensionsToLoad'],
+        );
+        $packageInfo = (new ComposerPackageManager())->getPackageInfo($extensionKeyOrComposerPackageName);
+        if ($packageInfo === null) {
+            return false;
+        }
+        return $packageInfo->getExtensionKey() !== '' && in_array($packageInfo->getExtensionKey(), $instanceExtensions, true);
+    }
+
+    /**
+     * Gather list of extension keys available within created test instance
+     * based on `coreExtensionsToLoad` and `testExtensionToLoad` config.
+     */
+    private function getInstanceExtensionKeys(
+        array $coreExtensionsToLoad,
+        array $testExtensionsToLoad,
+    ): array {
+        $composerPackageManager = new ComposerPackageManager();
+        if ($coreExtensionsToLoad === []) {
+            // Fallback to all system extensions needed for TYPO3 acceptanceInstall tests.
+            $coreExtensionsToLoad = $composerPackageManager->getSystemExtensionExtensionKeys();
+        }
+        $result = [];
+        foreach ($coreExtensionsToLoad as $extensionKeyOrComposerPackageName) {
+            $packageInfo = $composerPackageManager->getPackageInfo($extensionKeyOrComposerPackageName);
+            if ($packageInfo === null || $packageInfo->getExtensionKey() === '') {
+                continue;
+            }
+            $result[] = $packageInfo->getExtensionKey();
+        }
+        foreach ($testExtensionsToLoad as $extensionKeyOrComposerPackageName) {
+            $packageInfo = $composerPackageManager->getPackageInfo($extensionKeyOrComposerPackageName);
+            if ($packageInfo === null || $packageInfo->getExtensionKey() === '') {
+                continue;
+            }
+            $result[] = $packageInfo->getExtensionKey();
+        }
+        return $result;
     }
 }


### PR DESCRIPTION
[TASK] Allow defining test instance files copy for acceptance tests

Running acceptance tests with codeception on a created
test instance with a real `Apache2` webserver requires
to have the `.htaccess` files in place, otherwise the
required rewriting to the endpoints will not work.

Since TYPO3 v13 with droppend backend entrypoint this
grows to a even higher requirement.

TYPO3 monorepo implemented that directly within the
extended `BackendEnvironment` class.

To make the live for developers easier using the
`typo3/testing-framework` for project or extension
acceptance testing a new tooling is now added based
on the direct monorepo implementation.

Following `BackendEnvironment::$config[]` options are
now available:

* `'copyInstanceFiles' => [],` (`array<string, string[]>`)
  to copy the soureFile to all listed target paths.        
* `'copyInstanceFilesCreateTargetPath' => true,` to
  configure if target folders should be created when
  missing or throw a excetion.

`BackendEnvironment` applies default files to copy based on
available core extensions:

* `EXT:backend`
  source.: 'typo3/sysext/backend/Resources/Public/Icons/favicon.ico'
  targets:
    - 'favicon.ico'

* `EXT:install`
  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess'
  targets: 
    - '.htaccess'

  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-htaccess'
  targets:
    - 'fileadmin/_temp_/.htaccess'

  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/fileadmin-temp-index.html'
  targets:
   - 'fileadmin/_temp_/index.html'

  source.: 'typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/typo3temp-var-htaccess'
  targets:
    . 'typo3temp/var/.htaccess',

That way, additional files could be defined and configured
instead of implementing custom code in the extended class.

Note that files are always provided, which does not hurt
when not using `Apache2` as acceptance instance webserver.

Releases: main, 8
Related: #663 