### PR TITLE
[TASK] Allow installation of guzzlehttp/psr7 v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^8.2",
     "composer/class-map-generator": "^1.3.4",
-    "guzzlehttp/psr7": "^2.5.0",
+    "guzzlehttp/psr7": "^2.5.0 || ^3.0",
     "phpunit/phpunit": "^11.2.5 || ^12.1.2 || ^13.0.2",
     "psr/container": "^2.0",
     "typo3/cms-backend": "14.*.*@dev || 15.*.*@dev",


### PR DESCRIPTION
In order to prepare for guzzlehttp/guzzle v8 in
TYPO3 core, we allow the installation of the
`guzzlehttp/psr7` helper package.

composer req guzzlehttp/psr7:"^2.5.0 || ^3.0"

Releases: main, 9, 8