### PR TITLE
[TASK] Accept test deprecation

### DIFF
--- a/Tests/Unit/Core/PackageCollectionTest.php
+++ b/Tests/Unit/Core/PackageCollectionTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Typo3\TestingFramework\Tests\Unit\Core;
 
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Package\PackageManager;
@@ -33,6 +34,7 @@ use TYPO3\TestingFramework\Core\PackageCollection;
 final class PackageCollectionTest extends TestCase
 {
     #[Test]
+    #[IgnoreDeprecations]
     public function sortsComposerPackages(): void
     {
         $packageStates = require __DIR__ . '/../Fixtures/Packages/PackageStates.php';


### PR DESCRIPTION
With recent core main changes related to ext_emconf.php works, a single unit test needs a #[IgnoreDepreation] marker.