### PR TITLE
[TASK] Speed up PostgreSQL functional database resets

### DIFF
--- a/Classes/Core/Testbase.php
+++ b/Classes/Core/Testbase.php
@@ -816,6 +816,8 @@ class Testbase
         $platform = $connection->getDatabasePlatform();
         if ($platform instanceof DoctrineMariaDBPlatform || $platform instanceof DoctrineMySQLPlatform) {
             $this->truncateAllTablesForMysql();
+        } elseif ($platform instanceof DoctrinePostgreSQLPlatform) {
+            $this->truncateAllTablesForPostgres();
         } else {
             $this->truncateAllTablesForOtherDatabases();
         }
@@ -880,6 +882,24 @@ class Testbase
                 $connection->truncate($tableName);
             }
         }
+    }
+
+    /**
+     * Truncates all PostgreSQL tables and restarts their sequences in one statement.
+     */
+    private function truncateAllTablesForPostgres(): void
+    {
+        /** @var Connection $connection */
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+        $tableNames = $connection->createSchemaManager()->listTableNames();
+        if ($tableNames === []) {
+            return;
+        }
+        $quotedTableNames = array_map($connection->quoteIdentifier(...), $tableNames);
+        $connection->executeStatement(
+            'TRUNCATE TABLE ' . implode(', ', $quotedTableNames) . ' RESTART IDENTITY CASCADE'
+        );
     }
 
     /**


### PR DESCRIPTION
Functional tests currently truncate every PostgreSQL table separately and query its sequence before resetting it. This creates dozens of round trips between test methods even when the database is small.\n\nUse PostgreSQL's native multi-table TRUNCATE with RESTART IDENTITY and CASCADE. This preserves the existing cleanup semantics while reducing the reset to schema discovery plus one statement.\n\nA representative 66-test class improves from a median 11.782 seconds to 5.149 seconds (56.3%).