### PR TITLE
[TASK] Avoid value decoding in `DataSet::import()`

### DIFF
--- a/Classes/Core/Functional/Framework/DataHandling/DataSet.php
+++ b/Classes/Core/Functional/Framework/DataHandling/DataSet.php
@@ -85,14 +85,14 @@ final readonly class DataSet
                     $types[] = $columnType->getBindingType();
                 }
                 // Insert the row
-                $connection->insert($tableName, $element, $types);
+                $connection->insert($tableName, $element, $types, true);
             }
             Testbase::resetTableSequences($connection, $tableName);
         }
     }
 
     /**
-     * Main entry method: Get at absosulete (!) path to a .csv file, read it and return an instance of self
+     * Main entry method: Get at absolute (!) path to a .csv file, read it and return an instance of self
      */
     public static function read(string $fileName, bool $applyDefaultValues = false, bool $checkForDuplicates = false): self
     {


### PR DESCRIPTION
TYPO3 v14 no longer converts values to database values
when using `Connection::insert()`, which makes decoding
values from CSV DataSet files an error.

One solution would be to pass the argument to enforce
converting values again, which is used here.

This is possible since an early introduction of the
method argument with [1] and becomes mandantory with
[2] flipping the default value.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/89293
[2] https://review.typo3.org/c/Packages/TYPO3.CMS/+/90957

Releases: main
