### PR TITLE
[BUGFIX] Skip class loading info dump in Composer mode

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Psr\Container\ContainerInterface;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\ClassLoadingInformation;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Schema\SchemaManager\CoreSchemaManagerFactory;
@@ -762,10 +763,26 @@ class Testbase
     }
 
     /**
-     * Dump class loading information
+     * Dump class loading information.
+     *
+     * This is only relevant for non Composer mode ("classic mode") setups, where the
+     * Composer class loader does not know about extensions: the generated files add
+     * the class map, the PSR-4 prefixes and the class alias map of all active
+     * extensions - including their `Tests/` directories - to the class loader.
+     *
+     * Functional test instances are classic mode instances by definition, so they do
+     * need the dump. Unit tests on the other hand run in the scope of the outer
+     * Composer installation, where the Composer class loader is authoritative and
+     * `PackageManager::scanAvailablePackages()` bails out early: the dump would only
+     * write empty files - into the project root ("<project>/packages/autoload-tests/"
+     * since TYPO3 v14.3.1). Skip it, mirroring the `Environment::isComposerMode()`
+     * guards TYPO3 Core uses on all of its own call sites.
      */
     public function dumpClassLoadingInformation(): void
     {
+        if (Environment::isComposerMode()) {
+            return;
+        }
         if (!ClassLoadingInformation::isClassLoadingInformationAvailable()) {
             ClassLoadingInformation::dumpClassLoadingInformation();
             ClassLoadingInformation::registerClassLoadingInformation();


### PR DESCRIPTION
Backport of #730 to branch `9`. Related: #725.

Clean cherry-pick of `6073033` — no adaptation needed, the code is identical on both branches.

## Problem

`Testbase::dumpClassLoadingInformation()` is called unconditionally — also from
`Resources/Core/Build/UnitTestsBootstrap.php`, which runs in the scope of the **outer
Composer installation**.

TYPO3 v14.3.1 changed where the classic-mode autoload information of the testing context is
written. `ClassLoadingInformation::getClassLoadingInformationDirectory()` now derives the
directory from `Environment::getExtensionsPath()`, and that resolves to
`<projectRoot>/packages/ext` in Composer mode:

| | v13.4 | v14.3.1+ |
|---|---|---|
| `getExtensionsPath()` (Composer mode) | `<public>/typo3conf/ext` | `<project>/packages/ext` |
| dump dir (testing context) | `<public>/typo3conf/autoload-tests/` | `<project>/packages/autoload-tests/` |

So every unit test run creates `<projectRoot>/packages/autoload-tests/`, colliding with the
directory many projects use for their own local extensions.

Accountable Core change: `edfb03ae775` / `770c5383930` *"[TASK] Allow public folder in classic
mode"*, [forge #109470](https://forge.typo3.org/issues/109470), Gerrit
[93491](https://review.typo3.org/c/Packages/TYPO3.CMS/+/93491) /
[93799](https://review.typo3.org/c/Packages/TYPO3.CMS/+/93799).

## Why branch `9` matters most here

Branch `9` supports core **v13 and v14** — it is the branch v14 users actually consume today,
so it is the branch where the bug is reachable in practice. The reporter of #725 hit it with
testing-framework 9.5.0 on TYPO3 14.3.4.

## No core-version-aware code needed

The guard works unchanged on both cores this branch supports:

* `Environment::isComposerMode()` exists unchanged since v9.
* `PackageManager::scanAvailablePackages()` has the identical Composer-mode early return on
  v12, v13, v14 and main — verified against `v13.4.33` and `v14.3.5` sources.

So the dump was **already a no-op in Composer mode on v13** (four empty files, 118/147/147/147
bytes); only the location regressed on v14.3.1, from gitignored build output to the project
root. Nothing can be lost by not writing them.

## Functional tests are not affected

| Caller | Composer mode | Dump |
|---|---|---|
| `UnitTestsBootstrap.php` (extension/project) | `TYPO3_COMPOSER_MODE` → `true` | skipped (was empty anyway) |
| `UnitTestsBootstrap.php` (Core mono-repository) | undefined → `false` | unchanged |
| `Testbase::setUpBasicTypo3Bootstrap()` (all functional tests) | hard-coded `false` | unchanged |

## Test results

Verified with this exact guard applied to the vendored testing-framework 9.6.0 in two
extensions, PHP 8.2, sqlite. Baseline (unpatched) unit runs were done first on each core, so
the before/after is on the same project rather than inferred.

[`web-vision/deepltranslate-core`](https://github.com/web-vision/deepltranslate-core) — ships
three functional fixture extensions, the case that would break if the guard were wrong:

| Core | Suite | Result |
|---|---|---|
| v13.4.33 | `-s unit` (baseline) | SUCCESS — no `packages/`, dump at `.Build/Web/typo3conf/autoload-tests/` |
| v13.4.33 | `-s unit` (patched) | **SUCCESS** (16 tests, 30 assertions) — no `packages/` |
| v13.4.33 | `-s functional` (patched) | **SUCCESS** (44 tests, 101 assertions) |
| v14.3.5 | `-s unit` (baseline) | SUCCESS — **`packages/autoload-tests/` created**, four empty files |
| v14.3.5 | `-s unit` (patched) | **SUCCESS** (16 tests, 30 assertions) — no `packages/` |
| v14.3.5 | `-s functional` (patched) | **SUCCESS** (44 tests, 101 assertions) |

Functional instances still receive the full classic-mode dump, including the fixture extension
and all `Tests/` directories:

```php
'WebVision\TestingFrameworkBackendUserHandlerReplacement\'
    => typo3conf/ext/deepltranslate_core/Tests/Functional/Fixtures/Extensions/
       testing_framework_backenduserhandler_replacement/Classes
'WebVision\Deepltranslate\Core\Tests\'   => typo3conf/ext/deepltranslate_core/Tests
'WebVision\Deepltranslate\Core\Testing\' => typo3conf/ext/deepltranslate_core/TestClasses
'WebVision\Deepl\Base\Tests\'            => typo3conf/ext/deepl_base/Tests
```

plus 100 class map entries.

[`web-vision/deepl-write`](https://github.com/web-vision/deepl-write):

| Core | Suite | Result |
|---|---|---|
| v14.3.5 | `-s unit` | SUCCESS — no `packages/` (before: created) |
| v14.3.5 | `-s functional` | SUCCESS (10 tests, 11 assertions) |
| v13.4.33 | `-s unit` | SUCCESS — no `packages/` |
| v13.4.33 | `-s functional` | SUCCESS (4 tests, 3 assertions) |

TYPO3 Core mono-repository (`main`, v15-dev), PHP 8.4 — behaviour unchanged, mono-repo is
classic mode:

| Suite | Result |
|---|---|
| `-s unit -- --filter GeneralUtilityTest` | SUCCESS (676 tests, 756 assertions), `typo3conf/autoload-tests/` still written |
| `-d sqlite -s functional -- typo3/sysext/core/Tests/Functional/Package/` | SUCCESS (6 tests, 26 assertions) |
| `-d sqlite -s functional -- typo3/sysext/extbase/Tests/Functional/Persistence/` | SUCCESS (468 tests, 1671 assertions) |

This branch's own gates, PHP 8.2:

| Gate | Result |
|---|---|
| `-s composerUpdate` | SUCCESS |
| `-s cgl -n` | SUCCESS |
| `-s lint` | SUCCESS |
| `-s phpstan` | SUCCESS — no errors |
| `-s unit` | SUCCESS — 124 tests, 329 assertions |

## Note for users

A `packages/autoload-tests/` directory left behind by an earlier test run has to be removed
manually once — this change only stops new ones from being created.
