### PR TITLE
[TASK] Guard SchemaMigrator::install() with applySafe()

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -919,6 +919,12 @@ class Testbase
         $sqlReader = GeneralUtility::makeInstance(SqlReader::class);
         $sqlCode = $sqlReader->getTablesDefinitionString();
         $createTableStatements = $sqlReader->getCreateTableStatementArray($sqlCode);
+        // @todo: Remove the install() fallback when v14 compat is dropped, the
+        //        method no longer exists in v15.
+        if (method_exists($schemaMigrationService, 'applySafe')) {
+            $schemaMigrationService->applySafe($createTableStatements);
+            return;
+        }
         $schemaMigrationService->install($createTableStatements);
     }
 


### PR DESCRIPTION
## Problem

TYPO3 v15 reworks the database analyzer stack. As part of it, the internal
`SchemaMigrator::install()` is replaced by `applySafe()`: `install()` is kept as a
`@deprecated` thin wrapper for exactly one reason — this package creates the database
of every functional test through it — and is removed in a follow-up change.

`Classes/Core/Testbase.php::createDatabaseStructure()` is the only call site:

```php
$schemaMigrationService->install($createTableStatements);
```

TYPO3 v14 only knows `install()`, and the `main` branch here supports
`14.*.*@dev || 15.*.*@dev`, so the call has to work against both.

## Change

Call `applySafe()` when the migrator provides it, keep `install()` as the fallback:

```php
// @todo: Remove the install() fallback when v14 compat is dropped, the
//        method no longer exists in v15.
if (method_exists($schemaMigrationService, 'applySafe')) {
    $schemaMigrationService->applySafe($createTableStatements);
    return;
}
$schemaMigrationService->install($createTableStatements);
```

Behaviour is unchanged on both sides: `install()` in v15 does nothing but delegate to
`applySafe()`, this call site never passed the v14 `$createOnly` argument, and the
return value was not evaluated before either.

### Why a capability check and not a core version check

A `Typo3Version` check would be wrong here, not just less elegant. v15 nightlies and
every v15 dev state predating the analyzer rework report `15.x` while still only having
`install()` — a version check would break them. `method_exists()` on the migrator
instance is true exactly when the call is valid.

`method_exists()` on the object is also preferred over `class_exists()` on one of the
new DTOs: the DTOs and `applySafe()` happen to land in the same core change today, but
the core side is a patch series still under review, and a split that introduces the
classes before the method would make a `class_exists()` probe return true one line
before a fatal. It follows the same shape as the existing
`method_exists(Bootstrap::class, 'loadExtTables')` guard a few lines above.

## Verification

Run in this repository, all green:

| PHP | resolves | suites |
|---|---|---|
| 8.3 | `typo3/cms-core` 14.3.x-dev (fallback branch) | `composerUpdate`, `cgl`, `lint`, `phpstan`, `unit` |
| 8.5 | `typo3/cms-core` dev-main (v15) | `composerUpdate`, `lint`, `unit` |

No `phpstan-baseline.neon` entry is needed: `$container->get()` is PSR-11 and returns
`mixed`, so the probe is not statically resolvable and produces no
`function.alreadyNarrowedType`.

The TYPO3 Core functional suite result against this branch is added as a comment once
the corresponding core change has run through CI.

## Coordination

This has to be merged and released **before** the core change that removes
`SchemaMigrator::install()` can be merged. The core side references this pull request in
its commit message.
