### PR TITLE
[BUGFIX] Skip class loading info dump in Composer mode

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Psr\Container\ContainerInterface;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Schema\SchemaManager\CoreSchemaManagerFactory;
@@ -764,10 +765,26 @@ class Testbase
     }
 
     /**
-     * Dump class loading information
+     * Dump class loading information.
+     *
+     * This is only relevant for non Composer mode ("classic mode") setups, where the
+     * Composer class loader does not know about extensions: the generated files add
+     * the class map, the PSR-4 prefixes and the class alias map of all active
+     * extensions - including their `Tests/` directories - to the class loader.
+     *
+     * Functional test instances are classic mode instances by definition, so they do
+     * need the dump. Unit tests on the other hand run in the scope of the outer
+     * Composer installation, where the Composer class loader is authoritative and
+     * `PackageManager::scanAvailablePackages()` bails out early: the dump would only
+     * write empty files - into the project root ("<project>/packages/autoload-tests/"
+     * since TYPO3 v14.3.1). Skip it, mirroring the `Environment::isComposerMode()`
+     * guards TYPO3 Core uses on all of its own call sites.
      */
     public function dumpClassLoadingInformation(): void
     {
+        if (Environment::isComposerMode()) {
+            return;
+        }
         if (!ClassLoadingInformation::isClassLoadingInformationAvailable()) {
             ClassLoadingInformation::dumpClassLoadingInformation();
             ClassLoadingInformation::registerClassLoadingInformation();


### PR DESCRIPTION
Closes #725

## Problem

`Testbase::dumpClassLoadingInformation()` is called unconditionally — also from
`Resources/Core/Build/UnitTestsBootstrap.php`, which runs in the scope of the **outer
Composer installation**.

TYPO3 v14.3.1 changed where the classic-mode autoload information of the testing context
is written. `ClassLoadingInformation::getClassLoadingInformationDirectory()` now derives
the directory from `Environment::getExtensionsPath()`, and that resolves to
`<projectRoot>/packages/ext` in Composer mode:

| | v13.4 | v14.3.1+ |
|---|---|---|
| `getExtensionsPath()` (Composer mode) | `<public>/typo3conf/ext` | `<project>/packages/ext` |
| dump dir (testing context) | `<public>/typo3conf/autoload-tests/` | `<project>/packages/autoload-tests/` |

So every unit test run now creates `<projectRoot>/packages/autoload-tests/` — colliding
with the directory many projects use for their own local extensions (the layout documented
in TYPO3's Composer best-practices guide). Previously the same dump landed in the web dir,
i.e. inside gitignored build output, and nobody noticed.

Accountable Core change: `edfb03ae775` / `770c5383930` *"[TASK] Allow public folder in
classic mode"*, [forge #109470](https://forge.typo3.org/issues/109470), Gerrit
[93491](https://review.typo3.org/c/Packages/TYPO3.CMS/+/93491) /
[93799](https://review.typo3.org/c/Packages/TYPO3.CMS/+/93799). First released in
**v14.3.1** — v14.0/14.2/14.3.0 are not affected, so this is not a testing-framework
version regression but a Core patch-level one.

## Why the dump can simply be skipped

It is a **no-op in Composer mode** and always has been. `PackageManager::scanAvailablePackages()`
returns early when `Environment::isComposerMode()` is true — identical code in v13.4.33 and
v14.3.5 — so `UnitTestPackageManager` registers zero packages and the generated files are
empty:

```
autoload_classaliasmap.php  118 bytes   # empty alias mappings
autoload_classmap.php       147 bytes   # return array();
autoload_files.php          147 bytes   # return array();
autoload_psr4.php           147 bytes   # return array();
```

Only the *location* regressed. Nothing can be lost by not writing them.

Every other consumer of this API in `typo3/cms-core` (`DumpAutoloadCommand`,
`MaintenanceController`, `SetupService`, `ClassLoadingInformationUpdater`) already guards on
Composer mode. `Testbase` was the only unguarded call site.

## Functional tests are not affected

This is the important part, because functional test instances genuinely **do** need the
classic-mode dump for their fixture extensions:

| Caller | Composer mode | Dump |
|---|---|---|
| `UnitTestsBootstrap.php` (extension/project) | `TYPO3_COMPOSER_MODE` → `true` | skipped (was empty anyway) |
| `UnitTestsBootstrap.php` (Core mono-repository) | undefined → `false` | unchanged |
| `Testbase::setUpBasicTypo3Bootstrap()` (all functional tests) | hard-coded `false` (`Testbase.php:756`) | unchanged |

Verified after the change: functional instances still get a non-empty dump at
`.Build/Web/typo3temp/var/tests/functional-*/typo3conf/autoload-tests/`, with all fixture
and extension PSR-4 prefixes including `…\Tests\`, and a 71-line class map.

The fix has to live in `Testbase`, not in `UnitTestsBootstrap.php`: that file is boilerplate
which extensions are encouraged to copy, so guarding it there would not reach any of the
already-copied bootstraps.

No Core bugfix is required — `dirname(getExtensionsPath())` is the correct anchor for
classic-mode autoload information, and Core itself never calls the dump in Composer mode.

## Steps to reproduce

With `web-vision/deepl-write` on `main` (project root ≠ web root, `web-dir = .Build/Web`):

```bash
# broken with v14
rm -rf .Build/ packages/ composer.lock
Build/Scripts/runTests.sh -t 14 -p 8.2 -s composerUpdate
Build/Scripts/runTests.sh -t 14 -p 8.2 -s unit
ls packages/autoload-tests/          # <-- created, four empty files

# fine with v13
rm -rf .Build/ packages/ composer.lock
Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
Build/Scripts/runTests.sh -t 13 -p 8.2 -s unit
ls packages/                         # <-- does not exist
```

## Test results

`web-vision/deepl-write`, PHP 8.2, testing-framework patched with this change:

| Core | Suite | Result |
|---|---|---|
| v14.3.5 | `-s unit` | SUCCESS — **no `packages/`** (before: `packages/autoload-tests/` created) |
| v14.3.5 | `-d sqlite -s functional` | SUCCESS (10 tests, 11 assertions), instance dumps intact and non-empty |
| v13.4.33 | `-s unit` | SUCCESS — no `packages/`, no `typo3conf/autoload-tests/` either |
| v13.4.33 | `-d sqlite -s functional` | SUCCESS (4 tests, 3 assertions) |

TYPO3 Core mono-repository (`main`, v15-dev), PHP 8.4, vendored testing-framework patched:

| Suite | Result |
|---|---|
| `-s unit -- --filter GeneralUtilityTest` | SUCCESS (676 tests, 756 assertions) — `typo3conf/autoload-tests/` still written, behaviour unchanged |
| `-d sqlite -s functional -- typo3/sysext/core/Tests/Functional/Package/` | SUCCESS (6 tests, 26 assertions) |
| `-d sqlite -s functional -- typo3/sysext/extbase/Tests/Functional/Persistence/` | SUCCESS (468 tests, 1671 assertions) |

This repository's own gates, PHP 8.2:

| Gate | Result |
|---|---|
| `-s composerUpdate` | SUCCESS |
| `-s cgl -n` | SUCCESS |
| `-s lint` | SUCCESS |
| `-s phpstan` | SUCCESS — no errors |
| `-s unit` | SUCCESS — 124 tests, 329 assertions |

## Branches

`Releases: main, 9`. Branch `9` is the branch v14 users actually consume today, so the port
should not lag behind. **No core-version-aware conditional is needed there**:
`Environment::isComposerMode()` exists unchanged since v9, and the Composer-mode early
return in `PackageManager::scanAvailablePackages()` is identical on v12, v13, v14 and main.

## Note for users

A `packages/autoload-tests/` directory left behind by an earlier test run has to be removed
manually once — this change only stops new ones from being created.
