### PR TITLE
[TASK] Speed up MySQL functional database resets

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -876,10 +876,20 @@ class Testbase
         while ($tableData = $result->fetchAssociative()) {
             $hasChangedAutoIncrement = ((int)$tableData['auto_increment']) > 1;
             $hasAtLeastOneRow = (bool)$tableData['has_rows'];
-            $isChanged = $hasChangedAutoIncrement || $hasAtLeastOneRow;
-            if ($isChanged) {
-                $tableName = $tableData['table_name'];
+            $tableName = $tableData['table_name'];
+            if ($hasChangedAutoIncrement) {
                 $connection->truncate($tableName);
+            } elseif ($hasAtLeastOneRow) {
+                // MySQL may not expose the current counter for populated auto-increment tables.
+                // Check the column metadata before using DELETE, which does not reset the counter.
+                $autoIncrementColumn = $connection->executeQuery(
+                    'SHOW COLUMNS FROM ' . $connection->quoteIdentifier($tableName) . ' WHERE Extra = \'auto_increment\''
+                )->fetchOne();
+                if ($autoIncrementColumn === false) {
+                    $connection->executeStatement('DELETE FROM ' . $connection->quoteIdentifier($tableName));
+                } else {
+                    $connection->truncate($tableName);
+                }
             }
         }
     }


### PR DESCRIPTION
Functional test cleanup currently truncates every touched MySQL or MariaDB table. TRUNCATE is expensive DDL even for tables without an auto-increment column, where no sequence state needs to be restored.

Delete rows from touched tables without auto-increment instead, while retaining TRUNCATE for tables whose counter changed. MySQL may omit the current counter for populated auto-increment tables, so inspect column metadata before selecting DELETE in that ambiguous case.

For Extbase RelationTest, this reduces MariaDB 10.4 runtime from about 63.3 to 57.3 seconds and MySQL 8.4 runtime from 112.1 to 100.1 seconds. The complete MariaDB functional suite passes with 12,523 tests and 73,326 assertions.