### PR TITLE
[TASK] Update version information for v14 and v15

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,27 @@ tests within the TYPO3 extension ecosystem.
 
 ## Installation
 
-This framework works on top of a composer based installation.
+This framework works on top of a Composer based installation:
 
+```bash
+composer require --dev "typo3/testing-framework":"^10.0"
 ```
-$ composer require --dev typo3/testing-framework
-```
+
+## Version matrix
+
+Which version to use depends on the TYPO3 and PHP versions to be supported.
+
+| Branch | testing-framework | TYPO3            | PHP                               | PHPUnit         |
+|--------|-------------------|------------------|-----------------------------------|-----------------|
+| main   | 10.x.x            | v14, v15 (main)  | 8.2, 8.3, 8.4, 8.5                | ^11, ^12, ^13   |
+| 9      | 9.x.x             | v13, v14         | 8.2, 8.3, 8.4, 8.5                | ^11, ^12, ^13   |
+| 8      | 8.x.x             | v12, v13         | 8.1, 8.2, 8.3, (8.4)              | ^10, ^11        |
+| 7      | 7.x.x             | v11, v12         | 7.4, 8.0, 8.1, 8.2, 8.3, (8.4)    | ^9, ^10         |
+| 6      | 6.x.x             | v10, v11         | 7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3 | ^8, ^9          |
+
+Testing framework <= 7.x is no longer maintained.
 
 ## Documentation
 
 Usage examples within core and for extensions can be found in
-[TYPO3 explained](https://docs.typo3.org/typo3cms/CoreApiReference/Testing/Index.html).
-
-## Tags and branches
-
-* Branch main is used by core v15, tagged as 10.x.x. Extensions can use this to
-  run tests with core v14 and v15. Supports PHP ^8.2.
-* Branch 9 is used by core v13 and v14, tagged as 9.x.x. Extensions can use this to
-  run tests with core v13 and v14. Supports PHP ^8.2.
-* Branch 8 is used by core v12 and tagged as 8.x.x. Extensions can use this to
-  run tests with core v12 and prepare for v13 compatibility. Supports PHP ^8.1.
-* Branch 7 is used by core v11 and tagged as 7.x.x. Extensions can use this to
-  run tests with core v11 and prepare for v12 compatibility. Supports PHP 7.4 to 8.2.
-* Branch 6 is used by core v10 and tagged as 6.x.x. Extensions can use this to
-  run tests with core v10 and v11. Supports PHP 7.2 to 8.2
-* Branch 4 is for core v9 and tagged as 4.x.y
-* Branch 1 is for core v8 and tagged as 1.x.y
+[TYPO3 Explained](https://docs.typo3.org/permalink/t3coreapi:testing).

--- a/Resources/Core/Functional/Extensions/json_response/composer.json
+++ b/Resources/Core/Functional/Extensions/json_response/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "13.*.*@dev || 14.*.*@dev"
+        "typo3/cms-core": "14.*.*@dev || 15.*.*@dev"
     },
     "autoload": {
         "psr-4": {

--- a/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/json_response/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.0.0 - 14.9.99',
+            'typo3' => '14.0.0-15.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/Resources/Core/Functional/Extensions/private_container/composer.json
+++ b/Resources/Core/Functional/Extensions/private_container/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "13.*.*@dev || 14.*.*@dev"
+        "typo3/cms-core": "14.*.*@dev || 15.*.*@dev"
     },
     "autoload": {
         "psr-4": {

--- a/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
+++ b/Resources/Core/Functional/Extensions/private_container/ext_emconf.php
@@ -10,7 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => '',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.0.0-14.99.99',
+            'typo3' => '14.0.0-15.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
The functional test fixture extensions json_response and private_container now declare TYPO3 v14 and v15 in both composer.json and ext_emconf.php to match the root package constraints, using a consistent version range notation, and the README replaces its prose list of tags and branches with a version matrix in the same shape as TYPO3 Explained, listing branch, testing-framework, TYPO3, PHP and PHPUnit versions, dropping the unmaintained branches 4 and 1 and fixing the outdated documentation link.