### PR TITLE
[TASK] Set version branch alias for `dev-main`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,5 +66,10 @@
   },
   "replace": {
     "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "*"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "9.x-dev"
+    }
   }
 }


### PR DESCRIPTION
Composer and packagist automatically defines alias
for version looking branches, for example `7.x-dev`
for a branch called `7`. Even with tagged versions
and version branches in place, there is no automatic
"next highest" major alias for the default branch,
for example `main`.

To allow extension and projects to specifcy a concrete
development without using the branch, for example with
`composer req --dev typo3/testing-framework:'9.*.*@dev'`
branch alias for dev-main is set to the current major
development version for the main branch.

Note that that allows us to branch out main into a `9`
branch in the future and updating the branch alias of
main and extension will stay on the suitiable branch
for their TYPO3 versions without forced to new major.

Used command(s):

```shell
composer config extra."branch-alias"."dev-main" "9.x-dev"
```
