### PR TITLE
[TASK] Run CI containers with docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,15 @@
 name: CI
 
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and since 2026-07-29
+# their podman/crun combination aborts the first container start of a job with
+# "OCI runtime error: crun: unknown version specified" (exit code 126). It is
+# intermittent, hits any job, and was traced to neither the runner image nor
+# the TYPO3 testing image changing. Selecting docker here avoids crun entirely
+# and leaves the script default and local runs untouched. Drop the flag once
+# GitHub stops producing the mismatch.
+
 on:
   push:
   pull_request:
@@ -21,18 +31,18 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.head_ref || '' }}
 
       - name: Composer install
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
+        run: Build/Scripts/runTests.sh -b docker -p ${{ matrix.php }} -s composerUpdate
 
       - name: CGL
         if: ${{ matrix.php <= '8.3' }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s cgl -n
+        run: Build/Scripts/runTests.sh -b docker -p ${{ matrix.php }} -s cgl -n
 
       - name: Lint PHP
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+        run: Build/Scripts/runTests.sh -b docker -p ${{ matrix.php }} -s lint
 
       - name: Phpstan
         if: ${{ matrix.php <= '8.3' }}
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan
+        run: Build/Scripts/runTests.sh -b docker -p ${{ matrix.php }} -s phpstan
 
       - name: Unit Tests
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
+        run: Build/Scripts/runTests.sh -b docker -p ${{ matrix.php }} -s unit


### PR DESCRIPTION
## Why

GitHub hosted runners ship both podman and docker. Since 2026-07-29 their
podman/crun combination intermittently aborts the **first container start of a
job** with

```
Error: OCI runtime error: crun: unknown version specified
```

exit code 126. It is independent of the job, the core version and the PHP
version, and a rerun on another host clears it. Neither the runner image nor the
TYPO3 testing image changed, so this is variance in the GitHub host fleet.

## The change

`Build/Scripts/runTests.sh` prefers podman whenever it is present and only falls
back to docker. That default is correct for the script — podman-only machines
are exactly what it is built for — so it stays. The GitHub hosted runners are
the single place these workflows meet the broken combination, so the override
belongs in the workflows.

Every `runTests.sh` call now passes `-b docker`, with the reasoning in the
workflow header so the flag can be dropped knowingly once GitHub stops producing
the mismatch.

This mirrors what is already merged across the `deepl*` extension family, and
originates from fgtclb/academic-extensions.

## Companion fixes

Selecting docker exposes defects that podman masked. Only the ones that apply to
this repository are included — see the summary below.

* **sqlite tmpfs `mode=1777`** — docker runs the container as
  `--user $HOST_UID` with group 0, while the tmpfs inherits the mode of its host
  mountpoint (`0755 root:root` at a runner's umask). No test database can be
  created, and every functional sqlite test fails with `unable to open database
  file`. Rootless podman is root inside its user namespace and passes no
  `--user`, which is why this never showed. `mode=1777` fixes it for both
  runtimes and makes the suite umask-independent.
* **hardcoded `-it`** — the documentation rendering run hardcoded `-it` on top of
  the interactivity the script already manages. docker rejects `-t` without a
  TTY, so that suite cannot run under docker in CI.
* **`waitFor()` readiness cap** — the poll aborted after ~11 s. `mysql:8.0`
  needs 12–13 s to become ready under docker versus 7 s under podman, and
  mariadb 8.2 s. The cap is 60 s now. The abort itself also never fired in CI,
  because `kill -SIGINT -$$` relies on a SIGINT trap that is only installed when
  `CI` is not `"true"` — so the suite ran against a database that was not
  listening and reported misleading `Connection refused` errors.

## Applied here

* `-b docker` on 5 `runTests.sh` calls in `.github/workflows/ci.yml`, plus the
  header comment in that file. `Build/Scripts/runTests.sh` is **not** touched.
* The `nightly-*.yml` workflows contain no `runTests.sh` call — they only
  dispatch `ci.yml` via `gh workflow run`, so they stay byte-identical.
* sqlite tmpfs `mode=1777`: not applicable — this `runTests.sh` has no `--tmpfs`
  mount and no database container at all (suites: `cgl`, `clean`,
  `composerUpdate`, `lint`, `phpstan`, `phpstanGenerateBaseline`, `unit`).
* hardcoded `-it` removed: not applicable — there is no hardcoded `-it` on any
  container run. The only occurrence is the managed
  `CONTAINER_INTERACTIVE="-it --init"`, which is cleared when `CI` is `"true"`.
* `waitFor` cap 11s -> 60s: not applicable — this `runTests.sh` has no
  `waitFor()` function, because it starts no service containers to wait for.
