### PR TITLE
Truncate cascade on non-mysql database platforms for Testbase

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -869,7 +869,7 @@ class Testbase
 
         $schemaManager = $connection->createSchemaManager();
         foreach ($schemaManager->listTables() as $table) {
-            $connection->truncate($table->getName());
+            $connection->truncate($table->getName(), true);
             self::resetTableSequences($connection, $table->getName());
         }
     }


### PR DESCRIPTION
When using typo3/testing-framework with Postgres, you get the following error for tables with foreign keys:
```
PDOException: SQLSTATE[0A000]: Feature not supported: 7 ERROR:  cannot truncate a table referenced in a foreign key constraint
DETAIL:  Table "tx_groups_members_mm" references "fe_users".
HINT:  Truncate table "tx_groups_members_mm" at the same time, or use TRUNCATE ... CASCADE.
```

This is caused by `\TYPO3\TestingFramework\Core\Testbase::truncateAllTablesForOtherDatabases`, because the cascade argument is false by default.

This PR simply sets cascade to true.
Given that only the PostgreSQLPlatform uses the parameter atm, I don't think there will be any side effects.