### PR TITLE
[BUGFIX] Allow to process versions of language variants

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
+++ b/Classes/Core/Functional/Framework/DataHandling/Scenario/DataHandlerFactory.php
@@ -220,7 +220,14 @@ class DataHandlerFactory
         if (isset($itemSettings['actions'])) {
             $this->setInCommandMap($tableName, $newId, $nodeId, $itemSettings['actions'], (int)$workspaceId);
         }
-
+        foreach ($itemSettings['versionVariants'] ?? [] as $versionVariantSettings) {
+            $this->processVersionVariantItem(
+                $entityConfiguration,
+                $versionVariantSettings,
+                $newId,
+                $nodeId
+            );
+        }
         foreach ($itemSettings['languageVariants'] ?? [] as $variantItemSettings) {
             $this->processLanguageVariantItem(
                 $entityConfiguration,


### PR DESCRIPTION
This change allows for YAML-based fixtures
to also add version variants for a language variant
thus, making it fully overlayable.

See https://review.typo3.org/c/Packages/TYPO3.CMS/+/72015

Backport of #669
