### PR TITLE
[TASK] Improve error message

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/ActionService.php
+++ b/Classes/Core/Functional/Framework/DataHandling/ActionService.php
@@ -428,7 +428,7 @@ class ActionService
                 $versionedUid = $this->getVersionedId($tableName, (int)$liveUid);
                 if (empty($versionedUid)) {
                     if ($throwException) {
-                        throw new Exception('Versioned UID could not be determined', 1476049592);
+                        throw new Exception('Versioned UID of ' . $tableName . ':' . $liveUid . ' could not be determined', 1476049592);
                     }
                     continue;
                 }


### PR DESCRIPTION
When a versioned record cannot be found, the
DB table and the UID of the live record is now
added to the message of the exception.