### PR TITLE
[BUGFIX] Improve package name resolving

### DIFF
--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -655,7 +655,6 @@ final class ComposerPackageManager
             rtrim($this->rootPackage()->getVendorDir(), '/') . '/',
             rtrim($this->rootPackage()->getWebDir(), '/') . '/',
             rtrim($this->getRootPath(), '/') . '/',
-            basename($this->getRootPath()) . '/',
         ];
         foreach ($removePaths as $removePath) {
             if (str_starts_with($path, $removePath)) {

--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -101,7 +101,7 @@ final class ComposerPackageManager
      */
     public function getPackageInfo(string $name): ?PackageInfo
     {
-        return self::$packages[$this->resolvePackageName($name)] ?? null;
+        return self::$packages[$name] ?? self::$packages[$this->resolvePackageName($name)] ?? null;
     }
 
     /**

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -628,7 +628,7 @@ class Testbase
 
         // Activate test extensions that have been symlinked before
         foreach ($testExtensionPaths as $extensionPath) {
-            if ($packageInfo = $this->composerPackageManager->getPackageInfo($extensionPath)) {
+            if ($packageInfo = $this->composerPackageManager->getPackageInfoWithFallback($extensionPath)) {
                 $extensionName = $packageInfo->getExtensionKey();
             } else {
                 $extensionName = basename($extensionPath);

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -197,6 +197,27 @@ final class ComposerPackageManagerTest extends UnitTestCase
         self::assertTrue($packageInfo->isSystemExtension());
     }
 
+    /**
+     * A composer package name whose vendor segment matches one of the path
+     * prefixes removed for classic mode notation must not be rewritten before
+     * looking it up. The fixture extension used here is named
+     * `testing-framework/extension-absolute`, and `testing-framework` is the
+     * project root folder name of a default checkout.
+     */
+    #[Test]
+    public function knownPackageNameIsNotModifiedBeforeLookup(): void
+    {
+        $subject = new ComposerPackageManager();
+        // Register the fixture extension, it is not required by the root composer.json.
+        $subject->getPackageInfoWithFallback(__DIR__ . '/Fixtures/Extensions/ext_absolute');
+
+        $packageInfo = $subject->getPackageInfo('testing-framework/extension-absolute');
+
+        self::assertInstanceOf(PackageInfo::class, $packageInfo);
+        self::assertSame('testing-framework/extension-absolute', $packageInfo->getName());
+        self::assertSame('absolute_real', $packageInfo->getExtensionKey());
+    }
+
     #[Test]
     public function extensionWithoutJsonCanBeResolvedByAbsolutePath(): void
     {

--- a/Tests/Unit/Composer/ComposerPackageManagerTest.php
+++ b/Tests/Unit/Composer/ComposerPackageManagerTest.php
@@ -471,6 +471,24 @@ final class ComposerPackageManagerTest extends UnitTestCase
         self::assertSame($expected, $resolved, sprintf('"%s" resolved to "%s"', $name, $expected));
     }
 
+    /**
+     * The project root folder name must not be removed as path prefix. It is a
+     * relative single segment prefix, and it therefore also matches the vendor
+     * segment of a composer package name, for example `typo3/cms-core` for a
+     * project checked out into a folder named `typo3`.
+     */
+    #[Test]
+    public function prepareResolvePackageNameKeepsProjectRootFolderNamePrefix(): void
+    {
+        $composerPackageManager = new ComposerPackageManager();
+        $name = basename($composerPackageManager->getRootPath()) . '/some-package';
+
+        $prepareResolvePackageNameReflectionMethod = new \ReflectionMethod($composerPackageManager, 'prepareResolvePackageName');
+        $resolved = $prepareResolvePackageNameReflectionMethod->invoke($composerPackageManager, $name);
+
+        self::assertSame($name, $resolved, sprintf('"%s" resolved to "%s"', $name, $resolved));
+    }
+
     public static function resolvePackageNameReturnsExpectedPackageNameDataProvider(): \Generator
     {
         yield 'Composer package name returns unchanged (not checked for existence)' => [

--- a/Tests/Unit/Core/Fixtures/Extensions/ext_folder_name/composer.json
+++ b/Tests/Unit/Core/Fixtures/Extensions/ext_folder_name/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "typo3/testing-framework-diverging-extension-key",
+    "description": "Test extension with a folder name differing from its extension key",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "*"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "diverging_extension_key",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
+        }
+    }
+}

--- a/Tests/Unit/Core/TestbaseTest.php
+++ b/Tests/Unit/Core/TestbaseTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TYPO3\TestingFramework\Tests\Unit\Core;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\TestingFramework\Core\Testbase;
+
+final class TestbaseTest extends TestCase
+{
+    private string $instancePath = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->instancePath !== '' && is_dir($this->instancePath)) {
+            $this->removeDirectory($this->instancePath);
+        }
+        $this->instancePath = '';
+        parent::tearDown();
+    }
+
+    /**
+     * Testbase::linkTestExtensionsToInstance() symlinks a test extension using the
+     * extension key determined by ComposerPackageManager::getPackageInfoWithFallback().
+     * Testbase::setUpPackageStates() must determine the very same name, otherwise the
+     * written PackageStates.php points to a non-existing package path.
+     */
+    #[Test]
+    public function setUpPackageStatesUsesExtensionKeyOfTestExtensionAndNotItsFolderName(): void
+    {
+        $extensionPath = __DIR__ . '/Fixtures/Extensions/ext_folder_name';
+        // Folder name and extension key of the fixture extension differ on purpose.
+        self::assertSame('ext_folder_name', basename($extensionPath));
+
+        $this->instancePath = $this->createTestInstance();
+        // Symlink the extension the way linkTestExtensionsToInstance() does it.
+        symlink($extensionPath, $this->instancePath . '/typo3conf/ext/diverging_extension_key');
+
+        $subject = new Testbase();
+        $subject->setUpPackageStates($this->instancePath, [], [], [$extensionPath], []);
+
+        $packageStates = require $this->instancePath . '/typo3conf/PackageStates.php';
+
+        self::assertArrayHasKey('diverging_extension_key', $packageStates['packages']);
+        self::assertArrayNotHasKey('ext_folder_name', $packageStates['packages']);
+        self::assertSame(
+            'typo3conf/ext/diverging_extension_key/',
+            $packageStates['packages']['diverging_extension_key']['packagePath']
+        );
+    }
+
+    private function createTestInstance(): string
+    {
+        $instancePath = sys_get_temp_dir() . '/testbase-' . bin2hex(random_bytes(8));
+        mkdir($instancePath . '/typo3conf/ext', 0775, true);
+        return $instancePath;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        foreach ((array)scandir($path) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $entryPath = $path . '/' . $entry;
+            if (is_link($entryPath) || is_file($entryPath)) {
+                unlink($entryPath);
+                continue;
+            }
+            $this->removeDirectory($entryPath);
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
Resolving a value to a composer package went through
`ComposerPackageManager::resolvePackageName()`, which strips a list of known
path prefixes before the lookup is done. One of those prefixes was the plain
base name of the project root folder.

That entry is a relative single segment prefix, so it also matches the vendor
segment of a composer package name. For a project checked out into a folder
named `typo3`, the value `typo3/testing-framework` was reduced to
`testing-framework` and `typo3/sysext/core` to `sysext/core`. Both lookups then
fail, and functional tests abort with a method call on null:

```
Error: Call to a member function getRealPath() on null
vendor/typo3/testing-framework/Classes/Core/Testbase.php:369
```

This is reproducible with the TYPO3 core itself:

```bash
git clone https://github.com/typo3/typo3
cd typo3
Build/Scripts/runTests.sh -s composerInstall
Build/Scripts/runTests.sh -s functional typo3/sysext/core/Tests/Functional/Authentication/AbstractUserAuthenticationTest.php
```

The same mechanism hits any project whose root folder is named like one of its
composer vendors.

A second, independent defect surfaced while verifying this:
`Testbase::linkTestExtensionsToInstance()` determines the name of a test
extension with `getPackageInfoWithFallback()` and symlinks it into the test
instance under the resolved extension key, while
`Testbase::setUpPackageStates()` determines it with `getPackageInfo()`, which
only handles composer package names and extension keys. For a local extension
that is not required by the root `composer.json` that lookup fails and the code
falls back to the directory base name. If the directory name differs from the
extension key, `PackageStates.php` points to a path that was never created:

```
TYPO3\CMS\Core\Package\Exception\InvalidPackagePathException: Tried to
instantiate a package object for package "client_clientname" with a
non-existing package path ".../typo3conf/ext/client_clientname/".
```

## Changes

The three commits are kept separate and are bisectable:

1. **Remove obsolete basename removePrefixPath** — drops the project root folder
   base name from the prefix list in `removePrefixPaths()`. The entry had been
   added together with the relative path handling in
   `getPackageFromPathFallback()`, which resolves `../<root>/…` values by
   prefixing the project root real path and canonicalizing the result; the base
   name entry is not needed for that. Resolves #665.
2. **Prevent resolving existing package names** — `getPackageInfo()` now looks up
   the handed over value first and only falls back to the resolved name if it is
   not a known composer package. A value that already is a known package name
   does not need normalization at all. Resolves #665.
3. **Resolve test extension paths consistently** — `setUpPackageStates()` uses
   `getPackageInfoWithFallback()`, the same way `linkTestExtensionsToInstance()`
   already does, so both call sites derive the extension key identically.
   Resolves #683.

## Tests

Each commit carries its own regression test:

* `ComposerPackageManagerTest::prepareResolvePackageNameKeepsProjectRootFolderNamePrefix()`
  asserts that `<project-root-folder-name>/some-package` is not rewritten.
* `ComposerPackageManagerTest::knownPackageNameIsNotModifiedBeforeLookup()`
  registers a fixture extension and looks it up by its composer package name.
* `TestbaseTest::setUpPackageStatesUsesExtensionKeyOfTestExtensionAndNotItsFolderName()`
  builds a minimal test instance, symlinks a fixture extension whose folder name
  differs from its extension key, and asserts the written `PackageStates.php`
  entry. Without commit 3 this test fails with the
  `InvalidPackagePathException` quoted above.

All three tests fail against `main` and pass with the respective commit applied.

## Verification

Run locally on PHP 8.2 (podman):

```
Build/Scripts/runTests.sh -s composerUpdate   SUCCESS
Build/Scripts/runTests.sh -s cgl -n           SUCCESS
Build/Scripts/runTests.sh -s lint             SUCCESS
Build/Scripts/runTests.sh -s phpstan          SUCCESS
Build/Scripts/runTests.sh -s unit             OK (127 tests, 337 assertions)
```

Additionally verified against a TYPO3 project checkout placed in a folder named
`typo3` (issue #665) and against a project with a local, non-required extension
package whose folder name differs from its extension key (issue #683).

Resolves: #665
Resolves: #683
Releases: main, 9, 8
