### PR TITLE
[TASK] Bootstrap::loadExtTables()

### DIFF
--- a/Build/phpstan/phpstan-baseline.neon
+++ b/Build/phpstan/phpstan-baseline.neon
@@ -35,3 +35,9 @@ parameters:
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: ../../Classes/Core/Functional/FunctionalTestCase.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''TYPO3\\\\CMS\\\\Core\\\\Core\\\\Bootstrap'' and ''loadExtTables'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../../Classes/Core/Testbase.php

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -880,7 +880,9 @@ class Testbase
      */
     public function loadExtensionTables(): void
     {
-        Bootstrap::loadExtTables();
+        if (method_exists(Bootstrap::class, 'loadExtTables')) {
+            Bootstrap::loadExtTables();
+        }
     }
 
     /**


### PR DESCRIPTION
The core method is removed in v15 due to
removal of ext_table.php processing. Guard
it to not break v14.