### PR TITLE
[TASK] Declare codeception related files deprecated (#722)

### DIFF
--- a/Classes/Core/Acceptance/Extension/BackendEnvironment.php
+++ b/Classes/Core/Acceptance/Extension/BackendEnvironment.php
@@ -32,6 +32,10 @@ use TYPO3\TestingFramework\Core\Testbase;
  * typo3temp. Own acceptance test suites should extend from this class
  * and change the properties. This can be used to not copy the whole
  * bootstrapTypo3Environment() method but reuse it instead.
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 abstract class BackendEnvironment extends Extension
 {

--- a/Classes/Core/Acceptance/Helper/AbstractModalDialog.php
+++ b/Classes/Core/Acceptance/Helper/AbstractModalDialog.php
@@ -28,6 +28,10 @@ use TYPO3\CMS\Core\Tests\Acceptance\Support\ApplicationTester;
  * |                                |
  * |            [no] [maybe] [yeah] |
  *  --------------------------------
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 abstract class AbstractModalDialog
 {

--- a/Classes/Core/Acceptance/Helper/AbstractPageTree.php
+++ b/Classes/Core/Acceptance/Helper/AbstractPageTree.php
@@ -21,6 +21,10 @@ use Facebook\WebDriver\Remote\RemoteWebElement;
 
 /**
  * Helper class to interact with the page tree
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 abstract class AbstractPageTree
 {

--- a/Classes/Core/Acceptance/Helper/Acceptance.php
+++ b/Classes/Core/Acceptance/Helper/Acceptance.php
@@ -23,6 +23,10 @@ use Codeception\Step;
 
 /**
  * Helper class to verify javascript browser console does not throw errors.
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 class Acceptance extends Module
 {

--- a/Classes/Core/Acceptance/Helper/Login.php
+++ b/Classes/Core/Acceptance/Helper/Login.php
@@ -26,6 +26,10 @@ use TYPO3\CMS\Core\Session\UserSession;
 
 /**
  * Helper class to log in backend users and load backend.
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 class Login extends Module
 {

--- a/Classes/Core/Acceptance/Helper/Topbar.php
+++ b/Classes/Core/Acceptance/Helper/Topbar.php
@@ -19,6 +19,10 @@ namespace TYPO3\TestingFramework\Core\Acceptance\Helper;
 
 /**
  * Helper to interact with the Topbar
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 class Topbar
 {

--- a/Classes/Core/Acceptance/Step/FrameSteps.php
+++ b/Classes/Core/Acceptance/Step/FrameSteps.php
@@ -24,6 +24,10 @@ use Facebook\WebDriver\WebDriverBy;
 /**
  * Trait for AcceptanceTester ("$I") extending testing class
  * with helper methods for the backend.
+ *
+ * @deprecated: TYPO3 core v14 and v15 switched from codeception to playwright.
+ *              The testing-framework codeception related scaffolding files and
+ *              helpers will be removed with testing-framework v10.
  */
 trait FrameSteps
 {


### PR DESCRIPTION
TYPO3 core v14 and v15 finished the migration from codeception to playwright. The patch declares related files `@deprecated` for TF v9 and main/v10. They will be removed from main/v10 in another patch.

Resolves: #719
Releases: main, 9