### PR TITLE
[BUGFIX] Drop only bootstrap-opened output buffers

### DIFF
--- a/Classes/Core/Functional/FunctionalTestCase.php
+++ b/Classes/Core/Functional/FunctionalTestCase.php
@@ -1005,6 +1005,7 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
         $_SERVER['SCRIPT_NAME'] = '/index.php';
         $_SERVER['HTTP_HOST'] = $_SERVER['SERVER_NAME'] = $request->getUri()->getHost() ?: 'localhost';
 
+        $outputBufferingLevel = ob_get_level();
         $container = Bootstrap::init(ClassLoadingInformation::getClassLoader());
 
         /** @var InternalRequest $serverRequest */
@@ -1050,8 +1051,12 @@ abstract class FunctionalTestCase extends BaseTestCase implements ContainerInter
             $frontendApplication = $container->get(Application::class);
             $response = $frontendApplication->handle($serverRequest);
         } finally {
-            // Somewhere an ob_start() is called in frontend that is not cleaned. Work around that for now.
-            ob_end_clean();
+            // TYPO3 v14 opens an implicit output buffer in Bootstrap::init(), TYPO3 v15
+            // does not. Frontend or extension code may leave further buffers open. Drop
+            // everything opened by the sub request, but never phpunit's own buffer.
+            while (ob_get_level() > $outputBufferingLevel) {
+                ob_end_clean();
+            }
             FrameworkState::pop();
         }
         return $response;

--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -754,10 +754,15 @@ class Testbase
 
         $classLoader = require $this->getPackagesPath() . '/autoload.php';
         SystemEnvironmentBuilder::run(0, SystemEnvironmentBuilder::REQUESTTYPE_CLI, false);
+        $outputBufferingLevel = ob_get_level();
         $container = Bootstrap::init($classLoader);
         // Make sure output is not buffered, so command-line output can take place and
-        // phpunit does not whine about changed output bufferings in tests.
-        ob_end_clean();
+        // phpunit does not whine about changed output bufferings in tests. TYPO3 v14
+        // opens an implicit output buffer in Bootstrap::init(), TYPO3 v15 does not.
+        // Only drop buffers opened by the bootstrap, never phpunit's own one.
+        while (ob_get_level() > $outputBufferingLevel) {
+            ob_end_clean();
+        }
 
         $this->dumpClassLoadingInformation();
 


### PR DESCRIPTION
TYPO3 v15 removes the implicit output buffer that `Bootstrap::init()` opened as
its very first action. Two places in this package compensated for that buffer
with an **unconditional** `ob_end_clean()`:

* `Testbase::setUpBasicTypo3Bootstrap()` — called from **both** branches of
  `FunctionalTestCase::setUp()`, i.e. once per test
* `FunctionalTestCase::executeFrontendSubRequest()` — the "somewhere an
  `ob_start()` is called in frontend" of that comment *is* the
  `Bootstrap::init()` call a few lines above

Without the bootstrap buffer these calls close phpunit's own output buffer
instead, and phpunit reports every functional test as risky with
`Test code or tested code closed output buffers other than its own`.

Both places now remember `ob_get_level()` before `Bootstrap::init()` and unwind
only the buffers opened above that level. Deleting the calls outright was not an
option: branch `main` supports `typo3/cms-core: 14.*.*@dev || 15.*.*@dev`, and
TYPO3 v14 `Bootstrap::init()` still opens the buffer — a plain removal would
flip the failure mode on v14 to `…did not close its own output buffers`. The
`while` loop additionally guards the frontend sub request against stray buffers
left open by extension code, which is what the old "work around that for now"
comment was really about.

## Reproduction

TYPO3 Core `main` with https://review.typo3.org/c/Packages/TYPO3.CMS/+/94863
cherry-picked, **before** this change:

```
Build/Scripts/runTests.sh -s functional -d sqlite typo3/sysext/core/Tests/Functional/Database/
→ Tests: 376, Assertions: 1309, Skipped: 34, Risky: 376

Build/Scripts/runTests.sh -s functional -d sqlite typo3/sysext/frontend/Tests/Functional/Rendering/TypeRenderingTest.php
→ Tests: 9, Assertions: 9, Risky: 9
```

Core CI for that change fails in *all* functional jobs (sqlite 3/3, mariadb 6/6,
postgres 10/10) while `unit`, `phpstan`, `cgl`, `lint`, `integration various`,
`documentation rendering` and the playwright e2e jobs stay green.

## Core test runs with this change

`vendor/typo3/testing-framework` replaced by this branch.

**TYPO3 v15** — Core `main` @ `3c6390b797a` + Gerrit 94863/1 cherry-picked,
PHP 8.5, sqlite:

```
runTests.sh -s functional -d sqlite \
  typo3/sysext/core/Tests/Functional/Database/ \
  typo3/sysext/frontend/Tests/Functional/Rendering/TypeRenderingTest.php \
  typo3/sysext/frontend/Tests/Functional/Rendering/UriPrefixRenderingTest.php
→ Tests: 389, Assertions: 1338, Skipped: 34 — SUCCESS (0 risky)

runTests.sh -s functional -d sqlite typo3/sysext/core/Tests/Functional/
→ Tests: 4224, Assertions: 56298, Skipped: 36 — SUCCESS (0 risky)
```

**TYPO3 v14** — Core `14` @ `dd5735757cb` (bootstrap *does* open the buffer),
PHP 8.2, sqlite:

```
runTests.sh -s functional -d sqlite \
  typo3/sysext/core/Tests/Functional/Database/ \
  typo3/sysext/frontend/Tests/Functional/Rendering/TypeRenderingTest.php \
  typo3/sysext/frontend/Tests/Functional/Rendering/UriPrefixRenderingTest.php
→ Tests: 384, Assertions: 1317, Skipped: 34 — SUCCESS (0 risky)
```

## Package quality gates

`Build/Scripts/runTests.sh` in this repo, PHP 8.2 (default):

| Gate | Result |
|------|--------|
| `-s composerUpdate` | SUCCESS |
| `-s cgl -n` | SUCCESS (0 of 64 files to fix) |
| `-s lint` | SUCCESS |
| `-s phpstan` | SUCCESS (no errors) |
| `-s unit` | SUCCESS (127 tests, 337 assertions) |

## Notes

No backport needed: branches `9`/`8`/`7` do not support TYPO3 v15, so their
bootstrap always opens the buffer and the current unconditional `ob_end_clean()`
stays correct there.

Resolves: #732
Related: https://forge.typo3.org/issues/110250
Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/94863
Releases: main
