### PR TITLE
[TASK] Fix failing quality gates on main

### DIFF
--- a/Classes/Composer/ComposerPackageManager.php
+++ b/Classes/Composer/ComposerPackageManager.php
@@ -392,7 +392,7 @@ final class ComposerPackageManager
             return null;
         }
         try {
-            return json_decode((string)file_get_contents($composerFile), true, JSON_THROW_ON_ERROR);
+            return json_decode((string)file_get_contents($composerFile), true, 512, JSON_THROW_ON_ERROR);
         } catch (\Throwable) {
             // skipped
         }

--- a/Tests/Unit/Core/PackageCollectionTest.php
+++ b/Tests/Unit/Core/PackageCollectionTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Typo3\TestingFramework\Tests\Unit\Core;
 
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Package\PackageManager;
@@ -34,7 +33,6 @@ use TYPO3\TestingFramework\Core\PackageCollection;
 final class PackageCollectionTest extends TestCase
 {
     #[Test]
-    #[IgnoreDeprecations]
     public function sortsComposerPackages(): void
     {
         $packageStates = require __DIR__ . '/../Fixtures/Packages/PackageStates.php';
@@ -69,9 +67,9 @@ final class PackageCollectionTest extends TestCase
 
         self::assertSame(5, array_search('package0', array_keys($result)), 'Package 0 is not stored at loading order 5.');
         self::assertSame(6, array_search('package1', array_keys($result)), 'Package 1 is not stored at loading order 6.');
-        self::assertSame(7, array_search('extension_unsynced_extemconf', array_keys($result)), 'extension_unsynced_extemconf is not stored at loading order 7.');
+        self::assertSame(7, array_search('extension2_unsynced_extemconf', array_keys($result)), 'extension2_unsynced_extemconf is not stored at loading order 7.');
         self::assertSame(8, array_search('extension_with_extemconf', array_keys($result)), 'extension_with_extemconf is not stored at loading order 8.');
-        self::assertSame(9, array_search('extension2_unsynced_extemconf', array_keys($result)), 'extension2_unsynced_extemconf is not stored at loading order 9.');
+        self::assertSame(9, array_search('extension_unsynced_extemconf', array_keys($result)), 'extension_unsynced_extemconf is not stored at loading order 9.');
         self::assertSame(10, array_search('package2', array_keys($result)), 'Package 2 is not stored at loading order 10.');
         self::assertSame($expectedPackageStates['packages'], $result, 'Sorted packages does not match expected order');
     }

--- a/Tests/Unit/Fixtures/Packages/PackageStates_sorted.php
+++ b/Tests/Unit/Fixtures/Packages/PackageStates_sorted.php
@@ -23,14 +23,14 @@ return [
         'package1' => [
             'packagePath' => 'Tests/Unit/Fixtures/Packages/package1/',
         ],
-        'extension_unsynced_extemconf' => [
-            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/',
+        'extension2_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/',
         ],
         'extension_with_extemconf' => [
             'packagePath' => 'Tests/Unit/Fixtures/Packages/package-with-extemconf/',
         ],
-        'extension2_unsynced_extemconf' => [
-            'packagePath' => 'Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/',
+        'extension_unsynced_extemconf' => [
+            'packagePath' => 'Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/',
         ],
         'package2' => [
             'packagePath' => 'Tests/Unit/Fixtures/Packages/package2/',

--- a/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-unsynced-extemconf/composer.json
@@ -11,7 +11,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "extension_unsynced_extemconf"
+            "extension-key": "extension_unsynced_extemconf",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }

--- a/Tests/Unit/Fixtures/Packages/package-with-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package-with-extemconf/composer.json
@@ -12,7 +12,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "extension_with_extemconf"
+            "extension-key": "extension_with_extemconf",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }

--- a/Tests/Unit/Fixtures/Packages/package0/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package0/composer.json
@@ -11,7 +11,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "package0"
+            "extension-key": "package0",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }

--- a/Tests/Unit/Fixtures/Packages/package1/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package1/composer.json
@@ -15,7 +15,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "package1"
+            "extension-key": "package1",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }

--- a/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package2-unsynced-extemconf/composer.json
@@ -12,7 +12,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "extension2_unsynced_extemconf"
+            "extension-key": "extension2_unsynced_extemconf",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }

--- a/Tests/Unit/Fixtures/Packages/package2/composer.json
+++ b/Tests/Unit/Fixtures/Packages/package2/composer.json
@@ -17,7 +17,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "package2"
+            "extension-key": "package2",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes both quality gates that currently fail on `main`, independent of any
pending pull request. Both failures reproduce on a plain `main` checkout.

### `[BUGFIX] Pass JSON_THROW_ON_ERROR as flags`

`ComposerPackageManager::getPackageComposerJson()` passed `JSON_THROW_ON_ERROR`
as the third argument of `json_decode()`, which is `$depth`, leaving `$flags` at
`0`. The flag never took effect, the surrounding `try`/`catch` was dead code, and
`$depth` was set to `4194304`. Observable behaviour does not change, since
`json_decode()` returns `null` for invalid input, which already matched the
intended `null` fallback.

PHPStan 2.2 reports this as `argument.invalidConstant`. As `composer.lock` is not
part of the repository, CI resolves the latest PHPStan release, which turned a
long-standing defect into a failing gate on the PHP 8.2 and 8.3 jobs.

### `[TASK] Declare v15 package metadata in fixtures`

TYPO3 v15 no longer evaluates `ext_emconf.php` and requires extensions to declare
the extension version and the `providesPackages` definition in the
`extra/typo3/cms` section of `composer.json`, see deprecation #108345. Extensions
missing that metadata make the core `PackageManager` throw an
`InvalidPackageManifestException`:

```
InvalidPackageManifestException: The composer.json of extension "package2" must
declare the extension version and the "providesPackages" definition in the
"extra/typo3/cms" section.
```

Only the PHP 8.5 job hits this, because `typo3/cms-core` `dev-main` requires
`php: ^8.5`; the 8.2, 8.3 and 8.4 jobs resolve to `14.3.x-dev`.

The fixture `composer.json` files now declare `version` and an empty
`providesPackages` object. That metadata also marks an extension as "composer
only capable" for core v14 (`PackageManager::isComposerOnlyCapable()`), which
stops merging `ext_emconf.php` into the manifest there as well. Both supported
core versions therefore resolve package constraints from `composer.json` only and
provide the same loading order, so no core-version-aware expectations are needed.

The expected order changes accordingly: the "unsynced" fixtures declare a
dependency in `ext_emconf.php` that is not present in their `composer.json`, and
that dependency is no longer taken into account. `extension_unsynced_extemconf`
and `extension2_unsynced_extemconf` swap positions. The `IgnoreDeprecations`
attribute is dropped, as the fixtures no longer trigger the `ext_emconf.php`
deprecation on core v14.

### Test results

Full `ci.yml` matrix executed locally, `cgl` and `phpstan` only for PHP <= 8.3 as
in CI:

| PHP | resolved core | composerUpdate | cgl | phpstan | lint | unit |
| --- | --- | --- | --- | --- | --- | --- |
| 8.2 | 14.3.x-dev | OK | OK | OK | OK | OK |
| 8.3 | 14.3.x-dev | OK | OK | OK | OK | OK |
| 8.4 | 14.3.x-dev | OK | - | - | OK | OK |
| 8.5 | dev-main (v15) | OK | - | - | OK | OK |

### Follow-ups, not part of this pull request

* The `PackageCollection` class docblock still describes `ext_emconf.php` as the
  classic mode source of truth with a `composer.json` fallback, which is inverted
  now. The `@todo` in `PackageCollection::fromPackageStates()` is effectively
  answered by core v15.
* `Resources/Core/Functional/Extensions/{json_response,private_container}` still
  require `typo3/cms-core: 13.*.*@dev || 14.*.*@dev` while `main` targets v14 and
  v15. Both already declare the package metadata needed for v15.
* Test extensions of testing framework consumers that lack the package metadata
  will hard-fail on core v15 instead of degrading. Worth a release note for the
  next `10.x` tag.
